### PR TITLE
[FIX] core: match simulcast RIDs by exact MID

### DIFF
--- a/crates/core/src/runtime/rtc_engine/simulcast/common.rs
+++ b/crates/core/src/runtime/rtc_engine/simulcast/common.rs
@@ -107,15 +107,35 @@ fn media_section_for_mid(sdp: &str, mid: Mid) -> Option<&str> {
         webrtc::sdp::ATTRIBUTE_PREFIX,
         webrtc::sdp::attribute::MID
     );
-    let marker_start = sdp.find(&marker)?;
     let media_prefix = format!("\n{}", webrtc::sdp::MEDIA_PREFIX);
-    let section_start = sdp[..marker_start]
-        .rfind(&media_prefix)
-        .map_or(0, |index| index + 1);
-    let section_end = sdp[marker_start..]
-        .find(&media_prefix)
-        .map_or(sdp.len(), |offset| marker_start + offset + 1);
-    Some(&sdp[section_start..section_end])
+    let mut section_search_start = 0;
+    while let Some(section_start) =
+        find_next_media_section_start(sdp, section_search_start, &media_prefix)
+    {
+        let section_body_start = section_start + webrtc::sdp::MEDIA_PREFIX.len();
+        let section_end = find_next_media_section_start(sdp, section_body_start, &media_prefix)
+            .unwrap_or(sdp.len());
+        let section = &sdp[section_start..section_end];
+        if section
+            .lines()
+            .map(|line| line.trim_end_matches('\r'))
+            .any(|line| line == marker)
+        {
+            return Some(section);
+        }
+        section_search_start = section_end;
+    }
+    None
+}
+
+fn find_next_media_section_start(sdp: &str, start: usize, media_prefix: &str) -> Option<usize> {
+    let remaining = sdp.get(start..)?;
+    if remaining.starts_with(webrtc::sdp::MEDIA_PREFIX) {
+        return Some(start);
+    }
+    remaining
+        .find(media_prefix)
+        .map(|offset| start + offset + 1)
 }
 
 fn parse_send_rid(line: &str) -> Option<NegotiatedRid> {

--- a/crates/core/src/runtime/rtc_engine/simulcast/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/simulcast/mod.rs
@@ -241,6 +241,43 @@ mod tests {
     }
 
     #[test]
+    fn answer_send_rid_projection_matches_exact_mid_section() {
+        let answer = format!(
+            concat!(
+                "v=0\r\n",
+                "a=mid:cam\r\n",
+                "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n",
+                "a=mid:camera\r\n",
+                "a={rid_attr}:wrong {send} {max_br}=111000\r\n",
+                "a={simulcast_attr}:{send} wrong\r\n",
+                "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n",
+                "a=mid:cam\r\n",
+                "a={rid_attr}:right {send} {max_br}=222000\r\n",
+                "a={simulcast_attr}:{send} right\r\n"
+            ),
+            rid_attr = webrtc::sdp::attribute::RID,
+            simulcast_attr = webrtc::sdp::attribute::SIMULCAST,
+            send = webrtc::sdp::rid::DIRECTION_SEND,
+            max_br = webrtc::sdp::rid_restriction::MAX_BITRATE,
+        );
+
+        assert_eq!(
+            send_rids_for_mid(&answer, Mid::from("cam")),
+            vec![NegotiatedRid {
+                rid: Str0mRid::from("right"),
+                max_bitrate: Some(Bitrate::from_bps(222_000)),
+            }]
+        );
+        assert_eq!(
+            send_rids_for_mid(&answer, Mid::from("camera")),
+            vec![NegotiatedRid {
+                rid: Str0mRid::from("wrong"),
+                max_bitrate: Some(Bitrate::from_bps(111_000)),
+            }]
+        );
+    }
+
+    #[test]
     fn h264_and_vp8_profiles_are_promoted_simulcast_publication_paths() {
         let h264 = h264_parameters(1, "42e01f");
 


### PR DESCRIPTION
Answer-side simulcast RID projection must bind RIDs to the SDP media section identified by the exact MID. The previous substring lookup could match `a=mid:camera` while resolving `cam`, which let one media section inherit another section's RID ladder.

This changes the RTC simulcast helper to scan media sections and accept only a full `a=mid:<value>` line match. It keeps the fix inside the RTC edge where raw SDP answer parsing already lives, so router and room policy continue to consume normalized stream bindings.

performance:
the parser still performs one linear scan over the answer SDP. No hot RTP path state is touched, no allocations are added beyond the existing MID formatting work, and the media-section scan is proportional to a small negotiation payload rather than packet flow.

lines of code:
the change should stay close to neutral. The old substring helper is replaced by exact section matching plus one regression test that protects the RFC boundary.