### PR TITLE
[REF] core: unify room placement ownership

### DIFF
--- a/crates/core/src/runtime/room/controller.rs
+++ b/crates/core/src/runtime/room/controller.rs
@@ -19,8 +19,8 @@
 //!
 //! The file exists to keep one clear contract at the room boundary:
 //!
-//! - immutable room identity lives in `RoomDefinition`, while transport
-//!   placement lookup lives in `RoomPlacementDirectory`
+//! - immutable room identity lives in `RoomDefinition`, while committed
+//!   placement lookup lives in `RoomPlacementLedger`
 //! - mutable membership and media topology live behind `RoomState`
 //! - websocket and transport work must happen after room locks are released
 //! - signaling code consumes high-level room events instead of reaching into
@@ -41,7 +41,7 @@ use super::{
     events::RoomEventMessage,
     lifecycle::UserCloseReason,
     media_transaction::PendingPublishTransactions,
-    placement::{RoomPlacementDirectory, RoomPlacementUsageSnapshot, RoomWorkerLoadContribution},
+    placement::{RoomPlacementLedger, RoomPlacementUsageSnapshot, RoomWorkerLoadContribution},
     state::{ConsumerRouteState, RemoteTrackBootstrap, RoomState},
 };
 use crate::{
@@ -583,12 +583,12 @@ pub struct Room {
     /// `definition` is the stable read-only half of the room, while `state`
     /// contains the mutable membership and media graph.
     pub(super) definition: RoomDefinition,
-    /// Mutable transport placement lookup for committed room connections.
+    /// Mutable placement lookup for committed room connections.
     ///
-    /// The pure topology owns router execution state. This directory keeps the
-    /// transport worker address needed to build session keys after placement
+    /// The pure topology owns router execution state. This ledger keeps the
+    /// full committed placement needed to build session keys after placement
     /// has been committed.
-    pub(super) placement_directory: RoomPlacementDirectory,
+    pub(super) placement_ledger: RoomPlacementLedger,
     #[allow(
         dead_code,
         reason = "recording control-plane wiring is intentionally deferred until the replacement baseline is validated"
@@ -664,9 +664,7 @@ impl Room {
         Self {
             diagnostics,
             definition,
-            placement_directory: RoomPlacementDirectory::new(
-                runtime_context.local_routers().primary(),
-            ),
+            placement_ledger: RoomPlacementLedger::new(runtime_context.local_routers().primary()),
             recording_service: Arc::clone(&recording_service),
             metrics,
             cleanup_reconciler: StdMutex::new(CleanupReconciler::default()),
@@ -704,7 +702,7 @@ impl Room {
         user_id: &UserId,
         connection_id: ConnectionId,
     ) -> TransportSessionKey {
-        self.placement_directory.transport_user_key(
+        self.placement_ledger.transport_user_key(
             self.definition.instance_id(),
             user_id,
             connection_id,
@@ -905,7 +903,7 @@ impl Room {
     /// Runtime diagnostics and transport command paths use this to route work
     /// to the correct RTC worker.
     pub fn media_worker_id(&self) -> usize {
-        self.placement_directory.media_worker_id()
+        self.placement_ledger.media_worker_id()
     }
 
     pub(in crate::runtime::room) fn room_worker_policy(&self) -> RoomWorkerPolicy {
@@ -970,7 +968,7 @@ impl Room {
             })
             .collect();
         state.diagnostics_user_views(
-            self.placement_directory.media_worker_id(),
+            self.placement_ledger.media_worker_id(),
             &transport_by_session,
         )
     }
@@ -1036,10 +1034,7 @@ impl fmt::Debug for Room {
         formatter
             .debug_struct("Room")
             .field("instance_id", &self.definition.instance_id())
-            .field(
-                "media_worker_id",
-                &self.placement_directory.media_worker_id(),
-            )
+            .field("media_worker_id", &self.placement_ledger.media_worker_id())
             .field("uuid", &self.definition.uuid())
             .field("issuer", &self.definition.issuer())
             .field("web_rtc_enabled", &self.definition.web_rtc_enabled())

--- a/crates/core/src/runtime/room/manager/mod.rs
+++ b/crates/core/src/runtime/room/manager/mod.rs
@@ -15,10 +15,7 @@ use super::{
     RoomMediaCounts, RoomRuntimePolicy, RoomUserStatsSnapshot, UserOutboundSender,
     directory::{RoomDirectory, RoomDirectoryEntry},
     factory::{RoomCreationIntent, RoomFactory},
-    placement::{
-        RoomPlacementDecision, RoomPlacementPlanner, RoomPlacementUsageSnapshot,
-        WorkerPlacementLoad, WorkerPlacementLoadSet,
-    },
+    placement::{RoomPlacementPlanner, WorkerLoadIndex},
 };
 use crate::runtime::{
     ConnectionId, RoomInstanceId, UserId, UserPermissions,
@@ -336,52 +333,28 @@ impl RoomManager {
         media_transport: &MediaTransport,
     ) -> LocalRouterRuntimeContext {
         let room_snapshot = room.placement_usage_snapshot().await;
-        let worker_loads = self.worker_placement_loads(media_transport).await;
+        let worker_loads = self.worker_load_index(media_transport).await;
         let planner = RoomPlacementPlanner::new(self.media_worker_count, room.room_worker_policy());
-        self.resolve_placement_decision(
-            &room_snapshot,
-            planner.choose(&room_snapshot, &worker_loads),
-        )
+        planner
+            .choose(&room_snapshot, &worker_loads)
+            .resolve(&room_snapshot, || self.factory.allocate_spillover_router())
     }
 
-    async fn worker_placement_loads(
-        &self,
-        media_transport: &MediaTransport,
-    ) -> Vec<WorkerPlacementLoad> {
-        let mut load_set = WorkerPlacementLoadSet::new(
+    async fn worker_load_index(&self, media_transport: &MediaTransport) -> WorkerLoadIndex {
+        let mut load_index = WorkerLoadIndex::new(
             self.media_worker_count,
             media_transport.worker_pressure_snapshots(),
         );
         for entry in self.directory_entries().await {
             let contribution = entry.room().worker_load_contribution().await;
             for media_worker_id in contribution.session_workers {
-                load_set.record_session(media_worker_id);
+                load_index.record_session(media_worker_id);
             }
             for media_worker_id in contribution.consumer_workers {
-                load_set.record_consumer(media_worker_id);
+                load_index.record_consumer(media_worker_id);
             }
         }
-        load_set.into_loads()
-    }
-
-    fn resolve_placement_decision(
-        &self,
-        room_snapshot: &RoomPlacementUsageSnapshot,
-        decision: RoomPlacementDecision,
-    ) -> LocalRouterRuntimeContext {
-        match decision {
-            RoomPlacementDecision::AssignPrimary { media_worker_id } => LocalRouterRuntimeContext {
-                router: room_snapshot.primary_router(),
-                media_worker: media_worker_id,
-            },
-            RoomPlacementDecision::UseExisting(placement) => placement,
-            RoomPlacementDecision::AllocateSpillover { media_worker_id } => {
-                LocalRouterRuntimeContext {
-                    router: self.factory.allocate_spillover_router(),
-                    media_worker: media_worker_id,
-                }
-            }
-        }
+        load_index
     }
 
     /// Closes one runtime connection if the room is still current.

--- a/crates/core/src/runtime/room/membership.rs
+++ b/crates/core/src/runtime/room/membership.rs
@@ -24,7 +24,7 @@ use o_sfu_telemetry::schema::event as telemetry_event;
 use tracing::warn;
 
 #[cfg(any(test, feature = "testing-transport"))]
-use super::placement::{RoomPlacementDecision, RoomPlacementPlanner, WorkerPlacementLoadSet};
+use super::placement::{RoomPlacementPlanner, WorkerLoadIndex};
 use super::{
     BroadcastPayloadError, LocalRouterRuntimeContext, Room, RoomJoinError, RoomUserPermissions,
     UserOutbound, UserOutboundSender,
@@ -176,29 +176,18 @@ impl Room {
     ) -> LocalRouterRuntimeContext {
         let room_snapshot = self.placement_usage_snapshot().await;
         let policy = self.room_worker_policy();
-        let mut load_set =
-            WorkerPlacementLoadSet::new(policy.max_local_routers(), pressure_snapshots);
+        let mut load_index = WorkerLoadIndex::new(policy.max_local_routers(), pressure_snapshots);
         let contribution = self.worker_load_contribution().await;
         for media_worker_id in contribution.session_workers {
-            load_set.record_session(media_worker_id);
+            load_index.record_session(media_worker_id);
         }
         for media_worker_id in contribution.consumer_workers {
-            load_set.record_consumer(media_worker_id);
+            load_index.record_consumer(media_worker_id);
         }
         let planner = RoomPlacementPlanner::new(policy.max_local_routers(), policy);
-        match planner.choose(&room_snapshot, &load_set.into_loads()) {
-            RoomPlacementDecision::AssignPrimary { media_worker_id } => LocalRouterRuntimeContext {
-                router: room_snapshot.primary_router(),
-                media_worker: media_worker_id,
-            },
-            RoomPlacementDecision::UseExisting(placement) => placement,
-            RoomPlacementDecision::AllocateSpillover { media_worker_id } => {
-                LocalRouterRuntimeContext {
-                    router: room_snapshot.next_local_router_id(),
-                    media_worker: media_worker_id,
-                }
-            }
-        }
+        planner
+            .choose(&room_snapshot, &load_index)
+            .resolve(&room_snapshot, || room_snapshot.next_local_router_id())
     }
 
     /// join a user after placement has already been selected
@@ -525,8 +514,8 @@ impl Room {
         cleanup: UserCleanup<'_>,
     ) -> UserTransitionResult {
         let connection_id = outcome.connection_id;
-        self.placement_directory
-            .register_transport_placement(connection_id, outcome.transport_home_placement);
+        self.placement_ledger
+            .register_committed_placement(connection_id, outcome.transport_home_placement);
         if let Some(media_transport) = cleanup.cleaning_media_transport() {
             execute_relay_route_effects(self, media_transport, &outcome.relay_effects).await;
         }
@@ -562,7 +551,7 @@ impl Room {
     ) -> UserTransitionResult {
         let had_state = outcome.is_some();
         let media_worker_id = self
-            .placement_directory
+            .placement_ledger
             .media_worker_id_for_connection(connection_id);
         if let Some(outcome) = outcome {
             if let Some(media_transport) = cleanup.cleaning_media_transport() {
@@ -578,8 +567,8 @@ impl Room {
             self.record_closed_user(&user_id, connection_id, media_worker_id, cleanup)
                 .await;
         }
-        self.placement_directory
-            .unregister_transport_worker(connection_id);
+        self.placement_ledger
+            .unregister_committed_placement(connection_id);
         if had_state {
             UserTransitionResult::Applied
         } else {
@@ -651,7 +640,7 @@ impl Room {
     /// Record diagnostics for a user removed by the bulk disconnect path.
     fn record_disconnected_user(&self, user_id: &UserId, connection_id: ConnectionId) {
         let media_worker_id = self
-            .placement_directory
+            .placement_ledger
             .media_worker_id_for_connection(connection_id);
         self.diagnostics.record(
             DiagnosticsEventData::for_user(
@@ -662,8 +651,8 @@ impl Room {
             .with_media_worker_id(media_worker_id),
         );
         self.diagnostics.forget_user(self.uuid(), user_id);
-        self.placement_directory
-            .unregister_transport_worker(connection_id);
+        self.placement_ledger
+            .unregister_committed_placement(connection_id);
     }
 
     /// Emit close requests and room fan-outs captured by a state transition.

--- a/crates/core/src/runtime/room/placement.rs
+++ b/crates/core/src/runtime/room/placement.rs
@@ -12,7 +12,7 @@
 //! committed
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     sync::{Mutex, PoisonError},
 };
 
@@ -30,25 +30,23 @@ use crate::{
     },
 };
 
-/// room-local transport placement directory
+/// room-local committed placement ledger
 ///
-/// joins register the selected worker for each committed connection
-/// later transport commands use the same mapping to build stable session keys
-/// without putting mutable placement state inside `RoomDefinition`
+/// joins register the selected router and media worker for each committed
+/// connection. later transport commands use the same mapping to build stable
+/// session keys without deriving placement from several room indexes
 #[derive(Debug)]
-pub(super) struct RoomPlacementDirectory {
-    primary_router: RouterId,
-    primary_media_worker_id: Mutex<usize>,
-    worker_by_connection: Mutex<BTreeMap<ConnectionId, usize>>,
+pub(super) struct RoomPlacementLedger {
+    primary_placement: Mutex<LocalRouterRuntimeContext>,
+    placement_by_connection: Mutex<BTreeMap<ConnectionId, LocalRouterRuntimeContext>>,
 }
 
-impl RoomPlacementDirectory {
+impl RoomPlacementLedger {
     #[must_use]
     pub(super) fn new(primary: LocalRouterRuntimeContext) -> Self {
         Self {
-            primary_router: primary.router,
-            primary_media_worker_id: Mutex::new(primary.media_worker),
-            worker_by_connection: Mutex::new(BTreeMap::new()),
+            primary_placement: Mutex::new(primary),
+            placement_by_connection: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -67,48 +65,56 @@ impl RoomPlacementDirectory {
         )
     }
 
-    pub(super) fn register_transport_placement(
+    pub(super) fn register_committed_placement(
         &self,
         connection_id: ConnectionId,
         placement: LocalRouterRuntimeContext,
     ) {
-        self.worker_by_connection
+        self.placement_by_connection
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
-            .insert(connection_id, placement.media_worker);
-        if placement.router == self.primary_router {
-            *self
-                .primary_media_worker_id
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner) = placement.media_worker;
+            .insert(connection_id, placement);
+        let mut primary = self
+            .primary_placement
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if placement.router == primary.router {
+            *primary = placement;
         }
     }
 
-    pub(super) fn unregister_transport_worker(&self, connection_id: ConnectionId) {
-        self.worker_by_connection
+    pub(super) fn unregister_committed_placement(&self, connection_id: ConnectionId) {
+        self.placement_by_connection
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .remove(&connection_id);
     }
 
-    pub(super) fn media_worker_id_for_connection(&self, connection_id: ConnectionId) -> usize {
-        if let Some(media_worker_id) = self
-            .worker_by_connection
+    fn placement_for_connection(&self, connection_id: ConnectionId) -> LocalRouterRuntimeContext {
+        if let Some(placement) = self
+            .placement_by_connection
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .get(&connection_id)
             .copied()
         {
-            return media_worker_id;
+            return placement;
         }
-        self.media_worker_id()
+        *self
+            .primary_placement
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    pub(super) fn media_worker_id_for_connection(&self, connection_id: ConnectionId) -> usize {
+        self.placement_for_connection(connection_id).media_worker
     }
 
     pub(super) fn media_worker_id(&self) -> usize {
-        *self
-            .primary_media_worker_id
+        self.primary_placement
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
+            .media_worker
     }
 }
 
@@ -202,6 +208,26 @@ pub(super) enum RoomPlacementDecision {
     AllocateSpillover { media_worker_id: usize },
 }
 
+impl RoomPlacementDecision {
+    pub(super) fn resolve(
+        self,
+        room: &RoomPlacementUsageSnapshot,
+        allocate_spillover_router: impl FnOnce() -> RouterId,
+    ) -> LocalRouterRuntimeContext {
+        match self {
+            Self::AssignPrimary { media_worker_id } => LocalRouterRuntimeContext {
+                router: room.primary_router(),
+                media_worker: media_worker_id,
+            },
+            Self::UseExisting(placement) => placement,
+            Self::AllocateSpillover { media_worker_id } => LocalRouterRuntimeContext {
+                router: allocate_spillover_router(),
+                media_worker: media_worker_id,
+            },
+        }
+    }
+}
+
 /// aggregate placement load for one local media worker
 ///
 /// the room manager builds this from committed room mappings plus
@@ -209,7 +235,7 @@ pub(super) enum RoomPlacementDecision {
 /// each value is a one-join snapshot rather than a continuously maintained
 /// counter
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct WorkerPlacementLoad {
+struct WorkerPlacementLoad {
     /// worker this load describes after normalization by configured worker count
     media_worker_id: usize,
     /// sessions currently mapped to this worker
@@ -222,10 +248,7 @@ pub(super) struct WorkerPlacementLoad {
 
 impl WorkerPlacementLoad {
     #[must_use]
-    pub(super) const fn new(
-        media_worker_id: usize,
-        pressure: TransportPlacementPressureSnapshot,
-    ) -> Self {
+    const fn new(media_worker_id: usize, pressure: TransportPlacementPressureSnapshot) -> Self {
         Self {
             media_worker_id,
             session_count: 0,
@@ -298,13 +321,13 @@ struct WorkerPlacementScore {
 /// every configured worker receives an entry, even if transport observability
 /// has not published pressure yet
 /// this lets first-join placement prefer unused workers
-#[derive(Debug, Clone)]
-pub(super) struct WorkerPlacementLoadSet {
-    worker_count: usize,
-    loads: BTreeMap<usize, WorkerPlacementLoad>,
+#[derive(Debug)]
+pub(super) struct WorkerLoadIndex {
+    media_worker_count: usize,
+    loads: Vec<WorkerPlacementLoad>,
 }
 
-impl WorkerPlacementLoadSet {
+impl WorkerLoadIndex {
     /// create a complete worker load set from best-effort transport pressure
     ///
     /// missing snapshots are treated as idle workers
@@ -313,51 +336,87 @@ impl WorkerPlacementLoadSet {
     /// runtimes
     #[must_use]
     pub(super) fn new(
-        worker_count: usize,
+        media_worker_count: usize,
         pressure_snapshots: Vec<TransportWorkerPressureSnapshot>,
     ) -> Self {
-        let worker_count = worker_count.max(1);
-        let mut loads = (0..worker_count)
+        let media_worker_count = media_worker_count.max(1);
+        let mut loads = (0..media_worker_count)
             .map(|media_worker_id| {
-                (
+                WorkerPlacementLoad::new(
                     media_worker_id,
-                    WorkerPlacementLoad::new(
-                        media_worker_id,
-                        TransportPlacementPressureSnapshot::default(),
-                    ),
+                    TransportPlacementPressureSnapshot::default(),
                 )
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<Vec<_>>();
         for snapshot in pressure_snapshots {
-            let media_worker_id = snapshot.media_worker_id % worker_count;
-            loads.insert(
-                media_worker_id,
-                WorkerPlacementLoad::new(media_worker_id, snapshot.pressure),
-            );
+            let media_worker_id = snapshot.media_worker_id % media_worker_count;
+            if let Some(load) = loads.get_mut(media_worker_id) {
+                *load = WorkerPlacementLoad::new(media_worker_id, snapshot.pressure);
+            }
         }
         Self {
-            worker_count,
+            media_worker_count,
             loads,
         }
     }
 
     pub(super) fn record_session(&mut self, media_worker_id: usize) {
-        let media_worker_id = media_worker_id % self.worker_count;
-        if let Some(load) = self.loads.get_mut(&media_worker_id) {
+        if let Some(load) = self.load_mut_for_worker(media_worker_id) {
             load.record_session();
         }
     }
 
     pub(super) fn record_consumer(&mut self, media_worker_id: usize) {
-        let media_worker_id = media_worker_id % self.worker_count;
-        if let Some(load) = self.loads.get_mut(&media_worker_id) {
+        if let Some(load) = self.load_mut_for_worker(media_worker_id) {
             load.record_consumer();
         }
     }
 
-    #[must_use]
-    pub(super) fn into_loads(self) -> Vec<WorkerPlacementLoad> {
-        self.loads.into_values().collect()
+    fn load_mut_for_worker(&mut self, media_worker_id: usize) -> Option<&mut WorkerPlacementLoad> {
+        self.loads
+            .get_mut(media_worker_id % self.media_worker_count)
+    }
+
+    fn load_for_worker(&self, media_worker_id: usize) -> WorkerPlacementLoad {
+        let media_worker_id = media_worker_id % self.media_worker_count;
+        self.loads.get(media_worker_id).copied().unwrap_or_else(|| {
+            WorkerPlacementLoad::new(
+                media_worker_id,
+                TransportPlacementPressureSnapshot::default(),
+            )
+        })
+    }
+
+    fn least_loaded_worker(
+        &self,
+        excluded_placements: &[LocalRouterRuntimeContext],
+        policy: LocalSpilloverPolicy,
+    ) -> usize {
+        self.loads
+            .iter()
+            .filter(|load| {
+                !excluded_placements
+                    .iter()
+                    .any(|placement| placement.media_worker == load.media_worker_id)
+            })
+            .min_by_key(|load| load.score(policy))
+            .or_else(|| self.loads.iter().min_by_key(|load| load.score(policy)))
+            .map_or(0, |load| load.media_worker_id)
+    }
+
+    fn least_loaded_placement(
+        &self,
+        placements: &[LocalRouterRuntimeContext],
+        policy: LocalSpilloverPolicy,
+    ) -> LocalRouterRuntimeContext {
+        placements
+            .iter()
+            .copied()
+            .min_by_key(|placement| self.load_for_worker(placement.media_worker).score(policy))
+            .unwrap_or(LocalRouterRuntimeContext {
+                router: RouterId(0),
+                media_worker: 0,
+            })
     }
 }
 
@@ -392,9 +451,8 @@ impl RoomPlacementPlanner {
     pub(super) fn choose(
         &self,
         room: &RoomPlacementUsageSnapshot,
-        worker_loads: &[WorkerPlacementLoad],
+        load_index: &WorkerLoadIndex,
     ) -> RoomPlacementDecision {
-        let load_index = WorkerLoadIndex::new(self.media_worker_count, worker_loads);
         let placement_cap = self
             .policy
             .max_local_routers()
@@ -404,7 +462,7 @@ impl RoomPlacementPlanner {
         let assigned_placements = room.assigned_placements();
         if assigned_placements.is_empty() {
             return RoomPlacementDecision::AssignPrimary {
-                media_worker_id: load_index.least_loaded_worker(&BTreeSet::new(), score_policy),
+                media_worker_id: load_index.least_loaded_worker(&[], score_policy),
             };
         }
         match self.policy.spillover() {
@@ -420,7 +478,7 @@ impl RoomPlacementPlanner {
                 if assigned_placements.len() < placement_cap {
                     return RoomPlacementDecision::AllocateSpillover {
                         media_worker_id: load_index
-                            .least_loaded_worker(&used_workers(assigned_placements), score_policy),
+                            .least_loaded_worker(assigned_placements, score_policy),
                     };
                 }
                 RoomPlacementDecision::UseExisting(
@@ -438,95 +496,12 @@ impl RoomPlacementPlanner {
                 if assigned_placements.len() < placement_cap {
                     return RoomPlacementDecision::AllocateSpillover {
                         media_worker_id: load_index
-                            .least_loaded_worker(&used_workers(assigned_placements), policy),
+                            .least_loaded_worker(assigned_placements, policy),
                     };
                 }
                 RoomPlacementDecision::UseExisting(placement)
             }
         }
-    }
-}
-
-/// lookup table that gives the planner a stable score for every worker
-///
-/// callers can pass sparse data
-/// the index fills missing workers with idle loads so an unused worker can
-/// still win placement
-#[derive(Debug)]
-struct WorkerLoadIndex {
-    media_worker_count: usize,
-    loads: BTreeMap<usize, WorkerPlacementLoad>,
-}
-
-impl WorkerLoadIndex {
-    fn new(media_worker_count: usize, worker_loads: &[WorkerPlacementLoad]) -> Self {
-        let media_worker_count = media_worker_count.max(1);
-        let mut loads = (0..media_worker_count)
-            .map(|media_worker_id| {
-                (
-                    media_worker_id,
-                    WorkerPlacementLoad::new(
-                        media_worker_id,
-                        TransportPlacementPressureSnapshot::default(),
-                    ),
-                )
-            })
-            .collect::<BTreeMap<_, _>>();
-        for load in worker_loads {
-            let media_worker_id = load.media_worker_id % media_worker_count;
-            loads.insert(
-                media_worker_id,
-                WorkerPlacementLoad {
-                    media_worker_id,
-                    ..*load
-                },
-            );
-        }
-        Self {
-            media_worker_count,
-            loads,
-        }
-    }
-
-    fn load_for_worker(&self, media_worker_id: usize) -> WorkerPlacementLoad {
-        let media_worker_id = media_worker_id % self.media_worker_count;
-        self.loads
-            .get(&media_worker_id)
-            .copied()
-            .unwrap_or_else(|| {
-                WorkerPlacementLoad::new(
-                    media_worker_id,
-                    TransportPlacementPressureSnapshot::default(),
-                )
-            })
-    }
-
-    fn least_loaded_worker(
-        &self,
-        excluded_workers: &BTreeSet<usize>,
-        policy: LocalSpilloverPolicy,
-    ) -> usize {
-        self.loads
-            .values()
-            .filter(|load| !excluded_workers.contains(&load.media_worker_id))
-            .min_by_key(|load| load.score(policy))
-            .or_else(|| self.loads.values().min_by_key(|load| load.score(policy)))
-            .map_or(0, |load| load.media_worker_id)
-    }
-
-    fn least_loaded_placement(
-        &self,
-        placements: &[LocalRouterRuntimeContext],
-        policy: LocalSpilloverPolicy,
-    ) -> LocalRouterRuntimeContext {
-        placements
-            .iter()
-            .copied()
-            .min_by_key(|placement| self.load_for_worker(placement.media_worker).score(policy))
-            .unwrap_or(LocalRouterRuntimeContext {
-                router: RouterId(0),
-                media_worker: 0,
-            })
     }
 }
 
@@ -539,13 +514,6 @@ fn score_policy(policy: RoomWorkerPolicy) -> LocalSpilloverPolicy {
     }
 }
 
-fn used_workers(placements: &[LocalRouterRuntimeContext]) -> BTreeSet<usize> {
-    placements
-        .iter()
-        .map(|placement| placement.media_worker)
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use o_sfu_router::RouterId;
@@ -555,20 +523,20 @@ mod tests {
 
     #[test]
     fn first_join_uses_lowest_load_worker() {
-        let mut loads = WorkerPlacementLoadSet::new(2, Vec::new());
+        let mut loads = WorkerLoadIndex::new(2, Vec::new());
         loads.record_session(0);
         let planner = RoomPlacementPlanner::new(2, RoomWorkerPolicy::strict_single_router());
         let room = RoomPlacementUsageSnapshot::new(RouterId(7), false, Vec::new());
 
         assert_eq!(
-            planner.choose(&room, &loads.into_loads()),
+            planner.choose(&room, &loads),
             RoomPlacementDecision::AssignPrimary { media_worker_id: 1 }
         );
     }
 
     #[test]
     fn bounded_spillover_allocates_unused_worker_until_cap() {
-        let mut loads = WorkerPlacementLoadSet::new(3, Vec::new());
+        let mut loads = WorkerLoadIndex::new(3, Vec::new());
         loads.record_session(0);
         let planner = RoomPlacementPlanner::new(3, RoomWorkerPolicy::bounded_local_spillover(2));
         let room = RoomPlacementUsageSnapshot::new(
@@ -581,7 +549,7 @@ mod tests {
         );
 
         assert_eq!(
-            planner.choose(&room, &loads.into_loads()),
+            planner.choose(&room, &loads),
             RoomPlacementDecision::AllocateSpillover { media_worker_id: 1 }
         );
     }
@@ -599,10 +567,7 @@ mod tests {
         );
 
         assert_eq!(
-            planner.choose(
-                &room,
-                &WorkerPlacementLoadSet::new(3, Vec::new()).into_loads()
-            ),
+            planner.choose(&room, &WorkerLoadIndex::new(3, Vec::new())),
             RoomPlacementDecision::UseExisting(LocalRouterRuntimeContext {
                 router: RouterId(7),
                 media_worker: 2,
@@ -613,7 +578,7 @@ mod tests {
     #[test]
     fn load_triggered_spillover_reuses_capable_room_worker() -> Result<(), LocalSpilloverPolicyError>
     {
-        let mut loads = WorkerPlacementLoadSet::new(2, Vec::new());
+        let mut loads = WorkerLoadIndex::new(2, Vec::new());
         loads.record_session(0);
         let policy = LocalSpilloverPolicy::try_new(LocalSpilloverPolicyParts {
             min_receiver_count: 4,
@@ -630,7 +595,7 @@ mod tests {
         let room = RoomPlacementUsageSnapshot::new(RouterId(7), true, vec![placement]);
 
         assert_eq!(
-            planner.choose(&room, &loads.into_loads()),
+            planner.choose(&room, &loads),
             RoomPlacementDecision::UseExisting(placement)
         );
         Ok(())
@@ -639,7 +604,7 @@ mod tests {
     #[test]
     fn load_triggered_spillover_allocates_when_existing_worker_is_hot()
     -> Result<(), LocalSpilloverPolicyError> {
-        let mut loads = WorkerPlacementLoadSet::new(
+        let mut loads = WorkerLoadIndex::new(
             2,
             vec![TransportWorkerPressureSnapshot::new(
                 0,
@@ -669,7 +634,7 @@ mod tests {
         );
 
         assert_eq!(
-            planner.choose(&room, &loads.into_loads()),
+            planner.choose(&room, &loads),
             RoomPlacementDecision::AllocateSpillover { media_worker_id: 1 }
         );
         Ok(())

--- a/crates/core/src/runtime/room/tests/api/inspect.rs
+++ b/crates/core/src/runtime/room/tests/api/inspect.rs
@@ -167,6 +167,6 @@ impl RoomTestInspect<'_> {
 
     #[must_use]
     pub fn media_worker_id(self) -> usize {
-        self.room.placement_directory.media_worker_id()
+        self.room.placement_ledger.media_worker_id()
     }
 }


### PR DESCRIPTION
Room placement load was split between a transport placement directory, manager-side load materialization and a second planner index. That made join placement harder to audit because the same decision crossed several local shapes before it became a committed transport key