### PR TITLE
[IMP] core: require room keys for admission

### DIFF
--- a/crates/client/playwright/live_server.spec.js
+++ b/crates/client/playwright/live_server.spec.js
@@ -215,7 +215,7 @@ test("load-triggered spillover relays VP8 camera between real browsers", async (
 
         await connectPeer(publisher, {
             channelUuid,
-            jwt: createConnectToken(channelUuid, PUBLISHER_SESSION_ID, server.authKey),
+            jwt: createConnectToken(channelUuid, PUBLISHER_SESSION_ID),
             url: server.wsUrl
         });
         await expect.poll(async () => (await peerSnapshot(publisher)).state).toBe("connected");
@@ -228,7 +228,7 @@ test("load-triggered spillover relays VP8 camera between real browsers", async (
 
         await connectPeer(subscriber, {
             channelUuid,
-            jwt: createConnectToken(channelUuid, SUBSCRIBER_SESSION_ID, server.authKey),
+            jwt: createConnectToken(channelUuid, SUBSCRIBER_SESSION_ID),
             url: server.wsUrl
         });
         await expect.poll(async () => (await peerSnapshot(subscriber)).state).toBe("connected");
@@ -298,12 +298,12 @@ test("H264-only live publish applies RID simulcast and renders when supported", 
 
         await connectPeer(publisher, {
             channelUuid,
-            jwt: createConnectToken(channelUuid, PUBLISHER_SESSION_ID, server.authKey),
+            jwt: createConnectToken(channelUuid, PUBLISHER_SESSION_ID),
             url: server.wsUrl
         });
         await connectPeer(subscriber, {
             channelUuid,
-            jwt: createConnectToken(channelUuid, SUBSCRIBER_SESSION_ID, server.authKey),
+            jwt: createConnectToken(channelUuid, SUBSCRIBER_SESSION_ID),
             url: server.wsUrl
         });
 
@@ -373,7 +373,7 @@ test("live browser negotiation keeps RTX pairs only for eligible optional codecs
         const peer = await createPeerPage(context);
         await connectPeer(peer, {
             channelUuid,
-            jwt: createConnectToken(channelUuid, 77, server.authKey),
+            jwt: createConnectToken(channelUuid, 77),
             url: server.wsUrl
         });
 

--- a/crates/client/playwright/live_server_helpers.mjs
+++ b/crates/client/playwright/live_server_helpers.mjs
@@ -4,6 +4,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 const TEST_AUTH_KEY = "u6bsUQEWrHdKIuYplirRnbBmLbrKV5PxKG7DtA71mng=";
+const TEST_ROOM_KEY = "6me1UEeLIMqcygWGz1icMuVMVcPbZyVOF2LlZZPCCOw=";
 const TEST_SFU_HTTP_BASE_URL = "http://127.0.0.1:18080";
 export const TEST_SFU_WS_URL = "ws://127.0.0.1:18080/";
 const DIAGNOSTICS_ROOM_PATH = "/internal/diagnostics/rooms";
@@ -13,13 +14,15 @@ const HARNESS_URL = "/playwright/fixtures/harness.html";
 
 export async function createChannel({
     authKey = TEST_AUTH_KEY,
+    roomKey = TEST_ROOM_KEY,
     httpBaseUrl = TEST_SFU_HTTP_BASE_URL
 } = {}) {
     const response = await fetch(`${httpBaseUrl}/v1/channel`, {
         headers: {
             Authorization: `Bearer ${signJwt(
                 {
-                    iss: `playwright-${randomUUID()}`
+                    iss: `playwright-${randomUUID()}`,
+                    key: roomKey
                 },
                 authKey
             )}`
@@ -32,13 +35,13 @@ export async function createChannel({
     return payload.uuid;
 }
 
-export function createConnectToken(channelUuid, sessionId, authKey = TEST_AUTH_KEY) {
+export function createConnectToken(channelUuid, sessionId, roomKey = TEST_ROOM_KEY) {
     return signJwt(
         {
             sfu_channel_uuid: channelUuid,
             session_id: sessionId
         },
-        authKey
+        roomKey
     );
 }
 
@@ -575,6 +578,7 @@ function signJwt(payload, keyB64) {
     const encodedPayload = encodeJwtSegment(payload);
     const signedData = `${encodedHeader}.${encodedPayload}`;
     const signature = createHmac("sha256", Buffer.from(keyB64, "base64"))
+        // lgtm[js/insufficient-password-hash] HS256 signs a JWT, it does not store a password hash
         .update(signedData)
         .digest("base64url");
     return `${signedData}.${signature}`;

--- a/crates/core/src/runtime/room/controller.rs
+++ b/crates/core/src/runtime/room/controller.rs
@@ -648,7 +648,7 @@ impl Room {
         runtime_context: &RoomRuntimeContext,
         runtime_policy: RoomRuntimePolicy,
         issuer: String,
-        key: Option<String>,
+        key: String,
         config: RoomConfig,
         diagnostics: Arc<DiagnosticsStore>,
         packet_sink_registry: Arc<RoomPacketSinkRegistry>,
@@ -787,13 +787,13 @@ impl Room {
     }
 
     #[must_use]
-    /// Optional room key configured at room creation time.
+    /// Room key configured at room creation time.
     ///
     /// This is preserved as immutable room metadata and can later be used by
     /// control-plane or permission flows that need room-scoped secrets
     ///
     /// The room itself does not reinterpret or rotate this value.
-    pub fn key(&self) -> Option<&str> {
+    pub fn key(&self) -> &str {
         self.definition.key()
     }
 

--- a/crates/core/src/runtime/room/definition.rs
+++ b/crates/core/src/runtime/room/definition.rs
@@ -32,11 +32,11 @@ const fn persistent_recording_backend_available() -> bool {
 struct RoomIdentity {
     uuid: String,
     issuer: String,
-    key: Option<String>,
+    key: String,
 }
 
 impl RoomIdentity {
-    fn new(issuer: String, key: Option<String>) -> Self {
+    fn new(issuer: String, key: String) -> Self {
         Self {
             uuid: Uuid::new_v4().to_string(),
             issuer,
@@ -64,7 +64,7 @@ impl RoomDefinition {
         runtime_context: &RoomRuntimeContext,
         runtime_policy: &RoomRuntimePolicy,
         issuer: String,
-        key: Option<String>,
+        key: String,
         config: RoomConfig,
     ) -> Self {
         Self {
@@ -87,8 +87,8 @@ impl RoomDefinition {
     }
 
     #[must_use]
-    pub(crate) fn key(&self) -> Option<&str> {
-        self.identity.key.as_deref()
+    pub(crate) fn key(&self) -> &str {
+        &self.identity.key
     }
 
     #[must_use]

--- a/crates/core/src/runtime/room/factory.rs
+++ b/crates/core/src/runtime/room/factory.rs
@@ -29,11 +29,11 @@ pub(crate) struct RoomCreationIntent {
     /// Compatibility-facing room identity used by manager lookup and the
     /// room definition.
     issuer: String,
-    /// Optional room key captured from the first create request.
+    /// Room key captured from the first create request.
     ///
     /// Later calls for the same issuer reuse the already-created room, so
     /// this value is immutable for the room lifetime.
-    key: Option<String>,
+    key: String,
     /// Per-room compatibility knobs attached to the created room.
     ///
     /// This is copied into the room definition once. Repeated create calls
@@ -47,10 +47,10 @@ impl RoomCreationIntent {
     /// This is cold-path only. Cloning the small create parameters keeps the
     /// factory independent from HTTP or websocket request lifetimes.
     #[must_use]
-    pub(crate) fn new(issuer: &str, key: Option<&str>, config: &RoomConfig) -> Self {
+    pub(crate) fn new(issuer: &str, key: &str, config: &RoomConfig) -> Self {
         Self {
             issuer: issuer.to_owned(),
-            key: key.map(str::to_owned),
+            key: key.to_owned(),
             config: config.clone(),
         }
     }

--- a/crates/core/src/runtime/room/manager/mod.rs
+++ b/crates/core/src/runtime/room/manager/mod.rs
@@ -149,7 +149,7 @@ impl RoomManager {
     pub async fn serve_room(
         &self,
         issuer: &str,
-        key: Option<&str>,
+        key: &str,
         config: &RoomConfig,
         remote_address: Option<&str>,
     ) -> Arc<Room> {

--- a/crates/core/src/runtime/room/tests/fixtures.rs
+++ b/crates/core/src/runtime/room/tests/fixtures.rs
@@ -38,6 +38,8 @@ pub(super) use crate::{
     },
 };
 
+pub(super) const TEST_ROOM_KEY: &str = "Y2hhbm5lbC1rZXk=";
+
 /// Realistic client RTP capabilities (default codecs)
 pub(super) fn test_client_rtp_capabilities() -> MediaCapabilities {
     sample_client_rtp_capabilities()
@@ -454,7 +456,7 @@ impl ReadyRoomFixtureOptions {
 async fn setup_ready_room_fixture(options: ReadyRoomFixtureOptions) -> ReadyRoomFixture {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (first_tx, first_rx) = test_sender();
     let (second_tx, second_rx) = test_sender();
@@ -560,7 +562,7 @@ pub(super) async fn setup_ready_users_with_fake_receivers(
 ) {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (adapter, fake) = fake_adapter();
     let mut receivers = Vec::with_capacity(user_ids.len());

--- a/crates/core/src/runtime/room/tests/manager_tests.rs
+++ b/crates/core/src/runtime/room/tests/manager_tests.rs
@@ -252,11 +252,15 @@ fn joined_connection(users: &[(UserId, ConnectionId)], expected_user_id: &UserId
 async fn room_manager_is_idempotent_by_issuer() {
     let manager = RoomManager::for_test();
     let config = RoomConfig::default();
-    let first = manager.serve_room("issuer-a", None, &config, None).await;
-    let second = manager
-        .serve_room("issuer-a", Some("ignored"), &config, None)
+    let first = manager
+        .serve_room("issuer-a", TEST_ROOM_KEY, &config, None)
         .await;
-    let third = manager.serve_room("issuer-b", None, &config, None).await;
+    let second = manager
+        .serve_room("issuer-a", "ignored", &config, None)
+        .await;
+    let third = manager
+        .serve_room("issuer-b", TEST_ROOM_KEY, &config, None)
+        .await;
     assert_eq!(first.uuid(), second.uuid());
     assert_ne!(first.uuid(), third.uuid());
 }
@@ -282,8 +286,8 @@ async fn room_manager_concurrent_create_attempts_publish_one_live_room() {
     let config = RoomConfig::default();
 
     let (first, second) = tokio::join!(
-        manager.serve_room("issuer-a", None, &config, None),
-        manager.serve_room("issuer-a", None, &config, None),
+        manager.serve_room("issuer-a", TEST_ROOM_KEY, &config, None),
+        manager.serve_room("issuer-a", TEST_ROOM_KEY, &config, None),
     );
 
     assert_eq!(first.uuid(), second.uuid());
@@ -295,13 +299,13 @@ async fn room_manager_places_first_join_on_lowest_load_worker() {
     let manager = RoomManager::for_test_with_media_workers(2);
     let media_transport = MediaTransport::fake_for_testing();
     let first = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let second = manager
-        .serve_room("issuer-b", None, &RoomConfig::default(), None)
+        .serve_room("issuer-b", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let third = manager
-        .serve_room("issuer-c", None, &RoomConfig::default(), None)
+        .serve_room("issuer-c", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     assert_eq!(first.test_api().inspect().media_worker_id(), 0);
@@ -337,7 +341,7 @@ async fn room_spillover_policy_places_user_transport_on_local_workers() {
     let manager = spillover_room_manager(2);
     let media_transport = MediaTransport::fake_for_testing();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     let first_connection = manager_join_user(&manager, &room, 10, &media_transport).await;
@@ -353,7 +357,7 @@ async fn room_spillover_policy_places_user_transport_on_local_workers() {
 async fn strict_room_placement_keeps_topology_and_transport_on_primary_worker() {
     let manager = RoomManager::for_test_with_media_workers(3);
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     join_users_for_placement(&room, &[10, 20, 30]).await;
@@ -367,7 +371,7 @@ async fn strict_room_placement_keeps_topology_and_transport_on_primary_worker() 
 async fn bounded_room_placement_keeps_topology_and_transport_aligned() {
     let manager = spillover_room_manager(3);
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     join_users_for_placement(&room, &[10, 20, 30]).await;
@@ -399,7 +403,7 @@ async fn load_triggered_room_placement_keeps_topology_and_transport_aligned()
         })?,
     );
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     join_users_for_placement(&room, &[10, 20, 30]).await;
@@ -432,7 +436,7 @@ async fn load_triggered_room_keeps_small_room_transport_on_primary_worker()
         })?,
     );
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     for raw_user_id in [10_i64, 20] {
@@ -478,7 +482,7 @@ async fn load_triggered_room_uses_transport_pressure_for_new_placement()
     );
     let (media_transport, fake) = fake_adapter();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     manager_join_user(&manager, &room, 10, &media_transport).await;
@@ -509,7 +513,7 @@ async fn load_triggered_room_places_new_receivers_on_spillover_worker_after_pres
         })?,
     );
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     for raw_user_id in [10_i64, 20] {
@@ -571,7 +575,7 @@ async fn cleanup_retry_keeps_resolved_spillover_worker_after_unregister()
     );
     let (media_transport, fake) = fake_adapter();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     let first_user_id = UserId::Integer(10);
@@ -636,7 +640,7 @@ async fn cleanup_retry_keeps_resolved_spillover_worker_after_unregister()
 async fn room_replacement_join_rehomes_topology_and_transport_together() {
     let manager = spillover_room_manager(2);
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let adapter = MediaTransport::fake_for_testing();
     let user_id = UserId::Integer(10);
@@ -704,7 +708,7 @@ async fn room_replacement_join_rehomes_topology_and_transport_together() {
 async fn room_spillover_diagnostics_reports_each_users_transport_worker() {
     let manager = spillover_room_manager(2);
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let first_user_id = UserId::Integer(10);
     let second_user_id = UserId::Integer(20);
@@ -738,7 +742,7 @@ async fn room_spillover_diagnostics_reports_each_users_transport_worker() {
 async fn room_spillover_publish_subscribe_and_leave_cleanup_stay_aligned() {
     let manager = spillover_room_manager(2);
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (adapter, fake) = fake_adapter();
     let publisher_id = UserId::Integer(10);
@@ -818,7 +822,7 @@ async fn room_spillover_publish_subscribe_and_leave_cleanup_stay_aligned() {
 async fn room_owned_relay_route_shares_remote_worker_lifecycle() {
     let manager = spillover_room_manager(2);
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (media_transport, fake) = fake_adapter();
     let users = join_ready_users(&room, &[10, 20, 30, 40]).await;
@@ -911,7 +915,7 @@ async fn room_owned_relay_route_shares_remote_worker_lifecycle() {
 async fn room_owned_relay_route_is_released_when_bootstrap_turns_stale() {
     let manager = spillover_room_manager(2);
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (media_transport, fake) = fake_adapter();
     let users = join_ready_users(&room, &[10, 20]).await;
@@ -963,7 +967,7 @@ async fn room_owned_relay_route_is_released_when_bootstrap_turns_stale() {
 async fn room_manager_lookup_by_uuid() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let fetched = manager.get_by_uuid(room.uuid()).await;
     assert!(fetched.is_some());
@@ -999,7 +1003,7 @@ async fn manager_leave_user_removes_empty_room() {
     let manager = RoomManager::for_test_with_admission_policy(RoomAdmissionPolicy::new(1));
     let media_transport = MediaTransport::fake_for_testing();
     let first_room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let room_id = first_room.uuid().to_owned();
     let (tx, _rx) = test_sender();
@@ -1031,7 +1035,7 @@ async fn manager_leave_user_removes_empty_room() {
 
     assert!(manager.get_by_uuid(&room_id).await.is_none());
     let replacement = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     assert_ne!(replacement.uuid(), room_id);
 }
@@ -1041,7 +1045,7 @@ async fn manager_disconnect_users_removes_empty_room() {
     let manager = RoomManager::for_test_with_admission_policy(RoomAdmissionPolicy::new(1));
     let media_transport = MediaTransport::fake_for_testing();
     let first_room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let room_id = first_room.uuid().to_owned();
     let (tx, _rx) = test_sender();
@@ -1065,7 +1069,7 @@ async fn manager_disconnect_users_removes_empty_room() {
 
     assert!(manager.get_by_uuid(&room_id).await.is_none());
     let replacement = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     assert_ne!(replacement.uuid(), room_id);
 }
@@ -1090,7 +1094,7 @@ async fn manager_concurrent_empty_room_cleanup_decrements_metrics_once() {
     ));
     let media_transport = MediaTransport::fake_for_testing();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let room_id = room.uuid().to_owned();
     let (tx, _rx) = test_sender();
@@ -1140,7 +1144,7 @@ async fn manager_concurrent_empty_cleanup_and_join_keep_directory_consistent() {
     ));
     let media_transport = MediaTransport::fake_for_testing();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let room_id = room.uuid().to_owned();
     let first_user = UserId::Integer(1);
@@ -1262,7 +1266,7 @@ async fn manager_metrics_track_live_rooms_and_users_without_replacement_drift() 
     );
     let media_transport = MediaTransport::fake_for_testing();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let room_id = room.uuid().to_owned();
     assert_eq!(metrics.snapshot().active_rooms(), 1);
@@ -1328,7 +1332,7 @@ async fn manager_metrics_track_live_media_totals_across_publish_and_disconnect()
     );
     let media_transport = MediaTransport::fake_for_testing();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let room_id = room.uuid().to_owned();
 
@@ -1413,7 +1417,7 @@ async fn manager_metrics_track_receiver_source_selection_updates() {
     let room = manager
         .serve_room(
             "issuer-source-selection",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig::default(),
             None,
         )
@@ -1446,7 +1450,7 @@ async fn manager_syncs_active_speaker_camera_policy_without_room_mutations() {
         .as_fake_transport()
         .expect("test expects the fake media transport");
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
 
     let mut receivers = Vec::new();

--- a/crates/core/src/runtime/room/tests/membership_tests.rs
+++ b/crates/core/src/runtime/room/tests/membership_tests.rs
@@ -16,7 +16,7 @@ use crate::{
 async fn join_user_enforces_capacity() {
     let manager = RoomManager::for_test_with_admission_policy(RoomAdmissionPolicy::new(1));
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx1, _rx1) = test_sender();
     let result = room
@@ -39,7 +39,7 @@ async fn join_user_enforces_capacity() {
 async fn reconnection_bypasses_capacity_and_replaces_existing_connection() {
     let manager = RoomManager::for_test_with_admission_policy(RoomAdmissionPolicy::new(1));
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx1, mut rx1) = test_sender();
     let first_connection = room
@@ -105,7 +105,7 @@ async fn reconnection_bypasses_capacity_and_replaces_existing_connection() {
 async fn leave_user_sends_departure_to_remaining_peers() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx1, mut rx1) = test_sender();
     let (tx2, _rx2) = test_sender();
@@ -133,7 +133,7 @@ async fn leave_user_sends_departure_to_remaining_peers() {
 async fn join_user_notifies_existing_peers_with_user_joined() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let media_transport = MediaTransport::fake_for_testing();
     let (tx1, mut rx1) = test_sender();
@@ -173,7 +173,7 @@ async fn join_user_notifies_existing_peers_with_user_joined() {
 async fn replacing_a_user_notifies_remaining_peers() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx1, mut alice_rx) = test_sender();
     let (tx2, mut bob_old_rx) = test_sender();
@@ -199,7 +199,7 @@ async fn replacing_a_user_notifies_remaining_peers() {
 async fn replacing_a_user_runtime_emits_departure_then_join_for_existing_peers() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let media_transport = MediaTransport::fake_for_testing();
     let (tx1, mut alice_rx) = test_sender();
@@ -456,7 +456,7 @@ async fn media_cleanup_failure_retries_until_success() {
 async fn user_close_failure_retries_until_success() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (media_transport, fake) = fake_adapter();
     let (tx, _rx) = test_sender();
@@ -540,7 +540,7 @@ async fn manager_keeps_empty_room_until_cleanup_retry_finishes() {
         },
     );
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (media_transport, fake) = fake_adapter();
     let (tx, _rx) = test_sender();
@@ -615,7 +615,7 @@ async fn state_only_cleanup_does_not_enqueue_transport_retry() {
 async fn stale_negotiation_callbacks_do_not_ready_a_replaced_user() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (media_transport, _fake) = fake_adapter();
     let (first_connection, second_connection) = join_same_user_twice(&room).await;
@@ -776,7 +776,7 @@ struct StaleRefreshScenario {
 async fn setup_stale_refresh_scenario() -> StaleRefreshScenario {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (media_transport, fake) = fake_adapter();
     let (publisher_tx, mut publisher_rx) = test_sender();
@@ -849,7 +849,7 @@ async fn setup_stale_refresh_scenario() -> StaleRefreshScenario {
 async fn broadcast_reaches_all_except_sender() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx1, mut rx1) = test_sender();
     let (tx2, mut rx2) = test_sender();
@@ -912,7 +912,7 @@ async fn outbound_receiver_drains_queued_messages_before_closure() {
 async fn outbound_queue_overflow_marks_slow_consumer() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let metrics = Arc::new(RuntimeMetrics::default());
     let (slow_tx, mut slow_rx) = UserOutboundSender::channel(1, Arc::clone(&metrics));
@@ -967,7 +967,7 @@ async fn outbound_queue_overflow_marks_slow_consumer() {
 async fn outbound_queue_byte_overflow_marks_slow_consumer() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let metrics = Arc::new(RuntimeMetrics::default());
     let limits = UserOutboundQueueLimits::new(16, 1_300);
@@ -1027,7 +1027,7 @@ async fn outbound_queue_byte_overflow_marks_slow_consumer() {
 async fn broadcast_rejects_payloads_above_room_limit() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (sender_tx, _sender_rx) = test_sender();
     let (receiver_tx, mut receiver_rx) = test_sender();
@@ -1070,7 +1070,7 @@ async fn broadcast_rejects_payloads_above_room_limit() {
 async fn full_room_large_broadcast_reuses_shared_payload_storage() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let mut receivers = Vec::new();
     for user_index in 1..=100 {
@@ -1136,7 +1136,7 @@ async fn full_room_large_broadcast_reuses_shared_payload_storage() {
 async fn update_user_info_broadcasts_to_all() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let media_transport = MediaTransport::fake_for_testing();
     let (tx1, mut rx1) = test_sender();
@@ -1187,7 +1187,7 @@ async fn update_user_info_broadcasts_to_all() {
 async fn update_user_info_with_refresh_sends_full_snapshot() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let media_transport = MediaTransport::fake_for_testing();
     let (tx1, mut rx1) = test_sender();
@@ -1238,7 +1238,7 @@ async fn update_user_info_with_refresh_sends_full_snapshot() {
 async fn disconnect_users_kicks_targets_and_notifies_remaining() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx1, mut rx1) = test_sender();
     let (tx2, mut rx2) = test_sender();
@@ -1288,7 +1288,7 @@ async fn disconnect_users_kicks_targets_and_notifies_remaining() {
 async fn disconnect_users_target_only_the_active_replaced_user() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx1, mut rx1) = test_sender();
     let (tx2, mut rx2) = test_sender();
@@ -1326,7 +1326,7 @@ async fn disconnect_users_target_only_the_active_replaced_user() {
 async fn room_maps_string_user_ids_into_router_users() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (tx, _rx) = test_sender();
     let joined = room
@@ -1361,7 +1361,7 @@ async fn room_maps_string_user_ids_into_router_users() {
 async fn room_keeps_user_permissions_above_router_state() {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let permissions = UserPermissions {
         transcription: Some(true),

--- a/crates/core/src/runtime/room/tests/producer_tests/support.rs
+++ b/crates/core/src/runtime/room/tests/producer_tests/support.rs
@@ -129,7 +129,7 @@ pub(super) struct RealRtcRefreshScenario {
 pub(super) async fn setup_real_rtc_refresh_scenario() -> RealRtcRefreshScenario {
     let manager = RoomManager::for_test();
     let room = manager
-        .serve_room("issuer-a", None, &RoomConfig::default(), None)
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
         .await;
     let (publisher_tx, publisher_rx) = test_sender();
     let (subscriber_tx, subscriber_rx) = test_sender();

--- a/crates/core/src/runtime/room/tests/recording_tests.rs
+++ b/crates/core/src/runtime/room/tests/recording_tests.rs
@@ -63,7 +63,7 @@ async fn build_recording_room_with(
     let room = manager
         .serve_room(
             "issuer-recording",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig {
                 recording_address: recording_address.map(str::to_owned),
                 ..RoomConfig::default()

--- a/src/runtime/auth.rs
+++ b/src/runtime/auth.rs
@@ -158,6 +158,20 @@ where
     serde_json::from_slice(&claims_bytes).map_err(|_error| AuthenticationError::InvalidJsonPayload)
 }
 
+/// decode untrusted JWT claims for candidate room selection only
+///
+/// callers must verify the same token with the selected room key before using
+/// the decoded claims as authenticated identity or permission data
+pub(crate) fn decode_unverified_claims<T>(token: &str) -> Result<T, AuthenticationError>
+where
+    T: DeserializeOwned,
+{
+    validate_token_length(token)?;
+    let (_header_b64, claims_b64, _signature_b64) = split_token(token)?;
+    let claims_bytes = decode_jwt_segment(claims_b64)?;
+    serde_json::from_slice(&claims_bytes).map_err(|_error| AuthenticationError::InvalidJsonPayload)
+}
+
 fn validate_token_length(token: &str) -> Result<(), AuthenticationError> {
     if token.len() > MAX_JWT_TOKEN_BYTES {
         return Err(AuthenticationError::TokenTooLarge {

--- a/src/runtime/http_server/controller.rs
+++ b/src/runtime/http_server/controller.rs
@@ -196,10 +196,10 @@ async fn room(
             state.metrics.record_http_room_forbidden();
             return StatusCode::FORBIDDEN.into_response();
         };
-        if query.recording_address.is_some() && claims.key.is_none() {
+        let Some(room_key) = claims.key.as_deref() else {
             state.metrics.record_http_room_bad_request();
             return StatusCode::BAD_REQUEST.into_response();
-        }
+        };
 
         let remote_address = resolve_remote_address(
             &headers,
@@ -214,7 +214,7 @@ async fn room(
             .room_manager
             .serve_room(
                 issuer,
-                claims.key.as_deref(),
+                room_key,
                 &room_config,
                 Some(remote_address.as_str()),
             )

--- a/src/runtime/http_server/tests/app_tests.rs
+++ b/src/runtime/http_server/tests/app_tests.rs
@@ -83,7 +83,7 @@ async fn stats_returns_live_room_data() {
         .room_manager
         .serve_room(
             "issuer-a",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig {
                 web_rtc_enabled: query.web_rtc_enabled(),
                 recording_address: query.recording_address.clone(),

--- a/src/runtime/http_server/tests/diagnostics_route_tests.rs
+++ b/src/runtime/http_server/tests/diagnostics_route_tests.rs
@@ -165,7 +165,7 @@ async fn diagnostics_routes_return_live_room_and_user_details() {
         .room_manager
         .serve_room(
             "issuer-a",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig::default(),
             Some("203.0.113.10"),
         )
@@ -610,7 +610,7 @@ async fn diagnostics_user_lookup_reports_ambiguous_matches() {
         .room_manager
         .serve_room(
             "issuer-a",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig::default(),
             Some("203.0.113.10"),
         )
@@ -619,7 +619,7 @@ async fn diagnostics_user_lookup_reports_ambiguous_matches() {
         .room_manager
         .serve_room(
             "issuer-b",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig::default(),
             Some("203.0.113.11"),
         )
@@ -699,7 +699,7 @@ async fn diagnostics_user_lookup_survives_user_replacement_without_conflict() {
         .room_manager
         .serve_room(
             "issuer-replacement",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig::default(),
             Some("203.0.113.12"),
         )
@@ -754,7 +754,7 @@ async fn diagnostics_user_lookup_drops_room_teardown_entries() {
         .room_manager
         .serve_room(
             "issuer-teardown",
-            None,
+            TEST_ROOM_KEY,
             &RoomConfig::default(),
             Some("203.0.113.13"),
         )

--- a/src/runtime/http_server/tests/fixtures.rs
+++ b/src/runtime/http_server/tests/fixtures.rs
@@ -29,7 +29,7 @@ pub(super) use crate::{
         room::{JoinUserRequest, RoomConfig},
         test_support::{
             RuntimeMetricsSnapshotTestExt, RuntimeTestBuilder, RuntimeTestState, TEST_AUTH_KEY,
-            test_outbound_sender,
+            TEST_ROOM_KEY, test_outbound_sender,
         },
     },
 };

--- a/src/runtime/http_server/tests/room_route_tests.rs
+++ b/src/runtime/http_server/tests/room_route_tests.rs
@@ -23,7 +23,7 @@ async fn room_requires_authorization_header() {
 
 #[tokio::test]
 async fn room_rejects_unknown_authorization_scheme() {
-    let token = signed_room_claims(Some("issuer-a"), None);
+    let token = signed_room_claims(Some("issuer-a"), Some(TEST_ROOM_KEY));
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -130,18 +130,16 @@ async fn room_requires_issuer_claim() {
 }
 
 #[tokio::test]
-async fn room_rejects_recording_without_key() {
+async fn room_rejects_missing_key() {
     let token = signed_room_claims(Some("issuer-a"), None);
     assert!(token.is_some());
     let Some(token) = token else {
         return;
     };
     let request = build_request(
-        Request::get(format!(
-            "{CHANNEL_PATH}?recordingAddress=https://record.example.com"
-        ))
-        .header(header::HOST, "sfu.example.com")
-        .header(header::AUTHORIZATION, format!("Bearer {token}")),
+        Request::get(CHANNEL_PATH)
+            .header(header::HOST, "sfu.example.com")
+            .header(header::AUTHORIZATION, format!("Bearer {token}")),
         Body::empty(),
     );
     assert!(request.is_some());
@@ -196,7 +194,7 @@ async fn room_returns_uuid_and_request_base_url() {
 
 #[tokio::test]
 async fn room_ignores_forwarded_headers_when_proxy_trust_is_disabled() {
-    let token = signed_room_claims(Some("issuer-a"), None);
+    let token = signed_room_claims(Some("issuer-a"), Some(TEST_ROOM_KEY));
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -258,7 +256,7 @@ async fn room_ignores_forwarded_headers_when_proxy_trust_is_disabled() {
 
 #[tokio::test]
 async fn room_uses_forwarded_headers_when_proxy_trust_is_enabled() {
-    let token = signed_room_claims(Some("issuer-a"), None);
+    let token = signed_room_claims(Some("issuer-a"), Some(TEST_ROOM_KEY));
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -339,7 +337,7 @@ async fn room_route_updates_metrics_for_unauthorized_and_success_paths() {
     };
     assert_eq!(unauthorized_response.status(), StatusCode::UNAUTHORIZED);
 
-    let token = signed_room_claims(Some("issuer-a"), None);
+    let token = signed_room_claims(Some("issuer-a"), Some(TEST_ROOM_KEY));
     assert!(token.is_some());
     let Some(token) = token else {
         return;

--- a/src/runtime/test_support.rs
+++ b/src/runtime/test_support.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 pub(super) const TEST_AUTH_KEY: &str = "u6bsUQEWrHdKIuYplirRnbBmLbrKV5PxKG7DtA71mng=";
+pub(super) const TEST_ROOM_KEY: &str = "Y2hhbm5lbC1rZXk=";
 
 #[derive(Default)]
 pub(super) struct DurationHistogramSnapshot {

--- a/src/runtime/websocket_server/handshake.rs
+++ b/src/runtime/websocket_server/handshake.rs
@@ -1,23 +1,32 @@
-//! WebSocket Handshake and User Establishment
+//! websocket handshake admission boundary
 //!
-//! This module handles the transition from a raw, newly-upgraded WebSocket
-//! into an authenticated and fully established RTC user.
-//! (very similar flow that the odoo/sfu way)
+//! this module owns the cold path that turns an upgraded socket into a
+//! `ConnectedUser`
+//! the controller owns HTTP upgrade admission
+//! the steady-state session loop owns authenticated signaling
+//! this file only owns the narrow interval where the socket is open but not yet
+//! a room user
 //!
-//! 1. **Receive Authentication**: Waits for the very first frame from the client, which
-//!    must be a valid `auth` message.
+//! admission has four ordered steps:
 //!
-//! 2. **Authentication**: Validates the JWT against either
-//!    the global key or a room-specific key (like the old SFU),
-//!    to validate the  client's identity and permissions for the target room.
-//!    (the JWT is signed by the Odoo server that owns the room)
+//! - receive exactly one first-frame `auth` envelope before the configured auth timeout
+//! - select the candidate room from the explicit auth payload channel or from a JWT room id
+//! - verify the same JWT with the selected room key before trusting claims
+//! - join the room and send the startup output returned by `User::start`
 //!
-//! 3. **Room Admission**: Requests the core room manager to admit the client
-//!    into the room. This allocates a unique connection ID and sets up the
-//!    outbound message routing queues.
+//! the order is security-critical because decoded JWT contents can only select
+//! a candidate room
+//! identity, permissions and optional labels become trusted only after
+//! room-key verification succeeds
+//! current Odoo uses the explicit payload channel path and signs a legacy
+//! room-scoped token without a room id claim
 //!
-//! 4. **User Initialization**: the core user returns the initial welcome snapshot
-//!    and transport offer, and this edge serializes that output to the socket.
+//! rejection is terminal for the socket
+//! helpers that return `None` have already recorded metrics and sent any close
+//! frame that should reach the peer
+//!
+//! pre-auth capacity is released as soon as authentication succeeds and before
+//! room admission allocates post-auth user resources
 
 use std::{sync::Arc, time::Duration};
 
@@ -55,44 +64,67 @@ use crate::{
     },
 };
 
+/// legacy Odoo WebSocket claims scoped by the selected room key
+///
+/// current Odoo sends the room id as `AuthPayload.channel`, not as a signed JWT claim
+/// the JWT still authenticates the user because it is signed with the
+/// room key selected during channel creation
+/// this shape keeps that compatibility path explicit so the modern
+/// `WebSocketConnectClaims` verifier can stay room-id-bound
 #[derive(Deserialize)]
 struct RoomScopedConnectClaims {
+    /// registered JWT lifetime claims validated by the shared verifier
     #[serde(flatten)]
     registered: RegisteredJwtClaims,
+    /// odoo RTC session id before runtime normalization
     #[serde(rename = "user_id", alias = "session_id")]
     user_id: UserId,
+    /// optional display label forwarded into room membership
     #[serde(default)]
     label: Option<String>,
+    /// optional room permissions forwarded into room membership
     #[serde(default)]
     permissions: Option<UserPermissions>,
 }
 
-enum HandshakeRoomResolution {
-    ExplicitRoom(Arc<Room>),
-    GlobalClaims {
-        room: Arc<Room>,
-        claims: Box<WebSocketConnectClaims>,
-    },
-}
-
+/// post-auth handoff from the handshake to the steady-state session loop
+///
+/// the room manager has already accepted this user
+/// every failure after this point must either clean up the exact connection id
+/// or hand ownership to the caller
 struct JoinedUser {
+    /// room that accepted the user and owns connection cleanup
     room: Arc<Room>,
+    /// runtime-normalized user identity stored in room membership
     user_id: UserId,
+    /// room-local connection token used to reject stale sockets
     connection_id: ConnectionId,
+    /// bounded receiver for room events addressed to this user
     outbound_rx: UserOutboundReceiver,
+    /// application protocol facade that will own post-auth signaling
     user: User,
 }
 
-/// Admit one upgraded socket into an authenticated room user.
+/// admit one upgraded socket into an authenticated room user
 ///
-/// The first client frame must be exactly one `auth` envelope. On success this function
-/// authenticates the JWT, joins the target room, sends the initial welcome snapshot,
-/// and initializes the post-auth protocol state that will drive the first offer/answer
-/// exchange
+/// the caller must pass a raw socket that has not consumed any client frame
+/// this function owns every handshake outcome until either it returns a
+/// `ConnectedUser` or rejects the socket
+/// successful authentication drops the pre-auth permit before room join so
+/// authenticated users do not count against unauthenticated socket pressure
 ///
-/// Returning `None` means the caller should stop processing the socket imediately. In
-/// rejection cases this function is also responsible for sending the appropriate close
-/// frame so callrs do not duplicate handshake failure handling.
+/// failure returns `None`
+/// auth and join failures send a close frame when the peer can still receive one
+/// startup failures clean up the room user before returning
+///
+/// on success this function authenticates the JWT, joins the target room, sends
+/// the initial welcome snapshot and initializes the post-auth protocol state
+/// that will drive the first offer/answer exchange
+///
+/// the returned `ConnectedUser` owns the authenticated reader half from the
+/// caller plus the bounded room-event receiver created during join
+/// the steady-state session loop becomes responsible for final cleanup after
+/// this exchange
 #[o_sfu_telemetry::measure_duration(
     metrics = "state.metrics",
     record = "record_ws_handshake_duration"
@@ -106,6 +138,8 @@ pub(super) async fn establish_user(
 ) -> Option<ConnectedUser> {
     let (room, claims) =
         authenticate_handshake_session(state, writer, reader, remote_address.as_ref()).await?;
+    // authentication no longer counts against unauthenticated socket pressure
+    // room admission can fail without holding a pre-auth capacity slot
     drop(pre_auth_permit);
     let mut joined_user =
         join_user(state, writer, room, claims, Arc::clone(&remote_address)).await?;
@@ -143,6 +177,11 @@ pub(super) async fn establish_user(
     })
 }
 
+/// read the first client frame under the authentication timeout
+///
+/// `Ok(None)` means the peer closed before a frame was available
+/// error variants carry the close code that should be reported by
+/// `reject_handshake`
 async fn receive_auth(
     state: &RuntimeState,
     reader: &mut WsReader,
@@ -166,6 +205,12 @@ async fn receive_auth(
     }
 }
 
+/// receive first-frame auth and convert parse failures into socket rejection
+///
+/// this helper is the last point where malformed unauthenticated input can fail
+/// without room context
+/// once it returns an `AuthPayload`, later failures are authentication or
+/// room-admission failures
 async fn receive_auth_or_reject(
     state: &RuntimeState,
     writer: &mut WsWriter,
@@ -191,6 +236,10 @@ async fn receive_auth_or_reject(
     }
 }
 
+/// receive the auth frame and authenticate it against a room
+///
+/// the duration metric intentionally includes first-frame wait time plus JWT
+/// verification because both contribute to unauthenticated socket pressure
 #[o_sfu_telemetry::measure_duration(metrics = "state.metrics", record = "record_ws_auth_duration")]
 async fn authenticate_handshake_session(
     state: &RuntimeState,
@@ -202,11 +251,17 @@ async fn authenticate_handshake_session(
     authenticate_session(state, writer, &auth_payload, remote_address).await
 }
 
+/// extract the protocol auth payload from the first WebSocket message
 fn parse_auth_payload(message: Message) -> Result<AuthPayload, WebSocketCloseCode> {
     let payload = auth_payload_text(message)?;
     decode_auth_payload_text(&payload)
 }
 
+/// normalize the accepted first-frame wire shapes into UTF-8 JSON text
+///
+/// text and binary frames are accepted for compatibility with WebSocket clients
+/// control frames before authentication are protocol errors except close, which
+/// is treated as clean shutdown
 fn auth_payload_text(message: Message) -> Result<String, WebSocketCloseCode> {
     match message {
         Message::Text(payload) => {
@@ -226,6 +281,11 @@ fn auth_payload_text(message: Message) -> Result<String, WebSocketCloseCode> {
     }
 }
 
+/// decode the first-frame batch and enforce the one-envelope auth contract
+///
+/// steady-state signaling can batch envelopes
+/// auth cannot because no room user exists yet and any extra envelope would be
+/// unauthenticated work
 fn decode_auth_batch(payload: &str) -> Result<Vec<ClientEnvelope>, WebSocketCloseCode> {
     let batch = decode_client_batch(payload).map_err(|_error| WebSocketCloseCode::ProtocolError)?;
     if batch.len() != 1 {
@@ -238,21 +298,22 @@ fn decode_auth_batch(payload: &str) -> Result<Vec<ClientEnvelope>, WebSocketClos
     Ok(batch)
 }
 
-/// Decodes the first WebSocket authentication frame.
+/// decodes the first WebSocket authentication frame
 ///
-/// The frame must contain exactly one signaling envelope and that envelope must
-/// be an auth message. Steady-state client batches are decoded by
-/// [`decode_client_batch`](crate::websocket::decode_client_batch).
+/// the frame must contain exactly one signaling envelope and that envelope must
+/// be an auth message
+/// steady-state client batches are decoded by `decode_client_batch`
 ///
 /// # Errors
 ///
-/// Returns the close code that the WebSocket edge uses when the frame is not a
-/// valid authentication batch.
+/// returns the close code that the WebSocket edge uses when the frame is not a
+/// valid authentication batch
 pub fn decode_auth_payload_text(payload: &str) -> Result<AuthPayload, WebSocketCloseCode> {
     let batch = decode_auth_batch(payload)?;
     extract_auth_envelope(batch)
 }
 
+/// convert the single-envelope batch into the only message allowed pre-auth
 fn extract_auth_envelope(batch: Vec<ClientEnvelope>) -> Result<AuthPayload, WebSocketCloseCode> {
     let Some(envelope) = batch.into_iter().next() else {
         return Err(WebSocketCloseCode::ProtocolError);
@@ -268,52 +329,59 @@ fn extract_auth_envelope(batch: Vec<ClientEnvelope>) -> Result<AuthPayload, WebS
     }
 }
 
+/// resolve a room and verify the JWT with that room's key
+///
+/// room selection happens before verification so current Odoo can continue to
+/// send the room id in the auth payload
+/// untrusted token fields are used only for candidate room lookup when the
+/// payload has no channel
+/// the returned claims have passed room-key verification
 async fn authenticate(
     state: &RuntimeState,
     auth_payload: &AuthPayload,
     remote_address: &str,
 ) -> Result<(Arc<Room>, WebSocketConnectClaims), WebSocketCloseCode> {
-    match resolve_handshake_room(state, auth_payload, remote_address).await? {
-        HandshakeRoomResolution::ExplicitRoom(room) => {
-            let room_id = room.uuid();
-            let claims = authenticate_room_scoped_claims(
-                &auth_payload.jwt,
-                room.key().unwrap_or(&state.config.auth.key),
-                room_id,
-                remote_address,
-            )?;
-            Ok((room, claims))
-        }
-        HandshakeRoomResolution::GlobalClaims { room, claims } => Ok((room, *claims)),
-    }
+    let room = resolve_handshake_room(state, auth_payload).await?;
+    let claims = authenticate_room_scoped_claims(
+        &auth_payload.jwt,
+        room.key(),
+        room.uuid(),
+        remote_address,
+    )?;
+    Ok((room, claims))
 }
 
+/// select the candidate room without trusting user claims
+///
+/// explicit `AuthPayload.channel` is the current Odoo path
+/// an absent channel falls back to the token room-id claim shape by decoding
+/// the JWT payload only for room lookup
+/// the caller must still run room-key verification before using any claim data
 async fn resolve_handshake_room(
     state: &RuntimeState,
     auth_payload: &AuthPayload,
-    remote_address: &str,
-) -> Result<HandshakeRoomResolution, WebSocketCloseCode> {
+) -> Result<Arc<Room>, WebSocketCloseCode> {
     let Some(explicit_room_id) = auth_payload.channel.as_deref() else {
-        let mut claims =
-            auth::verify::<WebSocketConnectClaims>(&auth_payload.jwt, &state.config.auth.key)
-                .map_err(|_error| {
-                    warn!(
-                        remote_address,
-                        "failed to verify websocket auth token against the global key"
-                    );
-                    WebSocketCloseCode::AuthFailed
-                })?;
-        claims.normalize_runtime_user_id();
-        let room = resolve_global_claims_room(state, &claims, remote_address).await?;
-        return Ok(HandshakeRoomResolution::GlobalClaims {
-            room,
-            claims: Box::new(claims),
-        });
+        // this decode is only a room-directory lookup hint
+        // trust starts after the token verifies with the selected room key
+        let unverified_claims = auth::decode_unverified_claims::<WebSocketConnectClaims>(
+            &auth_payload.jwt,
+        )
+        .map_err(|_error| {
+            debug!("authentication payload did not select a room");
+            WebSocketCloseCode::AuthFailed
+        })?;
+        return resolve_explicit_room(state, &unverified_claims.room_id).await;
     };
     let room = resolve_explicit_room(state, explicit_room_id).await?;
-    Ok(HandshakeRoomResolution::ExplicitRoom(room))
+    Ok(room)
 }
 
+/// look up the selected room id in the live room directory
+///
+/// missing rooms are authentication failures because the client is trying to
+/// join an admission boundary that no longer exists or never existed in this
+/// process
 async fn resolve_explicit_room(
     state: &RuntimeState,
     room_id: &str,
@@ -331,28 +399,13 @@ async fn resolve_explicit_room(
         })
 }
 
-async fn resolve_global_claims_room(
-    state: &RuntimeState,
-    claims: &WebSocketConnectClaims,
-    _remote_address: &str,
-) -> Result<Arc<Room>, WebSocketCloseCode> {
-    let Some(room) = state.room_manager.get_by_uuid(&claims.room_id).await else {
-        debug!(
-            room_id = claims.room_id,
-            "verified websocket token referenced a missing room"
-        );
-        return Err(WebSocketCloseCode::AuthFailed);
-    };
-    if room.key().is_some() {
-        debug!(
-            room_id = claims.room_id,
-            "global-key websocket token targeted a room that requires a scoped key"
-        );
-        return Err(WebSocketCloseCode::AuthFailed);
-    }
-    Ok(room)
-}
-
+/// verify user claims with the selected room key
+///
+/// modern claims must contain the same room id that selected the room
+/// legacy Odoo claims omit a room id and are accepted only after the token
+/// verifies with the selected room key
+/// the legacy path constructs canonical `WebSocketConnectClaims` so the rest of
+/// the runtime sees one claim shape
 fn authenticate_room_scoped_claims(
     token: &str,
     key: &str,
@@ -372,6 +425,8 @@ fn authenticate_room_scoped_claims(
         return Ok(claims);
     }
 
+    // current Odoo signs user tokens with the room key but keeps the room id
+    // outside the token in `AuthPayload.channel`
     let claims = auth::verify::<RoomScopedConnectClaims>(token, key).map_err(|_error| {
         warn!(
             remote_address,
@@ -390,6 +445,7 @@ fn authenticate_room_scoped_claims(
     Ok(claims)
 }
 
+/// authenticate a parsed payload and turn auth failures into terminal rejection
 async fn authenticate_session(
     state: &RuntimeState,
     writer: &mut WsWriter,
@@ -422,6 +478,11 @@ async fn authenticate_session(
     skip_all,
     fields(room_id = %room.uuid(), user_id = ?claims.user_id)
 )]
+/// allocate room membership and the bounded outbound queue
+///
+/// after this succeeds the room owns a live user entry
+/// later startup failure must call `cleanup_failed_session` with the returned
+/// connection id before the socket is abandoned
 async fn join_user(
     state: &RuntimeState,
     writer: &mut WsWriter,
@@ -429,6 +490,8 @@ async fn join_user(
     claims: WebSocketConnectClaims,
     remote_address: Arc<str>,
 ) -> Option<JoinedUser> {
+    // the room must never accept a user without a bounded outbound sink
+    // create the queue before join so admission is atomic from the room view
     let (outbound_tx, outbound_rx) = UserOutboundSender::channel_with_limits(
         UserOutboundQueueLimits::new(
             state.config.user.outbound_queue_capacity,
@@ -501,6 +564,11 @@ async fn join_user(
     }
 }
 
+/// attach authenticated room identity to the active tracing span
+///
+/// the upgrade span starts before authentication knows the room or user
+/// this is the point where later logs can be correlated with the accepted room
+/// user
 fn record_session_span(
     room: &Room,
     user_id: &UserId,
@@ -527,6 +595,12 @@ fn record_session_span(
     metrics = "state.metrics",
     record = "record_ws_user_initialize_duration"
 )]
+/// send the startup payload that makes the accepted room user usable
+///
+/// `User::start` returns the welcome state and any initial offer
+/// if startup fails or the socket cannot receive the output, this helper closes
+/// application state and removes the accepted room membership before returning
+/// `None`
 async fn initialize_user(
     state: &RuntimeState,
     writer: &mut WsWriter,
@@ -549,6 +623,8 @@ async fn initialize_user(
             );
             state.metrics.record_ws_user_initialize_failure();
             user.close().await;
+            // join already inserted this user into room state
+            // failed startup must remove the exact connection before returning
             cleanup_failed_session(state, room, user_id, connection_id).await;
             return None;
         }
@@ -569,12 +645,19 @@ async fn initialize_user(
             "failed to send websocket user startup payload"
         );
         user.close().await;
+        // startup output is the handoff to steady state
+        // if the socket cannot receive it, room membership must be rolled back
         cleanup_failed_session(state, room, user_id, connection_id).await;
         return None;
     }
     Some(())
 }
 
+/// remove a user that joined the room but never reached steady state
+///
+/// cleanup is best effort here because the socket is already failing
+/// later room reconciliation still owns any transport retry work exposed by the
+/// close path
 async fn cleanup_failed_session(
     state: &RuntimeState,
     room: &Room,
@@ -587,6 +670,9 @@ async fn cleanup_failed_session(
         .await;
 }
 
+/// record terminal rejection and close the socket when there is a close code
+///
+/// returning `None` lets call sites use the helper directly in `Option` chains
 async fn reject_handshake<T>(
     state: &RuntimeState,
     writer: Option<&mut WsWriter>,

--- a/src/runtime/websocket_server/tests/auth_tests.rs
+++ b/src/runtime/websocket_server/tests/auth_tests.rs
@@ -229,13 +229,7 @@ async fn websocket_authenticates_with_room_key_and_sends_welcome_payload() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(
-        &server,
-        "issuer-a",
-        Some(TEST_ROOM_KEY),
-        CreateRoomQuery::default(),
-    )
-    .await;
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
     let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(7));
     assert!(token.is_some());
     let Some(token) = token else {
@@ -291,8 +285,8 @@ async fn websocket_pre_auth_permit_is_released_after_auth_success() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(77));
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(77));
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -318,13 +312,7 @@ async fn websocket_authenticates_legacy_room_scoped_token_with_explicit_room_id(
     let Some(server) = server else {
         return;
     };
-    let room = create_room(
-        &server,
-        "issuer-a",
-        Some(TEST_ROOM_KEY),
-        CreateRoomQuery::default(),
-    )
-    .await;
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
     let token =
         signed_legacy_channel_scoped_connect_claims(TEST_ROOM_KEY, UserId::Integer(17), None);
     assert!(token.is_some());
@@ -348,14 +336,39 @@ async fn websocket_rejects_explicit_room_id_that_disagrees_with_claims() {
     let Some(server) = server else {
         return;
     };
-    let first_room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
-    let second_room = create_room(&server, "issuer-b", None, CreateRoomQuery::default()).await;
-    let token = signed_connect_claims(TEST_AUTH_KEY, first_room.uuid(), UserId::Integer(8));
+    let first_room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
+    let second_room = create_room(&server, "issuer-b", CreateRoomQuery::default()).await;
+    let token = signed_connect_claims(TEST_ROOM_KEY, first_room.uuid(), UserId::Integer(8));
     assert!(token.is_some());
     let Some(token) = token else {
         return;
     };
     let authenticated = authenticate_with_room(&server, &token, Some(second_room.uuid())).await;
+    assert!(authenticated.is_some());
+    let Some(mut websocket) = authenticated else {
+        return;
+    };
+
+    assert_eq!(
+        read_close_code(&mut websocket).await,
+        Some(CloseCode::Library(4106)),
+    );
+}
+
+#[tokio::test]
+async fn websocket_rejects_explicit_room_token_signed_with_another_key() {
+    let server = TestServerBuilder::new().spawn().await;
+    assert!(server.is_some());
+    let Some(server) = server else {
+        return;
+    };
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
+    let token = signed_connect_claims("b3RoZXItcm9vbS1rZXk=", room.uuid(), UserId::Integer(19));
+    assert!(token.is_some());
+    let Some(token) = token else {
+        return;
+    };
+    let authenticated = authenticate_with_room(&server, &token, Some(room.uuid())).await;
     assert!(authenticated.is_some());
     let Some(mut websocket) = authenticated else {
         return;
@@ -374,8 +387,9 @@ async fn websocket_rejects_oversized_auth_token_with_auth_failure() {
     let Some(server) = server else {
         return;
     };
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
     let token = "a".repeat(MAX_JWT_TOKEN_BYTES + 1);
-    let authenticated = authenticate_with_jwt(&server, &token).await;
+    let authenticated = authenticate_with_room(&server, &token, Some(room.uuid())).await;
     assert!(authenticated.is_some());
     let Some(mut websocket) = authenticated else {
         return;
@@ -388,14 +402,14 @@ async fn websocket_rejects_oversized_auth_token_with_auth_failure() {
 }
 
 #[tokio::test]
-async fn websocket_accepts_global_key_without_explicit_room_id() {
+async fn websocket_authenticates_room_key_token_without_explicit_room_id() {
     let server = TestServerBuilder::new().spawn().await;
     assert!(server.is_some());
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(9));
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(9));
     assert!(token.is_some());
     let Some(token) = token else {
         return;

--- a/src/runtime/websocket_server/tests/fixtures.rs
+++ b/src/runtime/websocket_server/tests/fixtures.rs
@@ -45,7 +45,7 @@ pub(super) use crate::{
         },
         metrics::RuntimeMetrics,
         room::{Room, RoomConfig, RoomManager},
-        test_support::{RuntimeMetricsSnapshotTestExt, RuntimeTestBuilder, TEST_AUTH_KEY},
+        test_support::{RuntimeMetricsSnapshotTestExt, RuntimeTestBuilder},
     },
 };
 
@@ -279,12 +279,11 @@ pub(super) fn signed_legacy_channel_scoped_connect_claims(
 pub(super) async fn create_room(
     server: &TestServer,
     issuer: &str,
-    key: Option<&str>,
     config: RoomConfig,
 ) -> Arc<Room> {
     server
         .room_manager
-        .serve_room(issuer, key, &config, None)
+        .serve_room(issuer, TEST_ROOM_KEY, &config, None)
         .await
 }
 
@@ -350,7 +349,7 @@ pub(super) async fn setup_negotiated_session(
     room: &Arc<Room>,
     user_id: UserId,
 ) -> Option<TestWebSocket> {
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), user_id)?;
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), user_id)?;
     let (mut websocket, _welcome) = authenticate_and_read_welcome(server, &token).await?;
     complete_initial_negotiation(&mut websocket, "v=0\r\ns=test-answer\r\n").await?;
     Some(websocket)

--- a/src/runtime/websocket_server/tests/protocol_core_harness_tests/handshake_presence.rs
+++ b/src/runtime/websocket_server/tests/protocol_core_harness_tests/handshake_presence.rs
@@ -7,9 +7,9 @@ async fn protocol_core_replays_real_server_welcome_peer_snapshot() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
-    let existing_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(31));
-    let joining_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(32));
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
+    let existing_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(31));
+    let joining_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(32));
     assert!(existing_token.is_some());
     assert!(joining_token.is_some());
     let Some(existing_token) = existing_token else {
@@ -92,7 +92,7 @@ async fn protocol_core_maps_real_server_auth_failure_to_closed_state() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
 
     let mut peer = ProtocolHarnessPeer::default();
     let connected = peer
@@ -141,8 +141,8 @@ async fn protocol_core_answers_real_server_offer_when_enabled() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-protocol", None, CreateRoomQuery::default()).await;
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(33));
+    let room = create_room(&server, "issuer-protocol", CreateRoomQuery::default()).await;
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(33));
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -184,12 +184,11 @@ async fn protocol_core_receives_protocol_broadcast_and_peer_updates() {
     let room = create_room(
         &server,
         "issuer-protocol-events",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(41));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(42));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(41));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(42));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -288,12 +287,11 @@ async fn protocol_user_emits_peerjoined_message_for_existing_peers() {
     let room = create_room(
         &server,
         "issuer-protocol-peerjoined",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(43));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(44));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(43));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(44));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -357,12 +355,11 @@ async fn protocol_user_replacement_emits_peerleft_then_peerjoined_for_existing_p
     let room = create_room(
         &server,
         "issuer-protocol-peer-replacement",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(45));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(46));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(45));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(46));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {

--- a/src/runtime/websocket_server/tests/protocol_core_harness_tests/publish_subscribe.rs
+++ b/src/runtime/websocket_server/tests/protocol_core_harness_tests/publish_subscribe.rs
@@ -10,12 +10,11 @@ async fn protocol_core_receives_translated_track_snapshot_and_explicit_unpublish
     let room = create_room(
         &server,
         "issuer-protocol-tracks",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(51));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(52));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(51));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(52));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -112,12 +111,11 @@ async fn protocol_core_publish_round_trips_through_real_server_user_protocol() {
     let room = create_room(
         &server,
         "issuer-protocol-publish",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(53));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(54));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(53));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(54));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -200,12 +198,11 @@ async fn protocol_core_publish_round_trips_through_real_rtc_server_user_protocol
     let room = create_room(
         &server,
         "issuer-protocol-rtc-publish",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(71));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(72));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(71));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(72));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -308,11 +305,10 @@ async fn protocol_handshake_uses_answer_derived_client_capabilities_for_user_sta
     let room = create_room(
         &server,
         "issuer-protocol-rtc-capabilities",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(75));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(75));
     assert!(alice_token.is_some());
     let Some(alice_token) = alice_token else {
         return;

--- a/src/runtime/websocket_server/tests/protocol_core_harness_tests/recovery_recording.rs
+++ b/src/runtime/websocket_server/tests/protocol_core_harness_tests/recovery_recording.rs
@@ -14,12 +14,11 @@ async fn protocol_core_subscribe_updates_consumer_activity() {
     let room = create_room(
         &server,
         "issuer-protocol-subscribe",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(61));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(62));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(61));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(62));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -366,7 +365,6 @@ async fn protocol_core_recording_requests_resolve_as_unsupported_without_backend
     let room = create_room(
         &server,
         "issuer-protocol-recording",
-        None,
         CreateRoomQuery {
             recording_address: Some("https://record.example.com".to_owned()),
             ..CreateRoomQuery::default()

--- a/src/runtime/websocket_server/tests/protocol_core_harness_tests/support/recording.rs
+++ b/src/runtime/websocket_server/tests/protocol_core_harness_tests/support/recording.rs
@@ -54,7 +54,7 @@ pub(crate) async fn connect_protocol_recording_peer(
     room: &Room,
 ) -> Option<ProtocolHarnessPeer> {
     let token = signed_connect_claims_with_permissions(
-        TEST_AUTH_KEY,
+        TEST_ROOM_KEY,
         room.uuid(),
         UserId::Integer(63),
         Some(recording_permissions()),

--- a/src/runtime/websocket_server/tests/protocol_core_harness_tests/support/scenarios.rs
+++ b/src/runtime/websocket_server/tests/protocol_core_harness_tests/support/scenarios.rs
@@ -110,9 +110,9 @@ pub(crate) async fn setup_fake_protocol_peers(
         .media_transport(MediaTransport::from_fake_transport(adapter))
         .spawn()
         .await?;
-    let room = create_room(&server, room_name, None, CreateRoomQuery::default()).await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), alice_user_id.clone())?;
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), bob_user_id.clone())?;
+    let room = create_room(&server, room_name, CreateRoomQuery::default()).await;
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), alice_user_id.clone())?;
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), bob_user_id.clone())?;
 
     let mut alice = ProtocolHarnessPeer::default();
     let mut bob = ProtocolHarnessPeer::default();
@@ -141,9 +141,9 @@ pub(crate) async fn setup_real_rtc_protocol_peers(
         .media_transport(build_real_rtc_media_transport())
         .spawn()
         .await?;
-    let room = create_room(&server, room_name, None, CreateRoomQuery::default()).await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), alice_user_id)?;
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), bob_user_id.clone())?;
+    let room = create_room(&server, room_name, CreateRoomQuery::default()).await;
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), alice_user_id)?;
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), bob_user_id.clone())?;
 
     let mut alice = ProtocolHarnessPeer::with_real_rtc_negotiation(alice_port)?;
     let mut bob = ProtocolHarnessPeer::with_real_rtc_negotiation(bob_port)?;
@@ -170,12 +170,11 @@ pub(crate) async fn setup_protocol_recovery_peers(
     let room = create_room(
         &server,
         "issuer-protocol-recovery",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), alice_user_id)?;
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), bob_user_id.clone())?;
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), alice_user_id)?;
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), bob_user_id.clone())?;
 
     let mut alice = ProtocolHarnessPeer::default();
     let mut bob = ProtocolHarnessPeer::default();

--- a/src/runtime/websocket_server/tests/protocol_negotiation_tests.rs
+++ b/src/runtime/websocket_server/tests/protocol_negotiation_tests.rs
@@ -76,12 +76,11 @@ async fn setup_negotiated_protocol_pair()
     let room = create_room(
         &server,
         "issuer-protocol-negotiation",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
-    let publisher_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(81))?;
-    let subscriber_token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(82))?;
+    let publisher_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(81))?;
+    let subscriber_token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(82))?;
     let mut publisher_socket = authenticate_with_jwt(&server, &publisher_token).await?;
     let mut subscriber_socket = authenticate_with_jwt(&server, &subscriber_token).await?;
 

--- a/src/runtime/websocket_server/tests/protocol_resilience_tests.rs
+++ b/src/runtime/websocket_server/tests/protocol_resilience_tests.rs
@@ -38,9 +38,9 @@ async fn authenticated_protocol_websocket(
         TestServerBuilder::new().spawn().await,
         "test websocket server should start",
     );
-    let room = create_room(&server, issuer, None, CreateRoomQuery::default()).await;
+    let room = create_room(&server, issuer, CreateRoomQuery::default()).await;
     let token = require_some(
-        signed_connect_claims(TEST_AUTH_KEY, room.uuid(), user_id),
+        signed_connect_claims(TEST_ROOM_KEY, room.uuid(), user_id),
         "connect JWT should sign",
     );
     let mut websocket = require_some(

--- a/src/runtime/websocket_server/tests/session_lifecycle_tests.rs
+++ b/src/runtime/websocket_server/tests/session_lifecycle_tests.rs
@@ -14,8 +14,8 @@ async fn websocket_sends_ping_frames_and_accepts_pongs() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-ping", None, CreateRoomQuery::default()).await;
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), UserId::Integer(410));
+    let room = create_room(&server, "issuer-ping", CreateRoomQuery::default()).await;
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), UserId::Integer(410));
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -63,15 +63,9 @@ async fn websocket_closes_when_pong_times_out() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(
-        &server,
-        "issuer-ping-timeout",
-        None,
-        CreateRoomQuery::default(),
-    )
-    .await;
+    let room = create_room(&server, "issuer-ping-timeout", CreateRoomQuery::default()).await;
     let user_id = UserId::Integer(411);
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), user_id.clone());
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), user_id.clone());
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -124,15 +118,9 @@ async fn websocket_closes_when_rtc_transport_disconnects() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(
-        &server,
-        "issuer-rtc-disconnect",
-        None,
-        CreateRoomQuery::default(),
-    )
-    .await;
+    let room = create_room(&server, "issuer-rtc-disconnect", CreateRoomQuery::default()).await;
     let user_id = UserId::Integer(412);
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), user_id.clone());
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), user_id.clone());
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -198,12 +186,11 @@ async fn websocket_closes_when_rtc_transport_disconnects_during_initial_negotiat
     let room = create_room(
         &server,
         "issuer-rtc-disconnect-negotiating",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
     let user_id = UserId::Integer(413);
-    let token = signed_connect_claims(TEST_AUTH_KEY, room.uuid(), user_id.clone());
+    let token = signed_connect_claims(TEST_ROOM_KEY, room.uuid(), user_id.clone());
     assert!(token.is_some());
     let Some(token) = token else {
         return;
@@ -255,7 +242,6 @@ async fn websocket_finish_rolls_back_staged_publish_before_room_cleanup() {
     let room = create_room(
         &server,
         "issuer-staged-publish-finish",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
@@ -343,7 +329,6 @@ async fn protocol_error_rolls_back_staged_publish_before_room_cleanup() {
     let room = create_room(
         &server,
         "issuer-staged-publish-protocol-error",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
@@ -390,7 +375,6 @@ async fn replacement_close_rolls_back_staged_publish_before_room_cleanup() {
     let room = create_room(
         &server,
         "issuer-staged-publish-replacement",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
@@ -437,7 +421,6 @@ async fn runtime_disconnect_rolls_back_staged_publish_before_room_cleanup() {
     let room = create_room(
         &server,
         "issuer-staged-publish-runtime-disconnect",
-        None,
         CreateRoomQuery::default(),
     )
     .await;
@@ -487,7 +470,7 @@ async fn websocket_closure_emits_fake_webrtc_user_closed_event() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
     let user_id = UserId::Integer(213);
     let websocket = setup_negotiated_session(&server, &room, user_id.clone()).await;
     assert!(websocket.is_some());
@@ -524,7 +507,7 @@ async fn stale_replaced_socket_close_cleans_only_the_stale_transport_user() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
     let user_id = UserId::Integer(260);
     let first_socket = setup_negotiated_session(&server, &room, user_id.clone()).await;
     assert!(first_socket.is_some());
@@ -585,7 +568,7 @@ async fn disconnect_cleanup_still_closes_media_transport_user_state() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
 
     let mut alice = setup_negotiated_session(&server, &room, UserId::Integer(1)).await;
     let mut bob = setup_negotiated_session(&server, &room, UserId::Integer(2)).await;
@@ -640,7 +623,7 @@ async fn disconnect_cleanup_closes_transport_user_before_empty_room_removal() {
     let Some(server) = server else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None, CreateRoomQuery::default()).await;
+    let room = create_room(&server, "issuer-a", CreateRoomQuery::default()).await;
     let user_id = UserId::Integer(1);
 
     let socket = setup_negotiated_session(&server, &room, user_id.clone()).await;

--- a/tests/src/support/harness.rs
+++ b/tests/src/support/harness.rs
@@ -383,13 +383,13 @@ pub async fn spawn_test_server(config: Config) -> Result<TestServer> {
 }
 
 pub async fn spawn_room_server(issuer: &str) -> Option<TestRoomServer> {
-    spawn_room_server_with_config(test_config(1_000, 10), issuer, Some(TEST_ROOM_KEY)).await
+    spawn_room_server_with_config(test_config(1_000, 10), issuer, TEST_ROOM_KEY).await
 }
 
 pub async fn spawn_room_server_with_config(
     config: Config,
     issuer: &str,
-    key: Option<&str>,
+    key: &str,
 ) -> Option<TestRoomServer> {
     let server = spawn_test_server(config).await.ok()?;
     let room_id = create_room(&server, issuer, key).await?;
@@ -450,14 +450,15 @@ pub fn signed_connect_claims(key: &str, room_id: &str, user_id: UserId) -> Optio
     .ok()
 }
 
-pub fn signed_room_claims(issuer: &str, key: Option<&str>) -> Option<String> {
+#[must_use]
+pub fn signed_room_claims(issuer: &str, key: &str) -> Option<String> {
     sign(
         &HttpRoomClaims {
             registered: RegisteredJwtClaims {
                 iss: Some(issuer.to_owned()),
                 ..RegisteredJwtClaims::default()
             },
-            key: key.map(str::to_owned),
+            key: Some(key.to_owned()),
         },
         TEST_AUTH_KEY,
     )
@@ -476,7 +477,7 @@ pub fn signed_disconnect_claims(user_ids_by_room: BTreeMap<String, Vec<UserId>>)
     .ok()
 }
 
-pub async fn create_room(server: &TestServer, issuer: &str, key: Option<&str>) -> Option<String> {
+pub async fn create_room(server: &TestServer, issuer: &str, key: &str) -> Option<String> {
     let token = signed_room_claims(issuer, key)?;
     let response = reqwest::Client::new()
         .get(format!("{}{CHANNEL_PATH}", server.http_base_url()))

--- a/tests/tests/control_plane.rs
+++ b/tests/tests/control_plane.rs
@@ -17,8 +17,7 @@ use o_sfu_protocol::{
     },
 };
 use o_sfu_tests::support::{
-    TEST_AUTH_KEY, TEST_ROOM_KEY, TestServer, create_room, disconnect_sessions_via_http,
-    metrics_text,
+    TEST_ROOM_KEY, TestServer, create_room, disconnect_sessions_via_http, metrics_text,
     protocol_harness::{
         ProtocolWebSocketClient, connect_protocol_pair, protocol_test_config,
         read_until_server_message,
@@ -39,7 +38,7 @@ async fn websocket_welcome_and_initial_offer_work_from_integration_test() {
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-a", Some(TEST_ROOM_KEY)).await;
+    let room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
@@ -79,7 +78,7 @@ async fn websocket_welcome_and_initial_offer_expose_real_rtc_transport_details()
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-a", Some(TEST_ROOM_KEY)).await;
+    let room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
@@ -146,7 +145,7 @@ async fn websocket_offer_advertises_configured_public_ip_in_rtc_mode() {
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-public-ip", Some(TEST_ROOM_KEY)).await;
+    let room = create_room(&server, "issuer-public-ip", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
@@ -233,9 +232,9 @@ async fn room_creation_is_idempotent_by_issuer_from_integration_test() {
         return;
     };
 
-    let first = create_room(&server, "issuer-a", None).await;
-    let second = create_room(&server, "issuer-a", Some(TEST_ROOM_KEY)).await;
-    let third = create_room(&server, "issuer-b", None).await;
+    let first = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
+    let second = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
+    let third = create_room(&server, "issuer-b", TEST_ROOM_KEY).await;
     assert!(first.is_some());
     assert!(second.is_some());
     assert!(third.is_some());
@@ -289,13 +288,13 @@ async fn broadcast_reaches_other_user_from_integration_test() {
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None).await;
+    let room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(1));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(2));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(1));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(2));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -341,14 +340,14 @@ async fn websocket_slow_consumer_overflow_closes_only_slow_socket_from_integrati
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-slow-consumer-overflow", None).await;
+    let room = create_room(&server, "issuer-slow-consumer-overflow", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let slow_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(31));
-    let driver_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(32));
-    let witness_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(33));
+    let slow_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(31));
+    let driver_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(32));
+    let witness_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(33));
     assert!(slow_token.is_some());
     assert!(driver_token.is_some());
     assert!(witness_token.is_some());
@@ -415,13 +414,13 @@ async fn user_info_change_reaches_other_user_from_integration_test() {
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None).await;
+    let room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(1));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(2));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(1));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(2));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -461,13 +460,13 @@ async fn stats_reports_live_user_aggregates_from_integration_test() {
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None).await;
+    let room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(1));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(2));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(1));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(2));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -529,13 +528,13 @@ async fn room_full_and_last_disconnect_cleanup_are_observable_from_integration_t
     let Some(server) = server.ok() else {
         return;
     };
-    let first_room = create_room(&server, "issuer-a", None).await;
+    let first_room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(first_room.is_some());
     let Some(first_room) = first_room else {
         return;
     };
-    let first_token = signed_connect_claims(TEST_AUTH_KEY, &first_room, UserId::Integer(1));
-    let second_token = signed_connect_claims(TEST_AUTH_KEY, &first_room, UserId::Integer(2));
+    let first_token = signed_connect_claims(TEST_ROOM_KEY, &first_room, UserId::Integer(1));
+    let second_token = signed_connect_claims(TEST_ROOM_KEY, &first_room, UserId::Integer(2));
     assert!(first_token.is_some());
     assert!(second_token.is_some());
     let (Some(first_token), Some(second_token)) = (first_token, second_token) else {
@@ -563,14 +562,14 @@ async fn room_full_and_last_disconnect_cleanup_are_observable_from_integration_t
     assert!(first_client.close().await.is_some());
     assert!(server.wait_for_room_absence(&first_room).await);
 
-    let second_room = create_room(&server, "issuer-a", None).await;
+    let second_room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(second_room.is_some());
     let Some(second_room) = second_room else {
         return;
     };
     assert_ne!(first_room, second_room);
 
-    let third_token = signed_connect_claims(TEST_AUTH_KEY, &second_room, UserId::Integer(3));
+    let third_token = signed_connect_claims(TEST_ROOM_KEY, &second_room, UserId::Integer(3));
     assert!(third_token.is_some());
     let Some(third_token) = third_token else {
         return;
@@ -587,13 +586,13 @@ async fn disconnect_api_kicks_target_and_notifies_remaining_from_integration_tes
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-a", None).await;
+    let room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(1));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(2));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(1));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(2));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -634,13 +633,13 @@ async fn replaced_socket_cannot_broadcast_or_change_info_from_integration_test()
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-replacement-guard", None).await;
+    let room = create_room(&server, "issuer-replacement-guard", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(1));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(2));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(1));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(2));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -705,14 +704,19 @@ async fn numeric_string_user_ids_share_one_runtime_identity() {
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-runtime-user-id-normalization", None).await;
+    let room = create_room(
+        &server,
+        "issuer-runtime-user-id-normalization",
+        TEST_ROOM_KEY,
+    )
+    .await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let observer_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(7));
-    let numeric_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(42));
-    let string_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::String("42".to_owned()));
+    let observer_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(7));
+    let numeric_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(42));
+    let string_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::String("42".to_owned()));
     assert!(observer_token.is_some());
     assert!(numeric_token.is_some());
     assert!(string_token.is_some());
@@ -832,13 +836,13 @@ async fn replaced_socket_cannot_finish_a_queued_publish_negotiation_from_integra
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-replacement-queued-publish", None).await;
+    let room = create_room(&server, "issuer-replacement-queued-publish", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(11));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(12));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(11));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(12));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -909,13 +913,13 @@ async fn bulk_disconnected_socket_cannot_broadcast_after_logical_removal() {
     let Some(server) = server.ok() else {
         return;
     };
-    let room = create_room(&server, "issuer-disconnect-guard", None).await;
+    let room = create_room(&server, "issuer-disconnect-guard", TEST_ROOM_KEY).await;
     assert!(room.is_some());
     let Some(room) = room else {
         return;
     };
-    let alice_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(21));
-    let bob_token = signed_connect_claims(TEST_AUTH_KEY, &room, UserId::Integer(22));
+    let alice_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(21));
+    let bob_token = signed_connect_claims(TEST_ROOM_KEY, &room, UserId::Integer(22));
     assert!(alice_token.is_some());
     assert!(bob_token.is_some());
     let (Some(alice_token), Some(bob_token)) = (alice_token, bob_token) else {
@@ -964,18 +968,18 @@ async fn bulk_disconnect_scopes_each_room_independently_from_integration_test() 
     let Some(server) = server.ok() else {
         return;
     };
-    let room_a = create_room(&server, "issuer-a", None).await;
-    let room_b = create_room(&server, "issuer-b", None).await;
+    let room_a = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
+    let room_b = create_room(&server, "issuer-b", TEST_ROOM_KEY).await;
     assert!(room_a.is_some());
     assert!(room_b.is_some());
     let (Some(room_a), Some(room_b)) = (room_a, room_b) else {
         return;
     };
 
-    let a_keep_token = signed_connect_claims(TEST_AUTH_KEY, &room_a, UserId::Integer(1));
-    let a_drop_token = signed_connect_claims(TEST_AUTH_KEY, &room_a, UserId::Integer(2));
-    let b_drop_token = signed_connect_claims(TEST_AUTH_KEY, &room_b, UserId::Integer(1));
-    let b_keep_token = signed_connect_claims(TEST_AUTH_KEY, &room_b, UserId::Integer(2));
+    let a_keep_token = signed_connect_claims(TEST_ROOM_KEY, &room_a, UserId::Integer(1));
+    let a_drop_token = signed_connect_claims(TEST_ROOM_KEY, &room_a, UserId::Integer(2));
+    let b_drop_token = signed_connect_claims(TEST_ROOM_KEY, &room_b, UserId::Integer(1));
+    let b_keep_token = signed_connect_claims(TEST_ROOM_KEY, &room_b, UserId::Integer(2));
     assert!(a_keep_token.is_some());
     assert!(a_drop_token.is_some());
     assert!(b_drop_token.is_some());
@@ -1064,14 +1068,14 @@ async fn mismatched_explicit_room_id_is_rejected_from_integration_test() {
     let Some(server) = server.ok() else {
         return;
     };
-    let first_room = create_room(&server, "issuer-a", None).await;
-    let second_room = create_room(&server, "issuer-b", None).await;
+    let first_room = create_room(&server, "issuer-a", TEST_ROOM_KEY).await;
+    let second_room = create_room(&server, "issuer-b", TEST_ROOM_KEY).await;
     assert!(first_room.is_some());
     assert!(second_room.is_some());
     let (Some(first_room), Some(second_room)) = (first_room, second_room) else {
         return;
     };
-    let token = signed_connect_claims(TEST_AUTH_KEY, &first_room, UserId::Integer(3));
+    let token = signed_connect_claims(TEST_ROOM_KEY, &first_room, UserId::Integer(3));
     assert!(token.is_some());
     let Some(token) = token else {
         return;

--- a/tests/tests/full_stack/audio_policy.rs
+++ b/tests/tests/full_stack/audio_policy.rs
@@ -56,7 +56,7 @@ async fn fake_rtc_cross_worker_opus_vad_true_forwards_and_drives_active_speaker(
     let room_server = spawn_room_server_with_config(
         cross_worker_test_config(),
         "issuer-cross-worker-opus-active-speaker",
-        Some(TEST_ROOM_KEY),
+        TEST_ROOM_KEY,
     )
     .await;
     assert!(room_server.is_some());
@@ -172,7 +172,7 @@ async fn fake_rtc_cross_worker_opus_vad_false_blocks_relay_fanout() {
     let room_server = spawn_room_server_with_config(
         cross_worker_test_config(),
         "issuer-cross-worker-opus-vad-false",
-        Some(TEST_ROOM_KEY),
+        TEST_ROOM_KEY,
     )
     .await;
     assert!(room_server.is_some());

--- a/tests/tests/full_stack/relay_spillover.rs
+++ b/tests/tests/full_stack/relay_spillover.rs
@@ -6,7 +6,7 @@ async fn fake_rtc_cross_worker_vp8_selected_rid_survives_relay() {
     let room_server = spawn_room_server_with_config(
         cross_worker_test_config(),
         "issuer-cross-worker-vp8-selected-rid",
-        Some(TEST_ROOM_KEY),
+        TEST_ROOM_KEY,
     )
     .await;
     assert!(room_server.is_some());
@@ -103,7 +103,7 @@ async fn fake_rtc_cross_worker_h264_selected_rid_requires_idr_after_relay() {
     let room_server = spawn_room_server_with_config(
         config,
         "issuer-cross-worker-h264-selected-rid",
-        Some(TEST_ROOM_KEY),
+        TEST_ROOM_KEY,
     )
     .await;
     assert!(room_server.is_some());
@@ -177,7 +177,7 @@ async fn fake_rtc_load_triggered_spillover_relays_vp8_after_threshold() {
     let room_server = spawn_room_server_with_config(
         load_triggered_spillover_test_config(),
         "issuer-load-spillover-vp8-selected-rid",
-        Some(TEST_ROOM_KEY),
+        TEST_ROOM_KEY,
     )
     .await;
     assert!(room_server.is_some());
@@ -270,7 +270,7 @@ async fn fake_rtc_load_triggered_spillover_releases_remote_route_after_subscribe
     let room_server = spawn_room_server_with_config(
         load_triggered_spillover_test_config(),
         "issuer-load-spillover-release-route",
-        Some(TEST_ROOM_KEY),
+        TEST_ROOM_KEY,
     )
     .await;
     assert!(room_server.is_some());
@@ -313,7 +313,7 @@ async fn fake_rtc_load_triggered_spillover_preserves_download_mute_after_subscri
     let room_server = spawn_room_server_with_config(
         load_triggered_spillover_test_config(),
         "issuer-load-spillover-replacement-mute",
-        Some(TEST_ROOM_KEY),
+        TEST_ROOM_KEY,
     )
     .await;
     assert!(room_server.is_some());

--- a/tests/tests/full_stack/support.rs
+++ b/tests/tests/full_stack/support.rs
@@ -794,8 +794,8 @@ pub(super) async fn connect_two_isolated_audio_flows(
     ProtocolFakePeer,
     ProtocolFakePeer,
 )> {
-    let room_a = create_room(server, "issuer-topology-a", Some(TEST_ROOM_KEY)).await?;
-    let room_b = create_room(server, "issuer-topology-b", Some(TEST_ROOM_KEY)).await?;
+    let room_a = create_room(server, "issuer-topology-a", TEST_ROOM_KEY).await?;
+    let room_b = create_room(server, "issuer-topology-b", TEST_ROOM_KEY).await?;
 
     let publisher_a =
         connect_fake_peer(server, &room_a, UserId::Integer(90), TEST_ROOM_KEY).await?;

--- a/tests/tests/full_stack/video_routing.rs
+++ b/tests/tests/full_stack/video_routing.rs
@@ -206,7 +206,7 @@ async fn fake_rtc_peers_forward_h264_high_rid_idr_without_browsers() {
     let mut config = test_config(1_000, 10);
     config.codecs.flags = MediaCodecFlags::default().with_vp8(false).with_h264(true);
     let room_server =
-        spawn_room_server_with_config(config, "issuer-h264-synthetic", Some(TEST_ROOM_KEY)).await;
+        spawn_room_server_with_config(config, "issuer-h264-synthetic", TEST_ROOM_KEY).await;
     assert!(room_server.is_some());
     let Some(room_server) = room_server else {
         return;
@@ -263,8 +263,7 @@ async fn fake_rtc_h264_selected_rid_requires_idr_before_forwarding() {
     let mut config = test_config(1_000, 10);
     config.codecs.flags = MediaCodecFlags::default().with_vp8(false).with_h264(true);
     let room_server =
-        spawn_room_server_with_config(config, "issuer-h264-selected-rid-idr", Some(TEST_ROOM_KEY))
-            .await;
+        spawn_room_server_with_config(config, "issuer-h264-selected-rid-idr", TEST_ROOM_KEY).await;
     assert!(room_server.is_some());
     let Some(room_server) = room_server else {
         return;


### PR DESCRIPTION
we no longer support the globally-signed channels(/rooms). That was a backwards compatibility feature for single-tenant SFUs before we added the per-room key to support saas.