### PR TITLE
[IMP] core: reduce fanout planning clone cost

### DIFF
--- a/crates/core/src/runtime/rtc_engine/demux.rs
+++ b/crates/core/src/runtime/rtc_engine/demux.rs
@@ -41,6 +41,13 @@ pub(super) struct MediaRouteDestination {
     /// source payload types can differ from consumer payload types after router
     /// negotiation, so forwarding must not reuse the publisher value blindly
     pub(super) dest_payload_type: Option<Pt>,
+    /// stable retransmission policy for this consumer media line
+    ///
+    /// this is captured when the route is registered because the consumer
+    /// media kind is already known there
+    /// the packet loop can then write local RTP without asking `str0m` to
+    /// rediscover the media kind for every destination packet
+    pub(super) nackable: bool,
     /// destination-level activity gate controlled by consumer state
     pub(super) active: bool,
     /// effective transport gate used by the packet loop right now
@@ -57,12 +64,81 @@ pub(super) struct MediaRouteDestination {
 /// `source_active` is a source-wide route gate
 /// individual destinations still carry their own activity and layer gates so
 /// producer pause, consumer pause and selected-layer policy remain independent
+///
+/// callers must mutate `destinations` through this type's helpers
+/// `active_destination_count` is a cached admission invariant used by the hot
+/// planner before it walks the destination vector
 #[derive(Debug, Clone)]
 pub(super) struct MediaRouteEntry {
     /// source-wide activity gate applied before local destination fanout
     pub(super) source_active: bool,
+    /// active local destinations cached for source-route admission checks
+    pub(super) active_destination_count: usize,
     /// local consumer destinations reached from this source media id
     pub(super) destinations: Vec<MediaRouteDestination>,
+}
+
+impl MediaRouteEntry {
+    /// creates an empty route entry with no local destinations
+    ///
+    /// the active count starts at zero even when the source is active because
+    /// source activity and destination activity are independent gates
+    pub(super) fn new(source_active: bool) -> Self {
+        Self {
+            source_active,
+            active_destination_count: 0,
+            destinations: Vec::new(),
+        }
+    }
+
+    /// returns whether local fanout has any active destination work
+    ///
+    /// this is the O(1) route-admission check used before source packet gates
+    /// are evaluated
+    pub(super) const fn has_active_destinations(&self) -> bool {
+        self.active_destination_count > 0
+    }
+
+    /// appends one destination while preserving the active-count invariant
+    ///
+    /// route registration is the only caller that should add destinations
+    /// directly because it owns source validation and consumer media ownership
+    pub(super) fn push_destination(&mut self, destination: MediaRouteDestination) {
+        self.active_destination_count += usize::from(destination.active);
+        self.destinations.push(destination);
+    }
+
+    /// removes one destination while preserving the active-count invariant
+    ///
+    /// callers pass the index they found under the same mutable route borrow
+    /// this keeps teardown precise without scanning a second time inside the
+    /// helper
+    pub(super) fn remove_destination(&mut self, index: usize) -> MediaRouteDestination {
+        let destination = self.destinations.remove(index);
+        self.active_destination_count -= usize::from(destination.active);
+        destination
+    }
+
+    /// updates destination activity and reports whether the route changed
+    ///
+    /// a missing index is treated as unchanged because stale worker commands
+    /// are rejected by the caller's ownership checks before reaching the route
+    /// mutation
+    pub(super) fn set_destination_active(&mut self, index: usize, active: bool) -> bool {
+        let Some(destination) = self.destinations.get_mut(index) else {
+            return false;
+        };
+        if destination.active == active {
+            return false;
+        }
+        if active {
+            self.active_destination_count += 1;
+        } else {
+            self.active_destination_count -= 1;
+        }
+        destination.active = active;
+        true
+    }
 }
 
 /// source media id used as the packet-loop route index key

--- a/crates/core/src/runtime/rtc_engine/forwarding_destination.rs
+++ b/crates/core/src/runtime/rtc_engine/forwarding_destination.rs
@@ -11,14 +11,13 @@ use std::fmt;
 use str0m::RtcError;
 
 use super::{
-    demux::MediaRouteDestination,
     forwarded_packet::ForwardedPacket,
     local_forwarding::LocalPacketDestination,
     relay_registry::{RelayEnqueueOutcome, RelayTargetKind, RelayTargetTransport},
     state::PacketLoopState,
 };
 use crate::runtime::{
-    media_transport::{TransportMediaId, TransportSessionKey},
+    media_transport::TransportMediaId,
     metrics::{RtpForwardDestinationKind, RtpRelayDropKind},
     packet_sink_registry::RegisteredPacketSink,
 };
@@ -60,11 +59,22 @@ pub(super) enum ForwardSendOutcome {
     OverloadedRelay,
 }
 
-/// local rtc send target with the consumer session and rewrite identity
-#[derive(Debug, Clone)]
+/// turn-local handle for one local rtc route destination
+///
+/// the handle names a source route plus the destination index observed while
+/// planning the current packet-loop turn
+/// it deliberately does not clone the consumer session or RTP rewrite identity
+/// those route-stable facts are resolved during flush while `PacketLoopState`
+/// is borrowed mutably
+///
+/// callers must not persist this value beyond the flush that owns the matching
+/// `PacketForward`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct LocalRtcPacketDestination {
-    session_key: TransportSessionKey,
-    sender: LocalPacketDestination,
+    /// source route that owned the destination when planning ran
+    source_transport_media_id: TransportMediaId,
+    /// destination slot inside the route for this packet-loop turn
+    destination_index: usize,
 }
 
 /// packet sink destination tied to the source transport media id
@@ -82,20 +92,21 @@ pub(super) struct RelayPacketDestination {
 }
 
 impl PacketForward {
-    /// builds a local rtc destination from an already-authorized media route
+    /// builds a local rtc destination from an already-authorized route slot
+    ///
+    /// the caller must pass the destination index produced while walking the
+    /// current `MediaRouteEntry`
+    /// the index is resolved again during flush so planning can stay clone-free
     pub(super) fn from_local_route_destination(
         packet_idx: usize,
-        route_destination: &MediaRouteDestination,
+        source_transport_media_id: TransportMediaId,
+        destination_index: usize,
     ) -> Self {
         Self {
             packet_idx,
             destination: ForwardingDestination::LocalRtc(LocalRtcPacketDestination::new(
-                route_destination.dest_session.clone(),
-                LocalPacketDestination::new(
-                    route_destination.dest_transport_media_id,
-                    route_destination.dest_mid,
-                    route_destination.dest_payload_type,
-                ),
+                source_transport_media_id,
+                destination_index,
             )),
         }
     }
@@ -142,11 +153,11 @@ impl PacketForward {
 }
 
 impl ForwardingDestination {
-    /// exposes the local rtc session key for route-planner assertions
+    /// exposes the local rtc route handle for route-planner assertions
     #[cfg(test)]
-    pub(super) fn session_key(&self) -> Option<&TransportSessionKey> {
+    pub(super) fn local_route(&self) -> Option<LocalRtcPacketDestination> {
         match self {
-            Self::LocalRtc(destination) => Some(destination.session_key()),
+            Self::LocalRtc(destination) => Some(*destination),
             Self::PacketSink(_) | Self::Relay(_) => None,
         }
     }
@@ -192,49 +203,78 @@ impl ForwardingDestination {
 }
 
 impl LocalRtcPacketDestination {
-    /// stores the consumer session and rewrite target chosen by route planning
-    fn new(session_key: TransportSessionKey, sender: LocalPacketDestination) -> Self {
+    /// stores the compact route handle chosen by route planning
+    ///
+    /// this constructor is private so only the forwarding planner can create a
+    /// local rtc destination after route-control gates have already accepted
+    /// the packet
+    const fn new(source_transport_media_id: TransportMediaId, destination_index: usize) -> Self {
         Self {
-            session_key,
-            sender,
+            source_transport_media_id,
+            destination_index,
         }
     }
 
-    /// exposes the session key for route-planner assertions
     #[cfg(test)]
-    fn session_key(&self) -> &TransportSessionKey {
-        &self.session_key
+    pub(super) const fn source_transport_media_id(self) -> TransportMediaId {
+        self.source_transport_media_id
     }
 
-    /// writes one packet to the destination session when it is still live
+    #[cfg(test)]
+    pub(super) const fn destination_index(self) -> usize {
+        self.destination_index
+    }
+
+    /// writes one packet to the destination session when the route is still live
     ///
-    /// missing sessions are treated as a no-op because route cleanup and packet
-    /// flushing can interleave across packet-loop turns
-    /// a successful local write records egress bitrate and marks the destination
-    /// session dirty so str0m output is drained later
+    /// the compact handle is best-effort within the current flush
+    /// if the route slot or destination session disappeared, the send is a no-op
+    /// because cleanup already made the route non-authoritative
+    ///
+    /// successful writes clone the destination session key only after `str0m`
+    /// accepted the packet, so failed or stale local sends do not touch dirty
+    /// session scheduling
     fn send(
         &self,
         state: &mut PacketLoopState,
         packet: &mut ForwardedPacket,
         is_last_destination: bool,
     ) -> Result<ForwardSendOutcome, RtcError> {
-        let Some(session_state) = state.users.get_mut(&self.session_key) else {
-            return Ok(ForwardSendOutcome::LocalRtc {
-                payload_bytes: None,
-            });
+        let (payload_bytes, dirty_session_key) = {
+            let Some(route_destination) = state
+                .media_route_index
+                .get(&self.source_transport_media_id)
+                .and_then(|route_entry| route_entry.destinations.get(self.destination_index))
+            else {
+                return Ok(ForwardSendOutcome::LocalRtc {
+                    payload_bytes: None,
+                });
+            };
+            let session_key = &route_destination.dest_session;
+            let Some(session_state) = state.users.get_mut(session_key) else {
+                return Ok(ForwardSendOutcome::LocalRtc {
+                    payload_bytes: None,
+                });
+            };
+            let sender = LocalPacketDestination::new(
+                route_destination.dest_transport_media_id,
+                route_destination.dest_mid,
+                route_destination.dest_payload_type,
+                route_destination.nackable,
+            );
+            let vp8_payload = packet.local_vp8_payload();
+            let payload_bytes = sender.send(
+                session_state,
+                packet.local_send_packet(),
+                vp8_payload,
+                is_last_destination,
+            )?;
+            let dirty_session_key = payload_bytes.is_some().then(|| session_key.clone());
+            (payload_bytes, dirty_session_key)
         };
-        // capture cached VP8 facts before local_send_packet may consume the shared payload
-        let vp8_payload = packet.local_vp8_payload();
-        let payload_bytes = self.sender.send(
-            session_state,
-            packet.local_send_packet(),
-            vp8_payload,
-            is_last_destination,
-        )?;
-        if let Some(payload_bytes) = payload_bytes {
-            let _ =
-                state.record_egress_bitrate(&self.session_key, packet.received_at(), payload_bytes);
-            state.mark_session_dirty(&self.session_key);
+        if let (Some(payload_bytes), Some(session_key)) = (payload_bytes, dirty_session_key) {
+            let _ = state.record_egress_bitrate(&session_key, packet.received_at(), payload_bytes);
+            state.mark_session_dirty(&session_key);
         }
         Ok(ForwardSendOutcome::LocalRtc { payload_bytes })
     }
@@ -329,16 +369,13 @@ mod tests {
         time::Instant,
     };
 
-    use str0m::media::Mid;
-
     use super::*;
     use crate::runtime::{
         UserId,
-        media_transport::TransportMediaId,
+        media_transport::{TransportMediaId, TransportSessionKey},
         packet_sink_registry::PacketSink as MediaPacketSink,
         rtc_engine::{
             relay_registry::{InterNodeRelaySender, RelayPacketMailbox},
-            route_control::PacketLayerGate,
             test_support::{sample_forwarded_packet, test_transport_session_key},
         },
     };
@@ -369,24 +406,14 @@ mod tests {
 
     #[test]
     fn packet_forward_wraps_local_route_destinations_in_the_named_contract() {
-        let dest_session = test_transport_session_key(11, 0, 12, UserId::Integer(13));
-        let route_destination = MediaRouteDestination {
-            dest_session: dest_session.clone(),
-            dest_transport_media_id: TransportMediaId::default(),
-            dest_mid: Mid::from("aud-down"),
-            dest_payload_type: None,
-            active: true,
-            packet_gate: PacketLayerGate::Open,
-            pending_packet_gate: None,
-        };
-
-        let forward = PacketForward::from_local_route_destination(4, &route_destination);
+        let source_transport_media_id = TransportMediaId::new(7);
+        let forward = PacketForward::from_local_route_destination(4, source_transport_media_id, 3);
 
         assert_eq!(forward.packet_idx(), 4);
         assert!(matches!(
             forward.destination(),
             ForwardingDestination::LocalRtc(destination)
-                if destination.session_key == dest_session
+                if *destination == LocalRtcPacketDestination::new(source_transport_media_id, 3)
         ));
     }
 

--- a/crates/core/src/runtime/rtc_engine/forwarding_planner.rs
+++ b/crates/core/src/runtime/rtc_engine/forwarding_planner.rs
@@ -225,6 +225,11 @@ fn push_relay_forward(
 /// Local fanout remains proportional to the number of writable receiver
 /// sessions. This planner can avoid avoidable allocation work, but it cannot
 /// collapse receiver-specific WebRTC egress into one broadcast operation.
+///
+/// planned local destinations are compact route handles
+/// the flush step resolves each handle against `media_route_index` before
+/// touching the destination session, so planning does not clone route-stable
+/// consumer identity
 fn populate_local_forwards(
     route_entry: &MediaRouteEntry,
     packet_idx: usize,
@@ -239,11 +244,12 @@ fn populate_local_forwards(
         );
         return;
     }
-    for destination in &route_entry.destinations {
+    for (destination_index, destination) in route_entry.destinations.iter().enumerate() {
         if destination_packet_gate_permits(source_transport_media_id, destination, metadata) {
             forwards.push(PacketForward::from_local_route_destination(
                 packet_idx,
-                destination,
+                source_transport_media_id,
+                destination_index,
             ));
         }
     }
@@ -301,11 +307,5 @@ fn has_routed_forward(
     route_entry: Option<&MediaRouteEntry>,
 ) -> bool {
     relay_targets.is_some_and(|targets| !targets.is_empty())
-        || route_entry.is_some_and(|entry| {
-            entry.source_active
-                && entry
-                    .destinations
-                    .iter()
-                    .any(|destination| destination.active)
-        })
+        || route_entry.is_some_and(|entry| entry.source_active && entry.has_active_destinations())
 }

--- a/crates/core/src/runtime/rtc_engine/local_forwarding.rs
+++ b/crates/core/src/runtime/rtc_engine/local_forwarding.rs
@@ -23,16 +23,20 @@ use super::{
 };
 use crate::runtime::media_transport::TransportMediaId;
 
-/// Destination-local view of one routed RTP stream.
+/// destination-local view of one routed RTP stream
 ///
-/// `transport_media_id` keys the receiver-local rewrite state. `mid` and
+/// `transport_media_id` keys the receiver-local rewrite state
+/// `mid` and
 /// `payload_type` are the consumer-negotiated values that must replace the
-/// publisher-facing RTP identity before packets cross into str0m.
+/// publisher-facing RTP identity before packets cross into str0m
+/// `nackable` is cached route state, so local egress does not consult `str0m`
+/// media metadata for every packet
 #[derive(Debug, Clone)]
 pub(super) struct LocalPacketDestination {
     transport_media_id: TransportMediaId,
     mid: Mid,
     payload_type: Option<Pt>,
+    nackable: bool,
 }
 
 pub(super) struct LocalForwardedRtp<'a> {
@@ -87,11 +91,13 @@ impl LocalPacketDestination {
         transport_media_id: TransportMediaId,
         mid: Mid,
         payload_type: Option<Pt>,
+        nackable: bool,
     ) -> Self {
         Self {
             transport_media_id,
             mid,
             payload_type,
+            nackable,
         }
     }
 
@@ -106,13 +112,14 @@ impl LocalPacketDestination {
         self.send_rtp(session_state, &mut rtp, vp8_payload, is_last_destination)
     }
 
-    /// Write one routed RTP packet into the destination user's local `StreamTx`.
+    /// writes one routed RTP packet into the destination user's local `StreamTx`
     ///
-    /// Payload bytes stay source-derived, but MID/RID extensions, sequence
-    /// numbers, and RTP timestamps are rewritten into the destination's single
-    /// consumer stream. A missing destination stream is treated as a no-op
-    /// because route updates and negotiated removal can race with packets
-    /// already buffered for forwarding.
+    /// payload bytes stay source-derived, but MID and RID extensions, sequence
+    /// numbers and RTP timestamps are rewritten into the destination's single
+    /// consumer stream
+    /// a missing destination stream is treated as a no-op because route updates
+    /// and negotiated removal can race with packets already buffered for
+    /// forwarding
     fn send_rtp(
         &self,
         session_state: &mut RtcSessionState,
@@ -120,10 +127,6 @@ impl LocalPacketDestination {
         vp8_payload: Option<PacketVp8Payload>,
         is_last_destination: bool,
     ) -> Result<Option<usize>, RtcError> {
-        let nackable = session_state
-            .rtc
-            .media(self.mid)
-            .is_some_and(|media| !media.kind().is_audio());
         let payload_len = rtp.payload.len();
         let vp8_payload = vp8_payload.or_else(|| vp8_payload_from_rtp(rtp));
         let vp8_identity = vp8_payload
@@ -156,7 +159,7 @@ impl LocalPacketDestination {
                 }
                 let write_context = RtpWriteContext {
                     identity,
-                    nackable,
+                    nackable: self.nackable,
                     is_last_destination,
                     mid: self.mid,
                     payload_type: self.payload_type,

--- a/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
@@ -631,18 +631,26 @@ fn flush_forward_routes_marks_local_consumer_sessions_dirty() {
         "cam-up",
         b"payload",
     ));
+    let source_transport_media_id = TransportMediaId::new(224);
+    let mut route_entry = MediaRouteEntry::new(true);
+    route_entry.push_destination(MediaRouteDestination {
+        dest_session: consumer_session.clone(),
+        dest_transport_media_id: TransportMediaId::new(223),
+        dest_mid: consumer_mid,
+        dest_payload_type: None,
+        nackable: true,
+        active: true,
+        packet_gate: PacketLayerGate::Open,
+        pending_packet_gate: None,
+    });
+    state
+        .media_route_index
+        .insert(source_transport_media_id, route_entry);
     buffers.forwards.push(
         super::super::forwarding_destination::PacketForward::from_local_route_destination(
             0,
-            &MediaRouteDestination {
-                dest_session: consumer_session.clone(),
-                dest_transport_media_id: TransportMediaId::new(223),
-                dest_mid: consumer_mid,
-                dest_payload_type: None,
-                active: true,
-                packet_gate: PacketLayerGate::Open,
-                pending_packet_gate: None,
-            },
+            source_transport_media_id,
+            0,
         ),
     );
 
@@ -745,21 +753,20 @@ fn silent_audio_packets_are_dropped_from_routed_fanout_after_transport_activity_
             mid: Mid::from("aud-down"),
             source_transport_media_id,
         });
-    state.media_route_index.insert(
-        source_transport_media_id,
-        MediaRouteEntry {
-            source_active: true,
-            destinations: vec![MediaRouteDestination {
-                dest_session: consumer_session,
-                dest_transport_media_id: consumer_transport_media_id,
-                dest_mid: Mid::from("aud-down"),
-                dest_payload_type: None,
-                active: true,
-                packet_gate: PacketLayerGate::Open,
-                pending_packet_gate: None,
-            }],
-        },
-    );
+    let mut route_entry = MediaRouteEntry::new(true);
+    route_entry.push_destination(MediaRouteDestination {
+        dest_session: consumer_session,
+        dest_transport_media_id: consumer_transport_media_id,
+        dest_mid: Mid::from("aud-down"),
+        dest_payload_type: None,
+        nackable: false,
+        active: true,
+        packet_gate: PacketLayerGate::Open,
+        pending_packet_gate: None,
+    });
+    state
+        .media_route_index
+        .insert(source_transport_media_id, route_entry);
     let mut buffers = PacketLoopBuffers::new();
     buffers
         .pending_packets

--- a/crates/core/src/runtime/rtc_engine/test_support/debug_command.rs
+++ b/crates/core/src/runtime/rtc_engine/test_support/debug_command.rs
@@ -105,6 +105,7 @@ pub struct DebugRouteDestination {
 pub struct DebugRouteEntry {
     pub source_transport_media_id: TransportMediaId,
     pub source_active: bool,
+    pub active_destination_count: usize,
     pub effective_packet_gate: DebugPacketGate,
     pub destinations: Vec<DebugRouteDestination>,
 }

--- a/crates/core/src/runtime/rtc_engine/test_support/route_graph.rs
+++ b/crates/core/src/runtime/rtc_engine/test_support/route_graph.rs
@@ -81,10 +81,7 @@ impl<'a> MediaWorkerScenario<'a> {
             .media_route_index
             .entry(transport_media_id)
             .and_modify(|route_entry| route_entry.source_active = true)
-            .or_insert_with(|| MediaRouteEntry {
-                source_active: true,
-                destinations: Vec::new(),
-            });
+            .or_insert_with(|| MediaRouteEntry::new(true));
     }
 
     fn install_destination(
@@ -105,16 +102,13 @@ impl<'a> MediaWorkerScenario<'a> {
         self.state
             .media_route_index
             .entry(source_transport_media_id)
-            .or_insert_with(|| MediaRouteEntry {
-                source_active: true,
-                destinations: Vec::new(),
-            })
-            .destinations
-            .push(MediaRouteDestination {
+            .or_insert_with(|| MediaRouteEntry::new(true))
+            .push_destination(MediaRouteDestination {
                 dest_session: session_key,
                 dest_transport_media_id: transport_media_id,
                 dest_mid: mid,
                 dest_payload_type: None,
+                nackable: true,
                 active: true,
                 packet_gate,
                 pending_packet_gate,

--- a/crates/core/src/runtime/rtc_engine/test_support/worker_debug.rs
+++ b/crates/core/src/runtime/rtc_engine/test_support/worker_debug.rs
@@ -427,6 +427,7 @@ fn build_debug_route_entry(
         .map(|entry| DebugRouteEntry {
             source_transport_media_id,
             source_active: entry.source_active,
+            active_destination_count: entry.active_destination_count,
             effective_packet_gate: state
                 .route_control
                 .effective_packet_gate(source_transport_media_id)

--- a/crates/core/src/runtime/rtc_engine/tests/forwarding_planner_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/forwarding_planner_tests.rs
@@ -75,6 +75,19 @@ fn populate_forward_routes(
     }
 }
 
+fn local_destination_session<'a>(
+    state: &'a PacketLoopState,
+    destination: &ForwardingDestination,
+) -> Option<&'a TransportSessionKey> {
+    let local_route = destination.local_route()?;
+    state
+        .media_route_index
+        .get(&local_route.source_transport_media_id())?
+        .destinations
+        .get(local_route.destination_index())
+        .map(|destination| &destination.dest_session)
+}
+
 #[test]
 fn populate_forward_routes_wraps_local_rtc_destinations_in_the_named_contract() {
     let producer_session = TransportSessionKey::new(
@@ -120,7 +133,7 @@ fn populate_forward_routes_wraps_local_rtc_destinations_in_the_named_contract() 
     assert!(matches!(
         forwards.first().map(PacketForward::destination),
         Some(destination)
-            if destination.session_key() == Some(&consumer_session)
+            if local_destination_session(&state, destination) == Some(&consumer_session)
     ));
 }
 
@@ -480,12 +493,12 @@ fn populate_forward_routes_enforces_per_consumer_rid_gates_after_aggregate_admit
     assert_eq!(forwards.first().map(PacketForward::packet_idx), Some(0));
     assert!(matches!(
         forwards.first().map(PacketForward::destination),
-        Some(destination) if destination.session_key() == Some(&hi_consumer_session)
+        Some(destination) if local_destination_session(&state, destination) == Some(&hi_consumer_session)
     ));
     assert_eq!(forwards.get(1).map(PacketForward::packet_idx), Some(1));
     assert!(matches!(
         forwards.get(1).map(PacketForward::destination),
-        Some(destination) if destination.session_key() == Some(&lo_consumer_session)
+        Some(destination) if local_destination_session(&state, destination) == Some(&lo_consumer_session)
     ));
     let snapshot = metrics.snapshot();
     assert_eq!(snapshot.rtc_route_control_layer_allowed(), 2);
@@ -554,17 +567,17 @@ fn populate_forward_routes_enforces_per_consumer_temporal_ceilings_after_aggrega
     assert_eq!(forwards.first().map(PacketForward::packet_idx), Some(0));
     assert!(matches!(
         forwards.first().map(PacketForward::destination),
-        Some(destination) if destination.session_key() == Some(&high_consumer_session)
+        Some(destination) if local_destination_session(&state, destination) == Some(&high_consumer_session)
     ));
     assert_eq!(forwards.get(1).map(PacketForward::packet_idx), Some(1));
     assert!(matches!(
         forwards.get(1).map(PacketForward::destination),
-        Some(destination) if destination.session_key() == Some(&base_consumer_session)
+        Some(destination) if local_destination_session(&state, destination) == Some(&base_consumer_session)
     ));
     assert_eq!(forwards.get(2).map(PacketForward::packet_idx), Some(1));
     assert!(matches!(
         forwards.get(2).map(PacketForward::destination),
-        Some(destination) if destination.session_key() == Some(&high_consumer_session)
+        Some(destination) if local_destination_session(&state, destination) == Some(&high_consumer_session)
     ));
     let snapshot = metrics.snapshot();
     assert_eq!(snapshot.rtc_route_control_layer_allowed(), 2);
@@ -723,7 +736,7 @@ fn populate_forward_routes_gates_only_the_selected_source_media() {
     assert!(matches!(
         forwards.get(2).map(PacketForward::destination),
         Some(destination)
-            if destination.session_key() == Some(&open_consumer_session)
+            if local_destination_session(&state, destination) == Some(&open_consumer_session)
     ));
     let snapshot = metrics.snapshot();
     assert_eq!(snapshot.rtc_route_control_layer_dropped(), 1);
@@ -777,7 +790,7 @@ fn populate_forward_routes_applies_operating_point_packet_gates() {
     assert_eq!(forwards.len(), 1);
     assert!(matches!(
         forwards.first().map(PacketForward::destination),
-        Some(destination) if destination.session_key() == Some(&consumer_session)
+        Some(destination) if local_destination_session(&state, destination) == Some(&consumer_session)
     ));
     let snapshot = metrics.snapshot();
     assert_eq!(snapshot.rtc_route_control_layer_dropped(), 1);

--- a/crates/core/src/runtime/rtc_engine/tests/media_flow_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/media_flow_tests.rs
@@ -191,6 +191,7 @@ async fn rtc_consume_media_uses_negotiated_mid_and_ssrc() {
     };
     assert_eq!(route_entry.source_transport_media_id, source_media_id);
     assert!(route_entry.source_active);
+    assert_eq!(route_entry.active_destination_count, 1);
     assert!(route_entry.destinations.iter().any(|dest| {
         dest.dest_session == consumer_session_key
             && dest.dest_transport_media_id == consumer_media_id
@@ -502,6 +503,7 @@ async fn rtc_route_activity_updates_producer_and_consumer_flags() {
     };
     assert_eq!(route_entry.source_transport_media_id, source_media_id);
     assert!(!route_entry.source_active);
+    assert_eq!(route_entry.active_destination_count, 0);
     assert!(route_entry.destinations.iter().any(|destination| {
         destination.dest_session == consumer_session_key
             && destination.dest_transport_media_id == consumer_media_id

--- a/crates/core/src/runtime/rtc_engine/worker/media/control/routes.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/media/control/routes.rs
@@ -29,7 +29,7 @@
 use std::time::Instant;
 
 use o_sfu_router::MediaStream as RouterRtpParameters;
-use str0m::media::{Mid, Pt, Rid};
+use str0m::media::{MediaKind, Mid, Pt, Rid};
 
 use super::{
     super::types::{ConsumerPacketGateRequest, RouteSourceKind},
@@ -81,6 +81,12 @@ pub(in crate::runtime::rtc_engine::worker::media) struct ConsumerRouteRegistrati
     pub consumer_transport_media_id: TransportMediaId,
     /// consumer MID used when packets are rewritten for local egress
     pub consumer_mid: Mid,
+    /// committed consumer media kind used to cache local egress nackability
+    ///
+    /// route registration is the point where consumer ownership and negotiated
+    /// media kind are both known, so the packet loop can later avoid a per-send
+    /// media lookup
+    pub consumer_media_kind: MediaKind,
     /// producer or remote-source media id that feeds this destination
     pub source_transport_media_id: TransportMediaId,
     /// router-negotiated consumer stream used for payload rewriting and the
@@ -171,6 +177,11 @@ pub(in crate::runtime::rtc_engine::worker::media) fn ensure_existing_route_sourc
 /// room policy may later replace the gate for this one consumer without
 /// changing other destinations on the same source
 ///
+/// local egress retransmission policy is captured here from the committed
+/// consumer media kind
+/// if a future renegotiation can change media kind without recreating the route,
+/// that path must refresh the route destination before packets are forwarded
+///
 /// a strict selected-rid route is not made effective until packet-path liveness
 /// proves that the rid exists for this producer
 /// the pending gate keeps the room-selected target attached to the destination
@@ -187,6 +198,7 @@ pub(in crate::runtime::rtc_engine::worker::media) fn register_consumer_route(
         consumer_session_key,
         consumer_transport_media_id,
         consumer_mid,
+        consumer_media_kind,
         source_transport_media_id,
         consumer_rtp_parameters,
         now,
@@ -201,16 +213,13 @@ pub(in crate::runtime::rtc_engine::worker::media) fn register_consumer_route(
     state
         .media_route_index
         .entry(source_transport_media_id)
-        .or_insert_with(|| MediaRouteEntry {
-            source_active: true,
-            destinations: Vec::new(),
-        })
-        .destinations
-        .push(MediaRouteDestination {
+        .or_insert_with(|| MediaRouteEntry::new(true))
+        .push_destination(MediaRouteDestination {
             dest_session: consumer_session_key.clone(),
             dest_transport_media_id: consumer_transport_media_id,
             dest_mid: consumer_mid,
             dest_payload_type,
+            nackable: !consumer_media_kind.is_audio(),
             active: true,
             packet_gate,
             pending_packet_gate,
@@ -261,7 +270,7 @@ pub(in crate::runtime::rtc_engine::worker::media) fn remove_consumer_route(
         }) else {
             return;
         };
-        route_entry.destinations.remove(position);
+        route_entry.remove_destination(position);
         route_entry.destinations.is_empty()
     };
     if remove_route_entry {
@@ -507,24 +516,25 @@ fn update_consumer_route(
     {
         return Err(TransportAdapterError::InvalidInput);
     }
-    let destination = state
+    let route_entry = state
         .media_route_index
         .get_mut(&source_transport_media_id)
-        .ok_or(TransportAdapterError::TransportUnavailable)?
+        .ok_or(TransportAdapterError::TransportUnavailable)?;
+    let destination_index = route_entry
         .destinations
-        .iter_mut()
-        .find(|destination| {
+        .iter()
+        .position(|destination| {
             destination.dest_session == *consumer_session_key
                 && destination.dest_transport_media_id == consumer_transport_media_id
         })
         .ok_or(TransportAdapterError::TransportUnavailable)?;
     Ok(match (active, packet_gate_update) {
-        (Some(active), None) => {
-            let route_changed = destination.active != active;
-            destination.active = active;
-            route_changed
-        }
+        (Some(active), None) => route_entry.set_destination_active(destination_index, active),
         (None, Some((packet_gate, pending_packet_gate))) => {
+            let destination = route_entry
+                .destinations
+                .get_mut(destination_index)
+                .ok_or(TransportAdapterError::TransportUnavailable)?;
             let route_changed = destination.packet_gate != packet_gate
                 || destination.pending_packet_gate != pending_packet_gate;
             destination.packet_gate = packet_gate;
@@ -534,7 +544,6 @@ fn update_consumer_route(
         _ => false,
     })
 }
-
 /// extracts the rid restriction carried by a packet-layer gate
 ///
 /// keyframe routing and selected-rid readiness use this to map destination

--- a/crates/core/src/runtime/rtc_engine/worker/media/lifecycle.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/media/lifecycle.rs
@@ -574,6 +574,7 @@ fn worker_add_send_media(
             consumer_session_key,
             consumer_transport_media_id: transport_media_id,
             consumer_mid: mid,
+            consumer_media_kind: media_kind,
             source_transport_media_id,
             consumer_rtp_parameters,
             now,


### PR DESCRIPTION
The RTC packet loop builds local fanout plans for every routed packet. The previous plan cloned local route destinations into PacketForward entries, scanned active destinations before planning and then walked the same list while emitting forwards.

This change keeps PacketForward turn-local but stores local destinations as source-media plus destination-index handles. The flush step resolves the route destination inside the same packet-loop turn. MediaRouteEntry maintains active_destination_count for O(1) empty-route admission. MediaRouteDestination caches negotiated nackability so local egress does not ask str0m for media kind on every destination send.