### PR TITLE
[IMP] o-sfu: keep H264 relay gates codec-aware

### DIFF
--- a/crates/core/src/runtime/rtc_engine/forwarded_packet/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/forwarded_packet/mod.rs
@@ -1,14 +1,14 @@
 use std::{mem::take, time::Instant};
 
-use o_sfu_rfc::rtp::{self, frame_marking, h264, vp8};
+use o_sfu_rfc::rtp::{frame_marking, h264, vp8};
 use str0m::{
     media::{ExtensionValues, Mid, Rid},
     rtp::{RtpHeader, RtpPacket, Ssrc},
 };
 
 use super::{
-    local_forwarding::LocalForwardedRtp, route_control::PacketLayerMetadata,
-    shared_payload::SharedPayload, state::RtcBootstrapState,
+    local_forwarding::LocalForwardedRtp, media_registry::DecoderRefreshCodec,
+    route_control::PacketLayerMetadata, shared_payload::SharedPayload, state::RtcBootstrapState,
 };
 use crate::runtime::media_transport::{TransportMediaId, TransportSessionKey};
 
@@ -100,15 +100,13 @@ impl ForwardedPacket {
         state: &RtcBootstrapState,
         source_transport_media_id: TransportMediaId,
     ) -> bool {
-        if producer_uses_codec(state, source_transport_media_id, &rtp::CodecName::H264) {
-            return h264::payload_starts_idr(self.payload.as_slice());
+        match state.source_decoder_refresh_codec(source_transport_media_id) {
+            Some(DecoderRefreshCodec::H264) => h264::payload_starts_idr(self.payload.as_slice()),
+            Some(DecoderRefreshCodec::Vp8) | None => {
+                vp8::payload_starts_keyframe(self.payload.as_slice())
+            }
+            Some(DecoderRefreshCodec::Unsupported) => false,
         }
-        if producer_uses_codec(state, source_transport_media_id, &rtp::CodecName::Vp8)
-            || producer_codec_unknown(state, source_transport_media_id)
-        {
-            return vp8::payload_starts_keyframe(self.payload.as_slice());
-        }
-        false
     }
 
     pub(super) fn route_control_ssrc(&self) -> Ssrc {
@@ -225,42 +223,6 @@ impl ForwardedPacket {
     }
 }
 
-fn producer_uses_codec(
-    state: &RtcBootstrapState,
-    source_transport_media_id: TransportMediaId,
-    codec_name: &rtp::CodecName,
-) -> bool {
-    producer_parameters(state, source_transport_media_id).is_some_and(|parameters| {
-        parameters
-            .formats()
-            .any(|format| format.codec() == codec_name)
-    })
-}
-
-fn producer_codec_unknown(
-    state: &RtcBootstrapState,
-    source_transport_media_id: TransportMediaId,
-) -> bool {
-    producer_parameters(state, source_transport_media_id).is_none()
-}
-
-fn producer_parameters(
-    state: &RtcBootstrapState,
-    source_transport_media_id: TransportMediaId,
-) -> Option<&o_sfu_router::MediaStream> {
-    let super::media_registry::RegisteredMediaHandle::Producer { session_key, mid } =
-        state.media_handle(source_transport_media_id)?
-    else {
-        return None;
-    };
-    state
-        .users
-        .get(session_key)?
-        .sdp_negotiation
-        .negotiated_producer_parameters
-        .get(mid)
-}
-
 fn frame_mark_temporal_layer_id(frame_mark: u32) -> u8 {
     let [first_octet, ..] = frame_mark.to_be_bytes();
     frame_marking::temporal_layer_id(first_octet)
@@ -330,27 +292,49 @@ mod tests {
             session_key: session_key.clone(),
             mid: producer_mid,
         });
+        let parameters = RouterRtpParameters::new(
+            vec![MediaFormat::new(
+                RouterMediaKind::Video,
+                CodecName::H264,
+                102,
+                90_000,
+            )],
+            vec![],
+            vec![],
+        );
         if let Some(session_state) = state.users.get_mut(&session_key) {
             session_state
                 .sdp_negotiation
                 .negotiated_producer_parameters
-                .insert(
-                    producer_mid,
-                    RouterRtpParameters::new(
-                        vec![MediaFormat::new(
-                            RouterMediaKind::Video,
-                            CodecName::H264,
-                            102,
-                            90_000,
-                        )],
-                        vec![],
-                        vec![],
-                    ),
-                );
+                .insert(producer_mid, parameters.clone());
         }
+        state.refresh_source_decoder_refresh_codec(transport_media_id, &parameters);
         let packet = sample_forwarded_packet(session_key, "cam-up", &[0x65, 0x88]);
 
         assert!(packet.route_control_decoder_refresh(&state, transport_media_id));
+    }
+
+    #[test]
+    fn forwarded_packet_detects_relayed_h264_idr_from_cached_source_facts() {
+        let session_key = test_transport_session_key(49, 0, 17, UserId::Integer(15));
+        let source_transport_media_id = TransportMediaId::new(23);
+        let mut state = RtcBootstrapState::default();
+        state.refresh_source_decoder_refresh_codec(
+            source_transport_media_id,
+            &RouterRtpParameters::new(
+                vec![MediaFormat::new(
+                    RouterMediaKind::Video,
+                    CodecName::H264,
+                    102,
+                    90_000,
+                )],
+                vec![],
+                vec![],
+            ),
+        );
+        let packet = sample_forwarded_packet(session_key, "cam-up", &[0x65, 0x88]);
+
+        assert!(packet.route_control_decoder_refresh(&state, source_transport_media_id));
     }
 
     #[test]

--- a/crates/core/src/runtime/rtc_engine/media_registry.rs
+++ b/crates/core/src/runtime/rtc_engine/media_registry.rs
@@ -6,6 +6,7 @@
 
 use std::{collections::BTreeSet, time::Instant};
 
+use o_sfu_rfc::rtp;
 use str0m::{
     media::{Mid, Rid},
     rtp::Ssrc,
@@ -56,6 +57,33 @@ impl RegisteredMediaHandle {
 pub(super) struct RemoteSourceRegistration {
     source_session_key: TransportSessionKey,
     source_control: RemoteSourceControl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DecoderRefreshCodec {
+    H264,
+    Vp8,
+    Unsupported,
+}
+
+impl DecoderRefreshCodec {
+    fn from_parameters(parameters: &o_sfu_router::MediaStream) -> Option<Self> {
+        let mut has_vp8 = false;
+        let mut has_unsupported_primary = false;
+        for format in parameters.formats() {
+            match format.codec() {
+                &rtp::CodecName::H264 => return Some(Self::H264),
+                &rtp::CodecName::Vp8 => has_vp8 = true,
+                codec if !codec.is_rtx() => has_unsupported_primary = true,
+                _ => {}
+            }
+        }
+        if has_vp8 {
+            Some(Self::Vp8)
+        } else {
+            has_unsupported_primary.then_some(Self::Unsupported)
+        }
+    }
 }
 
 impl RemoteSourceRegistration {
@@ -168,6 +196,8 @@ impl RtcBootstrapState {
             self.clear_producer_ssrc_bindings(transport_media_id, session_key);
             self.forget_live_producer_rids(transport_media_id);
             self.route_control.forget_source(transport_media_id);
+            self.source_decoder_refresh_codecs
+                .remove(&transport_media_id);
             self.remove_incoming_bitrate_counter(transport_media_id);
         } else if let RegisteredMediaHandle::Consumer {
             session_key, mid, ..
@@ -227,6 +257,8 @@ impl RtcBootstrapState {
                 .remove(&source_transport_media_id);
             self.forget_live_producer_rids(source_transport_media_id);
             self.route_control.forget_source(source_transport_media_id);
+            self.source_decoder_refresh_codecs
+                .remove(&source_transport_media_id);
         }
     }
 
@@ -251,6 +283,8 @@ impl RtcBootstrapState {
             .remove(&source_transport_media_id);
         self.forget_live_producer_rids(source_transport_media_id);
         self.route_control.forget_source(source_transport_media_id);
+        self.source_decoder_refresh_codecs
+            .remove(&source_transport_media_id);
     }
 
     pub(super) fn prune_unrouted_remote_sources(&mut self) {
@@ -275,6 +309,53 @@ impl RtcBootstrapState {
                         .remote_source_registry
                         .contains_key(source_transport_media_id)
             });
+        self.source_decoder_refresh_codecs
+            .retain(|source_transport_media_id, _codec| {
+                self.mid_registry
+                    .contains_key(&source_transport_media_id.as_u64())
+                    || self
+                        .remote_source_registry
+                        .contains_key(source_transport_media_id)
+            });
+    }
+
+    pub(super) fn source_decoder_refresh_codec(
+        &self,
+        source_transport_media_id: TransportMediaId,
+    ) -> Option<DecoderRefreshCodec> {
+        self.source_decoder_refresh_codecs
+            .get(&source_transport_media_id)
+            .copied()
+    }
+
+    pub(super) fn refresh_source_decoder_refresh_codec(
+        &mut self,
+        source_transport_media_id: TransportMediaId,
+        parameters: &o_sfu_router::MediaStream,
+    ) -> Option<DecoderRefreshCodec> {
+        let previous = self.source_decoder_refresh_codec(source_transport_media_id);
+        if let Some(codec) = DecoderRefreshCodec::from_parameters(parameters) {
+            self.source_decoder_refresh_codecs
+                .insert(source_transport_media_id, codec);
+        } else {
+            self.source_decoder_refresh_codecs
+                .remove(&source_transport_media_id);
+        }
+        previous
+    }
+
+    pub(super) fn restore_source_decoder_refresh_codec(
+        &mut self,
+        source_transport_media_id: TransportMediaId,
+        previous_codec: Option<DecoderRefreshCodec>,
+    ) {
+        if let Some(previous_codec) = previous_codec {
+            self.source_decoder_refresh_codecs
+                .insert(source_transport_media_id, previous_codec);
+        } else {
+            self.source_decoder_refresh_codecs
+                .remove(&source_transport_media_id);
+        }
     }
 
     pub(super) fn active_speaker_source_snapshot(&self, now: Instant) -> Vec<ActiveSpeakerSource> {
@@ -471,6 +552,7 @@ impl RtcBootstrapState {
             return;
         };
         self.clear_producer_ssrc_bindings(transport_media_id, session_key);
+        self.refresh_source_decoder_refresh_codec(transport_media_id, parameters);
         let bindings = parameters
             .bindings()
             .filter_map(|binding| {
@@ -513,6 +595,8 @@ impl RtcBootstrapState {
             return;
         };
         self.clear_producer_ssrc_bindings(transport_media_id, session_key);
+        self.source_decoder_refresh_codecs
+            .remove(&transport_media_id);
         self.producer_ssrcs_by_media
             .entry(transport_media_id)
             .or_default();

--- a/crates/core/src/runtime/rtc_engine/state/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/state/mod.rs
@@ -29,8 +29,8 @@ use super::{
     demux::{MediaRouteEntry, MediaRouteKey, RemoteAddrDemux},
     local_send_rewrite::{ConsumerStream, ConsumerStreamKey},
     media_registry::{
-        ConsumerMidLookupKey, ProducerMidLookupKey, ProducerSsrcLookupKey, RegisteredMediaHandle,
-        RemoteSourceRegistration,
+        ConsumerMidLookupKey, DecoderRefreshCodec, ProducerMidLookupKey, ProducerSsrcLookupKey,
+        RegisteredMediaHandle, RemoteSourceRegistration,
     },
     relay_registry::RelaySourceRegistration,
     route_control::RouteControlState,
@@ -96,6 +96,7 @@ pub(super) struct RtcBootstrapState {
     pub(super) producer_ssrc_registry: BTreeMap<ProducerSsrcLookupKey, TransportMediaId>,
     pub(super) producer_ssrc_rid_registry: BTreeMap<ProducerSsrcLookupKey, Rid>,
     pub(super) producer_ssrcs_by_media: BTreeMap<TransportMediaId, Vec<Ssrc>>,
+    pub(super) source_decoder_refresh_codecs: BTreeMap<TransportMediaId, DecoderRefreshCodec>,
     /// Recently observed producer RIDs, keyed by source media id.
     ///
     /// This is packet-path liveness, not signaling truth. It decides when a

--- a/crates/core/src/runtime/rtc_engine/worker/media/lifecycle.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/media/lifecycle.rs
@@ -30,7 +30,9 @@ use super::{
             bitrate::RtcBitrateState,
             commands::RtcWorkerResponse,
             local_send_rewrite::forget_transport_media_streams,
-            media_registry::RegisteredMediaHandle,
+            media_registry::{
+                DecoderRefreshCodec, RegisteredMediaHandle, RemoteSourceRegistration,
+            },
             simulcast,
             state::{PendingRecvStream, RtcBootstrapState, RtcSessionState},
         },
@@ -40,7 +42,7 @@ use super::{
         ConsumerRouteRegistration, ensure_route_source_registered, register_consumer_route,
         remove_consumer_route,
     },
-    types::AddSendMediaRequest,
+    types::{AddSendMediaRequest, RouteSourceKind},
 };
 use crate::{
     Bitrate, CodecPreferences, MediaCodecFlags, VideoBitrateLimits,
@@ -56,6 +58,53 @@ pub struct RecvMediaPolicy {
     pub video_bitrate_limits: VideoBitrateLimits,
     pub codec_flags: MediaCodecFlags,
     pub codec_preferences: CodecPreferences,
+}
+
+#[derive(Clone)]
+struct RemoteSourceRollback {
+    is_remote_source: bool,
+    source_transport_media_id: TransportMediaId,
+    previous_registration: Option<RemoteSourceRegistration>,
+    previous_decoder_refresh_codec: Option<DecoderRefreshCodec>,
+}
+
+impl RemoteSourceRollback {
+    fn capture(
+        state: &RtcBootstrapState,
+        is_remote_source: bool,
+        source_transport_media_id: TransportMediaId,
+    ) -> Self {
+        let previous_registration = is_remote_source
+            .then(|| {
+                state
+                    .remote_source_registration(source_transport_media_id)
+                    .cloned()
+            })
+            .flatten();
+        let previous_decoder_refresh_codec = is_remote_source
+            .then(|| state.source_decoder_refresh_codec(source_transport_media_id))
+            .flatten();
+        Self {
+            is_remote_source,
+            source_transport_media_id,
+            previous_registration,
+            previous_decoder_refresh_codec,
+        }
+    }
+
+    fn rollback(&self, state: &mut RtcBootstrapState) {
+        if !self.is_remote_source {
+            return;
+        }
+        state.restore_remote_source_registration(
+            self.source_transport_media_id,
+            self.previous_registration.clone(),
+        );
+        state.restore_source_decoder_refresh_codec(
+            self.source_transport_media_id,
+            self.previous_decoder_refresh_codec,
+        );
+    }
 }
 
 pub fn respond_remove_media(
@@ -461,14 +510,11 @@ fn worker_add_send_media(
         remote_source_control,
         consumer_rtp_parameters,
     } = request;
-    let previous_remote_source_registration = (source_session_key.media_worker_id()
-        != consumer_session_key.media_worker_id())
-    .then(|| {
-        state
-            .remote_source_registration(source_transport_media_id)
-            .cloned()
-    })
-    .flatten();
+    let remote_source_rollback = RemoteSourceRollback::capture(
+        state,
+        source_session_key.media_worker_id() != consumer_session_key.media_worker_id(),
+        source_transport_media_id,
+    );
     let route_source = match ensure_route_source_registered(
         state,
         consumer_session_key,
@@ -490,16 +536,14 @@ fn worker_add_send_media(
             return Err(error);
         }
     };
-    let rollback_remote_source_registration = |state: &mut RtcBootstrapState| {
-        if matches!(route_source, super::types::RouteSourceKind::Remote) {
-            state.restore_remote_source_registration(
-                source_transport_media_id,
-                previous_remote_source_registration.clone(),
-            );
-        }
-    };
+    if matches!(route_source, RouteSourceKind::Remote) {
+        state.refresh_source_decoder_refresh_codec(
+            source_transport_media_id,
+            consumer_rtp_parameters,
+        );
+    }
     let Some(session_state) = state.users.get_mut(consumer_session_key) else {
-        rollback_remote_source_registration(state);
+        remote_source_rollback.rollback(state);
         return Err(TransportAdapterError::TransportUnavailable);
     };
     let mid = if session_state.sdp_negotiation.initial_offer_applied {
@@ -507,7 +551,7 @@ fn worker_add_send_media(
             Ok(mid) => mid,
             Err(error) => {
                 let _ = session_state;
-                rollback_remote_source_registration(state);
+                remote_source_rollback.rollback(state);
                 return Err(error);
             }
         }

--- a/tests/tests/full_stack.rs
+++ b/tests/tests/full_stack.rs
@@ -760,6 +760,81 @@ async fn fake_rtc_cross_worker_vp8_selected_rid_survives_relay() {
 }
 
 #[tokio::test]
+async fn fake_rtc_cross_worker_h264_selected_rid_requires_idr_after_relay() {
+    let mut config = cross_worker_test_config();
+    config.codecs.flags = MediaCodecFlags::default().with_vp8(false).with_h264(true);
+    let room_server = spawn_room_server_with_config(
+        config,
+        "issuer-cross-worker-h264-selected-rid",
+        Some(TEST_ROOM_KEY),
+    )
+    .await;
+    assert!(room_server.is_some());
+    let Some(room_server) = room_server else {
+        return;
+    };
+    let (server, room) = room_server.into_parts();
+    let publisher_user_id = UserId::Integer(184);
+    let subscriber_user_id = UserId::Integer(185);
+
+    let setup = connect_two_rtc_ready_fake_peers(
+        &server,
+        &room,
+        publisher_user_id.clone(),
+        subscriber_user_id.clone(),
+        Duration::from_secs(5),
+    )
+    .await;
+    assert!(setup.is_some());
+    let Some((mut publisher, mut subscriber)) = setup else {
+        return;
+    };
+    assert_cross_worker_placement(&server, &room, &publisher_user_id, &subscriber_user_id).await;
+
+    let mut source = FakeMediaSource::new(SyntheticH264Stream::with_idr(false));
+    assert!(publisher.publish_track(&source).await.is_some());
+    assert!(publisher.complete_next_negotiation().await.is_some());
+    let track_binding = assert_track_snapshot(
+        &mut subscriber,
+        publisher_user_id.clone(),
+        StreamType::Camera,
+        true,
+    )
+    .await;
+    assert!(subscriber.complete_next_negotiation().await.is_some());
+    assert_video_subscription_enabled(&mut subscriber, publisher_user_id.clone()).await;
+    assert_consumer_route_active(
+        &server,
+        &room,
+        &subscriber,
+        &publisher_user_id,
+        track_binding.stream_type,
+    )
+    .await;
+    assert!(
+        server
+            .wait_for_video_subscription_selected_rid(
+                &room,
+                subscriber.user_id(),
+                &publisher_user_id,
+                "hi",
+            )
+            .await
+    );
+
+    let mut clock = FakeClock::default();
+    assert_synthetic_video_packet_dropped(&mut publisher, &mut subscriber, &mut source, &mut clock)
+        .await;
+    assert_synthetic_video_packet_forwarded(
+        &mut publisher,
+        &mut subscriber,
+        &mut source,
+        &mut clock,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn fake_rtc_vp8_selected_rid_requires_keyframe_before_forwarding() {
     let room_server = spawn_room_server("issuer-vp8-selected-rid-keyframe").await;
     assert!(room_server.is_some());


### PR DESCRIPTION
realyed H264 selected-RID routes could not observe IDR packets on the consumer worker because decoder-refresh detection depended on local producer state. remote-source relay entries only carried source identity plus relay control, so the packet loop fell back to VP8 keyframe parsing for relayed H264 sources.

this change adds source decoder-refresh codec facts keyed by transport media id. local producer facts are refreshed from answered RTP parameters. remote relay facts are refreshed from the consummer route parameters used to create the relay-side send stream. failed send-media staging restores both remote source registration and the previous decoder-refresh classifier.

the packet loop now uses the cached classifier for H264 IDR and VP8 keyframe detection

Perf:
packet-rate decoder-refresh detection is now a single worker-local map lookup plus codec-specific payload parsing. it removes the previous local producer state scan from the forwarding path and avoids adding relay-side allocation or locking.