### PR TITLE
[IMP] core: cache source gates for packet routing

### DIFF
--- a/crates/core/src/runtime/rtc_engine/route_control/active_speaker.rs
+++ b/crates/core/src/runtime/rtc_engine/route_control/active_speaker.rs
@@ -65,7 +65,7 @@ impl SourceAudioPolicyState {
     }
 
     pub(super) fn packet_gate(&self) -> PacketLayerGate {
-        self.packet_gate.clone()
+        self.packet_gate
     }
 
     pub(super) fn active_speaker_observed_at(&self, now: Instant) -> Option<Instant> {

--- a/crates/core/src/runtime/rtc_engine/route_control/packet_gate.rs
+++ b/crates/core/src/runtime/rtc_engine/route_control/packet_gate.rs
@@ -25,7 +25,7 @@ use str0m::media::Rid;
 /// they do not carry room policy meaning
 /// by the time a gate reaches this file, "selected thumbnail quality" or
 /// "active speaker audio policy" has already been projected into layer facts
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(in crate::runtime::rtc_engine) enum PacketLayerGate {
     /// allow every packet layer for this route
     #[default]
@@ -183,8 +183,8 @@ pub(in crate::runtime::rtc_engine) fn aggregate_packet_gates<'a>(
     let mut aggregate = None;
     for packet_gate in packet_gates {
         aggregate = Some(aggregate.map_or_else(
-            || packet_gate.clone(),
-            |current| union_packet_gates(current, packet_gate.clone()),
+            || *packet_gate,
+            |current| union_packet_gates(current, *packet_gate),
         ));
         if matches!(aggregate.as_ref(), Some(PacketLayerGate::Open)) {
             return aggregate;

--- a/crates/core/src/runtime/rtc_engine/route_control/state.rs
+++ b/crates/core/src/runtime/rtc_engine/route_control/state.rs
@@ -115,19 +115,16 @@ impl RouteControlState {
         let should_remove = if let Some(source_control) =
             self.sources.get_mut(&source_transport_media_id)
         {
-            source_control.local_packet_gate = packet_gate;
+            source_control.set_local_packet_gate(packet_gate);
             source_control.is_empty()
         } else {
             let Some(packet_gate) = packet_gate else {
                 return;
             };
-            self.sources.insert(
-                source_transport_media_id,
-                SourceRouteControl {
-                    local_packet_gate: Some(packet_gate),
-                    ..Default::default()
-                },
-            );
+            let mut source_control = SourceRouteControl::default();
+            source_control.set_local_packet_gate(Some(packet_gate));
+            self.sources
+                .insert(source_transport_media_id, source_control);
             debug!(
                 ?source_transport_media_id,
                 effective_packet_gate = ?self.effective_packet_gate_for_log(source_transport_media_id),
@@ -200,8 +197,7 @@ impl RouteControlState {
         self.sources
             .entry(source_transport_media_id)
             .or_default()
-            .relay_packet_gates
-            .insert(target_id, packet_gate);
+            .set_relay_packet_gate(target_id, packet_gate);
     }
 
     /// returns the relay-specific packet gate for destination planning
@@ -230,7 +226,7 @@ impl RouteControlState {
         let Some(source_control) = self.sources.get_mut(&source_transport_media_id) else {
             return;
         };
-        source_control.relay_packet_gates.remove(&target_id);
+        source_control.forget_relay_packet_gate(target_id);
         if source_control.is_empty() {
             self.sources.remove(&source_transport_media_id);
         }
@@ -382,6 +378,8 @@ struct SourceRouteControl {
     local_packet_gate: Option<PacketLayerGate>,
     /// target-specific gates installed for active relay targets
     relay_packet_gates: BTreeMap<RelayTargetId, PacketLayerGate>,
+    /// cached source-wide gate used before destination planning
+    effective_packet_gate: Option<PacketLayerGate>,
 }
 
 /// coalescing window for keyframe requests that share one source/rid scope
@@ -464,7 +462,29 @@ impl SourceRouteControl {
         };
         source_policy.observe_packet(voice_activity, audio_level_dbov, now);
         self.source_audio_policy = Some(source_policy);
-        self.source_audio_policy != previous
+        let changed = self.source_audio_policy != previous;
+        if changed {
+            self.recompute_effective_packet_gate();
+        }
+        changed
+    }
+
+    /// replaces the source gate derived from local destinations
+    fn set_local_packet_gate(&mut self, packet_gate: Option<PacketLayerGate>) {
+        self.local_packet_gate = packet_gate;
+        self.recompute_effective_packet_gate();
+    }
+
+    /// replaces the packet gate requested by one relay target
+    fn set_relay_packet_gate(&mut self, target_id: RelayTargetId, packet_gate: PacketLayerGate) {
+        self.relay_packet_gates.insert(target_id, packet_gate);
+        self.recompute_effective_packet_gate();
+    }
+
+    /// removes the packet gate requested by one relay target
+    fn forget_relay_packet_gate(&mut self, target_id: RelayTargetId) {
+        self.relay_packet_gates.remove(&target_id);
+        self.recompute_effective_packet_gate();
     }
 
     /// computes the source-wide packet gate used by early packet filtering
@@ -474,6 +494,16 @@ impl SourceRouteControl {
     /// the packet-level audio policy is then intersected so inactive audio can
     /// block all downstream fanout
     fn effective_packet_gate(&self) -> Option<PacketLayerGate> {
+        self.effective_packet_gate
+    }
+
+    /// refreshes the cached packet gate after a source policy mutation
+    fn recompute_effective_packet_gate(&mut self) {
+        self.effective_packet_gate = self.compute_effective_packet_gate();
+    }
+
+    /// computes the source-wide packet gate from source policy state
+    fn compute_effective_packet_gate(&self) -> Option<PacketLayerGate> {
         intersect_packet_gates(
             aggregate_packet_gates(
                 self.local_packet_gate

--- a/crates/core/src/runtime/rtc_engine/tests/route_control_state_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/route_control_state_tests.rs
@@ -126,6 +126,73 @@ fn route_control_combines_local_and_remote_target_gates() {
 }
 
 #[test]
+fn route_control_refreshes_source_gate_after_relay_gate_removal() {
+    let mut state = RouteControlState::default();
+    let source_transport_media_id = TransportMediaId::new(121);
+    state.set_local_packet_gate(
+        source_transport_media_id,
+        Some(PacketLayerGate::Rid("hi".into())),
+    );
+    state.set_relay_packet_gate(
+        source_transport_media_id,
+        RelayTargetId::new(1),
+        PacketLayerGate::Rid("lo".into()),
+    );
+
+    assert_eq!(
+        state.effective_packet_gate(source_transport_media_id),
+        Some(PacketLayerGate::Open)
+    );
+
+    state.forget_relay_packet_gate(source_transport_media_id, RelayTargetId::new(1));
+
+    assert_eq!(
+        state.effective_packet_gate(source_transport_media_id),
+        Some(PacketLayerGate::Rid("hi".into()))
+    );
+    assert_eq!(
+        state.decide_packet_route(
+            source_transport_media_id,
+            PacketLayerMetadata::new(Some("lo".into()), None)
+        ),
+        PacketRouteDecision::Drop
+    );
+}
+
+#[test]
+fn route_control_refreshes_source_gate_after_local_gate_clear() {
+    let mut state = RouteControlState::default();
+    let source_transport_media_id = TransportMediaId::new(122);
+    state.set_local_packet_gate(
+        source_transport_media_id,
+        Some(PacketLayerGate::Rid("hi".into())),
+    );
+    state.set_relay_packet_gate(
+        source_transport_media_id,
+        RelayTargetId::new(1),
+        PacketLayerGate::Rid("hi".into()),
+    );
+
+    state.set_local_packet_gate(source_transport_media_id, None);
+
+    assert_eq!(
+        state.effective_packet_gate(source_transport_media_id),
+        Some(PacketLayerGate::Rid("hi".into()))
+    );
+
+    state.forget_relay_packet_gate(source_transport_media_id, RelayTargetId::new(1));
+
+    assert_eq!(state.effective_packet_gate(source_transport_media_id), None);
+    assert_eq!(
+        state.decide_packet_route(
+            source_transport_media_id,
+            PacketLayerMetadata::new(Some("lo".into()), None)
+        ),
+        PacketRouteDecision::Forward
+    );
+}
+
+#[test]
 fn route_control_transport_audio_policy_blocks_silent_sources() {
     let mut state = RouteControlState::default();
     let source_transport_media_id = TransportMediaId::new(22);

--- a/crates/core/src/runtime/rtc_engine/worker/media/control/routes.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/media/control/routes.rs
@@ -285,7 +285,7 @@ pub(in crate::runtime::rtc_engine::worker) fn refresh_source_packet_gate(
     let route_entry = state.media_route_index.get(&source_transport_media_id);
     let local_packet_gate = route_entry.and_then(local_source_packet_gate);
     let remote_packet_gate =
-        remote_source::remote_source_packet_gate_for_route(route_entry, local_packet_gate.clone());
+        remote_source::remote_source_packet_gate_for_route(route_entry, local_packet_gate);
     state
         .route_control
         .set_local_packet_gate(source_transport_media_id, local_packet_gate);
@@ -439,6 +439,7 @@ pub(super) fn worker_set_consumer_packet_gates(
 /// `media_route_index`
 /// this keeps late active-state and packet-gate commands from reaching a route
 /// after cleanup has removed or replaced either side of the binding
+#[derive(Clone, Copy)]
 enum ConsumerRouteMutation {
     /// replace the destination activity bit
     Active(bool),

--- a/crates/core/src/runtime/rtc_engine/worker/media/control/selected_rid.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/media/control/selected_rid.rs
@@ -464,7 +464,7 @@ fn suspend_stale_destination_gate(
     if selected_rid == incoming_rid || ready_rids.contains(&selected_rid) {
         return;
     }
-    let selected_packet_gate = destination.packet_gate.clone();
+    let selected_packet_gate = destination.packet_gate;
     debug!(
         ?source_transport_media_id,
         consumer_session_key = ?destination.dest_session,

--- a/crates/core/src/runtime/rtc_engine/worker/media/types.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/media/types.rs
@@ -25,6 +25,7 @@ pub struct AddSendMediaRequest<'a> {
     pub consumer_rtp_parameters: &'a RouterRtpParameters,
 }
 
+#[derive(Clone, Copy)]
 pub struct ConsumerPacketGateRequest<'a> {
     pub route: &'a TransportConsumerRoute,
     pub packet_gate: PacketLayerGate,


### PR DESCRIPTION
route-control packet decisions run once per packet before fanout, so walking relay gates on every decision made cost grow with relay-target count

this change stores the effective source gate on SourceRouteControl and refreshes it from the local-gate, relay-gate and audio-policy mutation paths. PacketLayerGate is Copy so recomputation does not clone gate values, while decide_packet_route reads the cached value directly