### PR TITLE
[IMP] core: avoid hot RTP session-key clones

### DIFF
--- a/crates/core/src/runtime/packet_sink_registry.rs
+++ b/crates/core/src/runtime/packet_sink_registry.rs
@@ -186,11 +186,14 @@ impl RoomPacketSinkRegistry {
 
     #[cfg(any(test, feature = "testing-transport"))]
     pub fn write_packet(&self, packet: &ForwardedPacket, transport_media_id: TransportMediaId) {
-        let Some(sink) = self.sink_for_room(packet.source_session_key().room_instance_id()) else {
+        let Some(source_session_key) = packet.stable_source_session_key() else {
+            return;
+        };
+        let Some(sink) = self.sink_for_room(source_session_key.room_instance_id()) else {
             return;
         };
         sink.record_packet(
-            packet.source_session_key(),
+            source_session_key,
             transport_media_id,
             packet.received_at(),
             packet.payload(),

--- a/crates/core/src/runtime/rtc_engine/benchmark_support/relay.rs
+++ b/crates/core/src/runtime/rtc_engine/benchmark_support/relay.rs
@@ -3,6 +3,7 @@ use tokio::sync::mpsc;
 use super::super::{
     forwarded_packet::ForwardedPacket,
     relay_registry::{RelayEnqueueOutcome, RelayPacketMailbox, RelayTargetTransport},
+    state::PacketLoopState,
     test_support::{sample_forwarded_packet, test_transport_session_key},
 };
 use crate::runtime::{UserId, media_transport::TransportMediaId};
@@ -26,6 +27,7 @@ pub struct RelayPressureBenchFixture {
     target: RelayTargetTransport,
     source_transport_media_id: TransportMediaId,
     packet: ForwardedPacket,
+    state: PacketLoopState,
     _rx: mpsc::Receiver<ForwardedPacket>,
 }
 
@@ -58,6 +60,7 @@ impl RelayPressureBenchFixture {
             target: RelayPacketMailbox::new(tx).into(),
             source_transport_media_id,
             packet,
+            state: PacketLoopState::default(),
             _rx: rx,
         }
     }
@@ -65,10 +68,11 @@ impl RelayPressureBenchFixture {
     fn count_matching_outcomes(&self, attempts: usize, expected: RelayEnqueueOutcome) -> usize {
         let mut matching_outcomes = 0;
         for _ in 0..attempts {
-            let report = self
+            if self
                 .target
-                .forward_packet(&self.packet, self.source_transport_media_id);
-            if report.outcome() == expected {
+                .forward_packet(&self.state, &self.packet, self.source_transport_media_id)
+                .is_some_and(|report| report.outcome() == expected)
+            {
                 matching_outcomes += 1;
             }
         }

--- a/crates/core/src/runtime/rtc_engine/forwarded_packet/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/forwarded_packet/mod.rs
@@ -28,7 +28,7 @@ use str0m::{
 use super::{
     local_forwarding::LocalForwardedRtp, local_send_rewrite::Vp8PayloadIdentity,
     media_registry::DecoderRefreshCodec, route_control::PacketLayerMetadata,
-    shared_payload::SharedPayload, state::PacketLoopState,
+    shared_payload::SharedPayload, slots::SessionHandle, state::PacketLoopState,
 };
 use crate::runtime::{
     RoomInstanceId,
@@ -50,7 +50,7 @@ pub struct ForwardedPacket {
     ///
     /// this also anchors the room instance used by source-policy wakeups and
     /// room-scoped packet sinks
-    source_session_key: TransportSessionKey,
+    source: ForwardedPacketSource,
     /// producer identity resolved from MID, SSRC or relay metadata
     ///
     /// once this is known it is cached so later state churn during the same
@@ -74,6 +74,28 @@ pub struct ForwardedPacket {
     payload: SharedPayload,
     /// origin-specific RTP header storage
     data: ForwardedPacketData,
+}
+
+/// source identity for one staged forwarded packet
+///
+/// local packets carry only a worker-local generation-checked handle while
+/// relayed packets carry the stable public key needed to cross worker mailboxes
+#[derive(Debug, Clone)]
+pub(super) enum ForwardedPacketSource {
+    Local(SessionHandle),
+    Relayed(TransportSessionKey),
+}
+
+impl ForwardedPacketSource {
+    pub(super) fn session_key<'a>(
+        &'a self,
+        state: &'a PacketLoopState,
+    ) -> Option<&'a TransportSessionKey> {
+        match self {
+            Self::Local(session_handle) => state.users.key_for_handle(*session_handle),
+            Self::Relayed(session_key) => Some(session_key),
+        }
+    }
 }
 
 /// rtp header storage for the two ingress paths handled by the packet loop
@@ -147,11 +169,11 @@ impl ForwardedPacket {
     /// the remaining `str0m` packet is kept only for header metadata and the
     /// original receive time
     pub(super) fn from_rtp_packet(
-        source_session_key: TransportSessionKey,
+        source_session_handle: SessionHandle,
         mut rtp_packet: RtpPacket,
     ) -> Self {
         Self {
-            source_session_key,
+            source: ForwardedPacketSource::Local(source_session_handle),
             source_transport_media_id: None,
             resolved_source_rid: None,
             facts: None,
@@ -163,8 +185,24 @@ impl ForwardedPacket {
     }
 
     #[must_use]
-    pub fn source_session_key(&self) -> &TransportSessionKey {
-        &self.source_session_key
+    pub(super) const fn source(&self) -> &ForwardedPacketSource {
+        &self.source
+    }
+
+    #[must_use]
+    pub(super) fn source_session_key<'a>(
+        &'a self,
+        state: &'a PacketLoopState,
+    ) -> Option<&'a TransportSessionKey> {
+        self.source.session_key(state)
+    }
+
+    #[cfg(any(test, feature = "testing-transport"))]
+    pub(in crate::runtime) fn stable_source_session_key(&self) -> Option<&TransportSessionKey> {
+        match &self.source {
+            ForwardedPacketSource::Local(_) => None,
+            ForwardedPacketSource::Relayed(session_key) => Some(session_key),
+        }
     }
 
     #[must_use]
@@ -211,7 +249,7 @@ impl ForwardedPacket {
             source_transport_media_id,
             layer_metadata,
             payload_len: self.payload_len(),
-            room_instance_id: self.source_session_key.room_instance_id(),
+            room_instance_id: self.source_session_key(state)?.room_instance_id(),
             voice_activity: extensions.voice_activity,
             audio_level: extensions.audio_level,
             decoder_refresh,
@@ -248,10 +286,7 @@ impl ForwardedPacket {
     }
 
     pub(super) fn route_control_ssrc(&self) -> Ssrc {
-        match &self.data {
-            ForwardedPacketData::Str0mRtp(rtp_data) => rtp_data.rtp_packet.header.ssrc,
-            ForwardedPacketData::RelayRtp(rtp_data) => rtp_data.header.ssrc,
-        }
+        self.rtp_header().ssrc
     }
 
     pub(super) fn route_control_mid(&self) -> Option<Mid> {
@@ -270,29 +305,23 @@ impl ForwardedPacket {
     /// identity from local producer registries
     /// cached facts and resolved RID are preserved so the receiving worker can
     /// reuse source observations
-    pub(super) fn share_for_relay(&self, source_transport_media_id: TransportMediaId) -> Self {
-        let data = match &self.data {
-            ForwardedPacketData::Str0mRtp(rtp_data) => {
-                ForwardedPacketData::RelayRtp(ForwardedRelayRtpData {
-                    header: rtp_data.rtp_packet.header.clone(),
-                })
-            }
-            ForwardedPacketData::RelayRtp(rtp_data) => {
-                ForwardedPacketData::RelayRtp(ForwardedRelayRtpData {
-                    header: rtp_data.header.clone(),
-                })
-            }
-        };
-        Self {
-            source_session_key: self.source_session_key.clone(),
+    pub(super) fn share_for_relay(
+        &self,
+        state: &PacketLoopState,
+        source_transport_media_id: TransportMediaId,
+    ) -> Option<Self> {
+        Some(Self {
+            source: ForwardedPacketSource::Relayed(self.source.session_key(state)?.clone()),
             source_transport_media_id: Some(source_transport_media_id),
             resolved_source_rid: self.resolved_source_rid,
             facts: self.facts,
             visits_origin_sinks: false,
             received_at: self.received_at,
             payload: self.payload.share(),
-            data,
-        }
+            data: ForwardedPacketData::RelayRtp(ForwardedRelayRtpData {
+                header: self.rtp_header().clone(),
+            }),
+        })
     }
 
     pub(super) fn payload_len(&self) -> usize {
@@ -319,29 +348,15 @@ impl ForwardedPacket {
         if let Some(source_transport_media_id) = self.source_transport_media_id {
             return Some(source_transport_media_id);
         }
-        let resolved = match &self.data {
-            ForwardedPacketData::Str0mRtp(rtp_data) => {
-                if let Some(source_mid) = rtp_data.rtp_packet.header.ext_vals.mid
-                    && let Some(source_transport_media_id) = state
-                        .source_transport_media_id_for_mid(&self.source_session_key, source_mid)
-                {
-                    Some(source_transport_media_id)
-                } else {
-                    let source_ssrc = rtp_data.rtp_packet.header.ssrc;
-                    state.source_transport_media_id_for_ssrc(&self.source_session_key, source_ssrc)
-                }
-            }
-            ForwardedPacketData::RelayRtp(rtp_data) => {
-                if let Some(source_mid) = rtp_data.header.ext_vals.mid
-                    && let Some(source_transport_media_id) = state
-                        .source_transport_media_id_for_mid(&self.source_session_key, source_mid)
-                {
-                    Some(source_transport_media_id)
-                } else {
-                    let source_ssrc = rtp_data.header.ssrc;
-                    state.source_transport_media_id_for_ssrc(&self.source_session_key, source_ssrc)
-                }
-            }
+        let source_session_key = self.source.session_key(state)?;
+        let header = self.rtp_header();
+        let resolved = if let Some(source_mid) = header.ext_vals.mid
+            && let Some(source_transport_media_id) =
+                state.source_transport_media_id_for_mid(source_session_key, source_mid)
+        {
+            Some(source_transport_media_id)
+        } else {
+            state.source_transport_media_id_for_ssrc(source_session_key, header.ssrc)
         };
         if let Some(source_transport_media_id) = resolved {
             self.source_transport_media_id = Some(source_transport_media_id);
@@ -369,18 +384,19 @@ impl ForwardedPacket {
     }
 
     fn route_control_extension_values(&self) -> &ExtensionValues {
+        &self.rtp_header().ext_vals
+    }
+
+    fn rtp_header(&self) -> &RtpHeader {
         match &self.data {
-            ForwardedPacketData::Str0mRtp(rtp_data) => &rtp_data.rtp_packet.header.ext_vals,
-            ForwardedPacketData::RelayRtp(rtp_data) => &rtp_data.header.ext_vals,
+            ForwardedPacketData::Str0mRtp(rtp_data) => &rtp_data.rtp_packet.header,
+            ForwardedPacketData::RelayRtp(rtp_data) => &rtp_data.header,
         }
     }
 
     fn route_control_rid_from_ssrc(&self, state: &PacketLoopState) -> Option<Rid> {
-        let source_ssrc = match &self.data {
-            ForwardedPacketData::Str0mRtp(rtp_data) => rtp_data.rtp_packet.header.ssrc,
-            ForwardedPacketData::RelayRtp(rtp_data) => rtp_data.header.ssrc,
-        };
-        state.source_rid_for_ssrc(&self.source_session_key, source_ssrc)
+        let source_session_key = self.source.session_key(state)?;
+        state.source_rid_for_ssrc(source_session_key, self.rtp_header().ssrc)
     }
 
     fn decoder_refresh_for_source(
@@ -423,6 +439,8 @@ fn frame_mark_temporal_layer_id(frame_mark: u32) -> u8 {
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
     use o_sfu_rfc::rtp::CodecName;
     use o_sfu_router::{
         MediaFormat, MediaKind as RouterMediaKind, MediaStream as RouterRtpParameters,
@@ -431,17 +449,39 @@ mod tests {
     use str0m::media::{Mid, Rid};
 
     use super::*;
-    use crate::runtime::{
-        UserId,
-        rtc_engine::{
-            forwarded_packet::test_support::{
-                sample_forwarded_packet, sample_forwarded_packet_with_frame_mark,
-                sample_forwarded_packet_with_rid, sample_forwarded_packet_without_mid,
+    use crate::{
+        Bitrate, MediaCodecFlags,
+        runtime::{
+            UserId,
+            rtc_engine::{
+                bootstrap::ensure_session_rtc_state,
+                forwarded_packet::test_support::{
+                    sample_forwarded_packet, sample_forwarded_packet_with_frame_mark,
+                    sample_forwarded_packet_with_rid, sample_forwarded_packet_without_mid,
+                    sample_local_forwarded_packet,
+                },
+                media_registry::RegisteredMediaHandle,
+                test_support::test_transport_session_key,
             },
-            media_registry::RegisteredMediaHandle,
-            test_support::test_transport_session_key,
         },
     };
+
+    fn install_test_session(
+        state: &mut PacketLoopState,
+        session_key: &TransportSessionKey,
+    ) -> Option<SessionHandle> {
+        assert!(
+            ensure_session_rtc_state(
+                &mut state.users,
+                session_key,
+                SocketAddr::from(([127, 0, 0, 1], 9)),
+                Bitrate::from_bps(1_000_000),
+                MediaCodecFlags::default(),
+            )
+            .is_ok()
+        );
+        state.users.handle_for_key(session_key)
+    }
 
     #[test]
     fn forwarded_packet_resolves_transport_media_id_through_the_registry() {
@@ -456,6 +496,55 @@ mod tests {
         assert_eq!(
             packet.resolve_source_transport_media_id(&state),
             Some(transport_media_id)
+        );
+    }
+
+    #[test]
+    fn local_forwarded_packet_resolves_transport_media_id_through_session_handle() {
+        let session_key = test_transport_session_key(51, 0, 19, UserId::Integer(17));
+        let mut state = PacketLoopState::default();
+        let session_handle = install_test_session(&mut state, &session_key);
+        assert!(session_handle.is_some());
+        let Some(session_handle) = session_handle else {
+            return;
+        };
+        let transport_media_id = state.register_media_handle(RegisteredMediaHandle::Producer {
+            session_key: session_key.clone(),
+            mid: Mid::from("aud-up"),
+        });
+        let mut packet = sample_local_forwarded_packet(session_handle, "aud-up", b"payload");
+
+        assert_eq!(packet.source_session_key(&state), Some(&session_key));
+        assert_eq!(
+            packet.resolve_source_transport_media_id(&state),
+            Some(transport_media_id)
+        );
+    }
+
+    #[test]
+    fn stale_local_forwarded_packet_does_not_resolve_through_reused_slot() {
+        let session_key = test_transport_session_key(52, 0, 20, UserId::Integer(18));
+        let replacement_session_key = test_transport_session_key(52, 0, 21, UserId::Integer(19));
+        let mut state = PacketLoopState::default();
+        let stale_handle = install_test_session(&mut state, &session_key);
+        assert!(stale_handle.is_some());
+        let Some(stale_handle) = stale_handle else {
+            return;
+        };
+        let _removed = state.users.remove(&session_key);
+        let _replacement_handle = install_test_session(&mut state, &replacement_session_key);
+        state.register_media_handle(RegisteredMediaHandle::Producer {
+            session_key: replacement_session_key,
+            mid: Mid::from("aud-up"),
+        });
+        let mut packet = sample_local_forwarded_packet(stale_handle, "aud-up", b"payload");
+
+        assert!(packet.source_session_key(&state).is_none());
+        assert_eq!(packet.resolve_facts(&state), None);
+        assert!(
+            packet
+                .share_for_relay(&state, TransportMediaId::new(99))
+                .is_none()
         );
     }
 
@@ -515,7 +604,11 @@ mod tests {
             ),
         );
         let source_packet = sample_forwarded_packet(session_key, "cam-up", &[0x65, 0x88]);
-        let mut relay_packet = source_packet.share_for_relay(source_transport_media_id);
+        let relay_packet = source_packet.share_for_relay(&state, source_transport_media_id);
+        assert!(relay_packet.is_some());
+        let Some(mut relay_packet) = relay_packet else {
+            return;
+        };
         let facts = relay_packet.resolve_facts(&state);
         assert!(facts.is_some());
         let Some(facts) = facts else {
@@ -529,9 +622,10 @@ mod tests {
     #[test]
     fn forwarded_packet_exposes_recording_payload_and_received_at() {
         let session_key = test_transport_session_key(42, 0, 10, UserId::Integer(8));
+        let state = PacketLoopState::default();
         let packet = sample_forwarded_packet(session_key.clone(), "aud-up", b"payload");
 
-        assert_eq!(packet.source_session_key(), &session_key);
+        assert_eq!(packet.source_session_key(&state), Some(&session_key));
         assert_eq!(packet.payload(), b"payload");
         assert_eq!(packet.payload_len(), 7);
         assert!(packet.received_at() <= Instant::now());
@@ -540,10 +634,15 @@ mod tests {
     #[test]
     fn forwarded_packet_relay_clone_keeps_payload_and_explicit_source_media_id() {
         let session_key = test_transport_session_key(43, 0, 11, UserId::Integer(9));
+        let state = PacketLoopState::default();
         let packet = sample_forwarded_packet(session_key.clone(), "aud-up", b"payload");
-        let mut relay_packet = packet.share_for_relay(TransportMediaId::new(18));
+        let relay_packet = packet.share_for_relay(&state, TransportMediaId::new(18));
+        assert!(relay_packet.is_some());
+        let Some(mut relay_packet) = relay_packet else {
+            return;
+        };
 
-        assert_eq!(relay_packet.source_session_key(), &session_key);
+        assert_eq!(relay_packet.source_session_key(&state), Some(&session_key));
         assert_eq!(relay_packet.payload(), b"payload");
         assert_eq!(
             relay_packet.resolve_source_transport_media_id(&PacketLoopState::default()),
@@ -664,7 +763,11 @@ mod tests {
             packet.resolve_route_control_layer_metadata(&source_state),
             PacketLayerMetadata::new(Some(Rid::from("hi")), None)
         );
-        let mut relay_packet = packet.share_for_relay(source_transport_media_id);
+        let relay_packet = packet.share_for_relay(&source_state, source_transport_media_id);
+        assert!(relay_packet.is_some());
+        let Some(mut relay_packet) = relay_packet else {
+            return;
+        };
 
         assert_eq!(
             relay_packet.resolve_route_control_layer_metadata(&PacketLoopState::default()),

--- a/crates/core/src/runtime/rtc_engine/forwarded_packet/test_support.rs
+++ b/crates/core/src/runtime/rtc_engine/forwarded_packet/test_support.rs
@@ -5,7 +5,11 @@ use str0m::{
     rtp::{RtpHeader, Ssrc},
 };
 
-use super::{ForwardedPacket, ForwardedPacketData, ForwardedRelayRtpData};
+use super::{ForwardedPacket, ForwardedPacketData, ForwardedPacketSource, ForwardedRelayRtpData};
+#[cfg(test)]
+use crate::runtime::media_transport::TransportMediaId;
+#[cfg(test)]
+use crate::runtime::rtc_engine::slots::SessionHandle;
 use crate::runtime::{
     media_transport::TransportSessionKey, rtc_engine::shared_payload::SharedPayload,
 };
@@ -18,6 +22,36 @@ pub fn sample_forwarded_packet(
 ) -> ForwardedPacket {
     sample_forwarded_packet_with_extensions(
         source_session_key,
+        mid,
+        None,
+        ExtensionValues::default(),
+        payload,
+    )
+}
+
+#[cfg(test)]
+#[must_use]
+pub(in crate::runtime::rtc_engine) fn sample_already_relayed_packet(
+    source_session_key: TransportSessionKey,
+    source_transport_media_id: TransportMediaId,
+    mid: &str,
+    payload: &[u8],
+) -> ForwardedPacket {
+    let mut packet = sample_forwarded_packet(source_session_key, mid, payload);
+    packet.source_transport_media_id = Some(source_transport_media_id);
+    packet.visits_origin_sinks = false;
+    packet
+}
+
+#[cfg(test)]
+#[must_use]
+pub(in crate::runtime::rtc_engine) fn sample_local_forwarded_packet(
+    source_session_handle: SessionHandle,
+    mid: &str,
+    payload: &[u8],
+) -> ForwardedPacket {
+    sample_forwarded_packet_with_source(
+        ForwardedPacketSource::Local(source_session_handle),
         mid,
         None,
         ExtensionValues::default(),
@@ -92,9 +126,25 @@ fn sample_forwarded_packet_with_extensions(
     ext_vals: ExtensionValues,
     payload: &[u8],
 ) -> ForwardedPacket {
+    sample_forwarded_packet_with_source(
+        ForwardedPacketSource::Relayed(source_session_key),
+        mid,
+        rid,
+        ext_vals,
+        payload,
+    )
+}
+
+fn sample_forwarded_packet_with_source(
+    source: ForwardedPacketSource,
+    mid: &str,
+    rid: Option<&str>,
+    ext_vals: ExtensionValues,
+    payload: &[u8],
+) -> ForwardedPacket {
     let received_at = Instant::now();
     ForwardedPacket {
-        source_session_key,
+        source,
         source_transport_media_id: None,
         resolved_source_rid: None,
         facts: None,
@@ -133,7 +183,7 @@ pub fn sample_forwarded_packet_without_mid(
 ) -> ForwardedPacket {
     let received_at = Instant::now();
     ForwardedPacket {
-        source_session_key,
+        source: ForwardedPacketSource::Relayed(source_session_key),
         source_transport_media_id: None,
         resolved_source_rid: None,
         facts: None,

--- a/crates/core/src/runtime/rtc_engine/forwarding_destination.rs
+++ b/crates/core/src/runtime/rtc_engine/forwarding_destination.rs
@@ -198,8 +198,8 @@ impl ForwardingDestination {
     ) -> Result<ForwardSendOutcome, RtcError> {
         match self {
             Self::LocalRtc(destination) => destination.send(state, packet, is_last_destination),
-            Self::PacketSink(destination) => Ok(destination.send(packet)),
-            Self::Relay(destination) => Ok(destination.send(packet)),
+            Self::PacketSink(destination) => Ok(destination.send(state, packet)),
+            Self::Relay(destination) => Ok(destination.send(state, packet)),
         }
     }
 }
@@ -290,9 +290,12 @@ impl PacketSinkDestination {
     }
 
     /// records the source packet without mutating rtc session state
-    fn send(&self, packet: &ForwardedPacket) -> ForwardSendOutcome {
+    fn send(&self, state: &PacketLoopState, packet: &ForwardedPacket) -> ForwardSendOutcome {
+        let Some(source_session_key) = packet.source_session_key(state) else {
+            return ForwardSendOutcome::SideEffect;
+        };
         self.sink.record_packet(
-            packet.source_session_key(),
+            source_session_key,
             self.transport_media_id,
             packet.received_at(),
             packet.payload(),
@@ -313,10 +316,13 @@ impl RelayPacketDestination {
     }
 
     /// enqueues a shared relay packet for another worker or node
-    fn send(&self, packet: &ForwardedPacket) -> ForwardSendOutcome {
-        ForwardSendOutcome::RelayEnqueue(
-            self.target.forward_packet(packet, self.transport_media_id),
-        )
+    fn send(&self, state: &PacketLoopState, packet: &ForwardedPacket) -> ForwardSendOutcome {
+        self.target
+            .forward_packet(state, packet, self.transport_media_id)
+            .map_or(
+                ForwardSendOutcome::SideEffect,
+                ForwardSendOutcome::RelayEnqueue,
+            )
     }
 }
 
@@ -399,7 +405,7 @@ mod tests {
         packet_sink_registry::PacketSink as MediaPacketSink,
         rtc_engine::{
             relay_registry::{InterNodeRelaySender, RelayPacketMailbox},
-            test_support::{sample_forwarded_packet, test_transport_session_key},
+            test_support::{sample_already_relayed_packet, test_transport_session_key},
         },
     };
 
@@ -459,13 +465,14 @@ mod tests {
     #[test]
     fn packet_forward_wraps_intra_node_relay_sinks_in_the_named_contract() {
         let (mailbox, mut relay_rx) = RelayPacketMailbox::channel_for_test();
-        let packet = sample_forwarded_packet(
+        let mut packet = sample_already_relayed_packet(
             test_transport_session_key(11, 0, 12, UserId::Integer(13)),
+            TransportMediaId::new(8),
             "aud-up",
             b"payload",
         );
         let forward = PacketForward::from_relay_target(6, TransportMediaId::new(9), mailbox.into());
-        let mut relay_packet = packet.share_for_relay(TransportMediaId::new(8));
+        let mut state = PacketLoopState::default();
 
         assert_eq!(forward.packet_idx(), 6);
         assert!(matches!(
@@ -474,23 +481,21 @@ mod tests {
                 if destination.transport_media_id == TransportMediaId::new(9)
                     && destination.target.kind() == RelayTargetKind::IntraNode
         ));
-        let _ =
-            forward
-                .destination()
-                .send(&mut PacketLoopState::default(), &mut relay_packet, true);
+        let _ = forward.destination().send(&mut state, &mut packet, true);
         assert!(relay_rx.try_recv().is_ok());
     }
 
     #[test]
     fn packet_forward_wraps_inter_node_relay_sinks_in_the_named_contract() {
         let (sender, mut relay_rx) = InterNodeRelaySender::channel_for_test();
-        let packet = sample_forwarded_packet(
+        let mut packet = sample_already_relayed_packet(
             test_transport_session_key(21, 0, 22, UserId::Integer(23)),
+            TransportMediaId::new(8),
             "aud-up",
             b"payload",
         );
         let forward = PacketForward::from_relay_target(7, TransportMediaId::new(10), sender.into());
-        let mut relay_packet = packet.share_for_relay(TransportMediaId::new(8));
+        let mut state = PacketLoopState::default();
 
         assert_eq!(forward.packet_idx(), 7);
         assert!(matches!(
@@ -499,10 +504,7 @@ mod tests {
                 if destination.transport_media_id == TransportMediaId::new(10)
                     && destination.target.kind() == RelayTargetKind::InterNode
         ));
-        let _ =
-            forward
-                .destination()
-                .send(&mut PacketLoopState::default(), &mut relay_packet, true);
+        let _ = forward.destination().send(&mut state, &mut packet, true);
         assert!(relay_rx.try_recv().is_ok());
     }
 }

--- a/crates/core/src/runtime/rtc_engine/media_registry.rs
+++ b/crates/core/src/runtime/rtc_engine/media_registry.rs
@@ -31,7 +31,11 @@ use str0m::{
 use tracing::{debug, warn};
 
 use super::{
-    commands::RemoteSourceControl, route_control::PacketLayerGate, state::PacketLoopState,
+    commands::RemoteSourceControl,
+    forwarded_packet::ForwardedPacketSource,
+    route_control::PacketLayerGate,
+    slots::{MediaStore, SessionHandle},
+    state::PacketLoopState,
 };
 use crate::runtime::{
     RoomInstanceId,
@@ -234,6 +238,79 @@ impl SessionMediaLookup {
             && self.producer_ssrcs.is_empty()
             && self.producer_ssrc_rids.is_empty()
             && self.consumer_mids.is_empty()
+    }
+}
+
+fn learn_producer_ssrc_binding_for_session(
+    mid_registry: &MediaStore,
+    session_media: &mut SessionMediaRegistry,
+    producer_ssrcs_by_media: &mut BTreeMap<TransportMediaId, Vec<Ssrc>>,
+    session_key: &TransportSessionKey,
+    transport_media_id: TransportMediaId,
+    ssrc: Ssrc,
+    rid: Option<Rid>,
+) {
+    let Some(RegisteredMediaHandle::Producer {
+        session_key: registered_session_key,
+        mid,
+    }) = mid_registry.get(&transport_media_id)
+    else {
+        return;
+    };
+    if registered_session_key != session_key {
+        return;
+    }
+    let mid = *mid;
+
+    let (inserted, previous_rid) = if let Some(session_lookup) = session_media.get_mut(session_key)
+    {
+        if let Some(existing_transport_media_id) = session_lookup.producer_ssrcs.get(&ssrc)
+            && existing_transport_media_id != transport_media_id
+        {
+            warn!(
+                user_id = ?session_key.user_id(),
+                media_worker_id = session_key.media_worker_id(),
+                ?transport_media_id,
+                ?existing_transport_media_id,
+                ?mid,
+                ?ssrc,
+                ?rid,
+                "ignored dynamic producer SSRC binding because SSRC already belongs to another media"
+            );
+            return;
+        }
+        let inserted = session_lookup
+            .producer_ssrcs
+            .insert(ssrc, transport_media_id)
+            .is_none();
+        let previous_rid = rid.and_then(|rid| session_lookup.producer_ssrc_rids.insert(ssrc, rid));
+        (inserted, previous_rid)
+    } else {
+        let session_lookup = session_media.entry(session_key.clone()).or_default();
+        let inserted = session_lookup
+            .producer_ssrcs
+            .insert(ssrc, transport_media_id)
+            .is_none();
+        let previous_rid = rid.and_then(|rid| session_lookup.producer_ssrc_rids.insert(ssrc, rid));
+        (inserted, previous_rid)
+    };
+
+    let ssrcs = producer_ssrcs_by_media
+        .entry(transport_media_id)
+        .or_default();
+    if !ssrcs.contains(&ssrc) {
+        ssrcs.push(ssrc);
+    }
+    if inserted || previous_rid != rid {
+        debug!(
+            user_id = ?session_key.user_id(),
+            media_worker_id = session_key.media_worker_id(),
+            ?transport_media_id,
+            ?mid,
+            ?ssrc,
+            ?rid,
+            "learned dynamic producer SSRC binding from RTP header extensions"
+        );
     }
 }
 
@@ -692,58 +769,60 @@ impl PacketLoopState {
         ssrc: Ssrc,
         rid: Option<Rid>,
     ) {
-        let Some(RegisteredMediaHandle::Producer {
-            session_key: registered_session_key,
-            mid,
-        }) = self.media_handle(transport_media_id)
-        else {
+        learn_producer_ssrc_binding_for_session(
+            &self.mid_registry,
+            &mut self.session_media,
+            &mut self.producer_ssrcs_by_media,
+            session_key,
+            transport_media_id,
+            ssrc,
+            rid,
+        );
+    }
+
+    /// learn an SSRC binding from a forwarded packet source without requiring
+    /// local packets to materialize an owned session key
+    pub(super) fn learn_producer_ssrc_binding_from_forwarded_source(
+        &mut self,
+        source: &ForwardedPacketSource,
+        transport_media_id: TransportMediaId,
+        ssrc: Ssrc,
+        rid: Option<Rid>,
+    ) {
+        match source {
+            ForwardedPacketSource::Relayed(session_key) => {
+                self.learn_producer_ssrc_binding(session_key, transport_media_id, ssrc, rid);
+            }
+            ForwardedPacketSource::Local(session_handle) => {
+                self.learn_producer_ssrc_binding_from_session_handle(
+                    *session_handle,
+                    transport_media_id,
+                    ssrc,
+                    rid,
+                );
+            }
+        }
+    }
+
+    fn learn_producer_ssrc_binding_from_session_handle(
+        &mut self,
+        session_handle: SessionHandle,
+        transport_media_id: TransportMediaId,
+        ssrc: Ssrc,
+        rid: Option<Rid>,
+    ) {
+        let Some(session_key) = self.users.key_for_handle(session_handle) else {
             return;
         };
-        if registered_session_key != session_key {
-            return;
-        }
-        let mid = *mid;
-        if let Some(existing_transport_media_id) =
-            self.source_transport_media_id_for_ssrc(session_key, ssrc)
-            && existing_transport_media_id != transport_media_id
-        {
-            warn!(
-                user_id = ?session_key.user_id(),
-                media_worker_id = session_key.media_worker_id(),
-                ?transport_media_id,
-                ?existing_transport_media_id,
-                ?mid,
-                ?ssrc,
-                ?rid,
-                "ignored dynamic producer SSRC binding because SSRC already belongs to another media"
-            );
-            return;
-        }
-
-        let session_lookup = self.session_media.entry(session_key.clone()).or_default();
-        let inserted = session_lookup
-            .producer_ssrcs
-            .insert(ssrc, transport_media_id)
-            .is_none();
-        let previous_rid = rid.and_then(|rid| session_lookup.producer_ssrc_rids.insert(ssrc, rid));
-        let ssrcs = self
-            .producer_ssrcs_by_media
-            .entry(transport_media_id)
-            .or_default();
-        if !ssrcs.contains(&ssrc) {
-            ssrcs.push(ssrc);
-        }
-        if inserted || previous_rid != rid {
-            debug!(
-                user_id = ?session_key.user_id(),
-                media_worker_id = session_key.media_worker_id(),
-                ?transport_media_id,
-                ?mid,
-                ?ssrc,
-                ?rid,
-                "learned dynamic producer SSRC binding from RTP header extensions"
-            );
-        }
+        learn_producer_ssrc_binding_for_session(
+            &self.mid_registry,
+            &mut self.session_media,
+            &mut self.producer_ssrcs_by_media,
+            session_key,
+            transport_media_id,
+            ssrc,
+            rid,
+        );
     }
 
     /// resolve the source media id that feeds a consumer MID

--- a/crates/core/src/runtime/rtc_engine/packet_loop/buffers.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/buffers.rs
@@ -17,7 +17,11 @@ use std::{net::SocketAddr, time::Instant};
 use str0m::media::Rid;
 
 use super::{
-    super::{forwarded_packet::ForwardedPacket, forwarding_destination::PacketForward},
+    super::{
+        forwarded_packet::{ForwardedPacket, ForwardedPacketSource},
+        forwarding_destination::PacketForward,
+        slots::SessionHandle,
+    },
     keyframe_requests::{CoalescedKeyframeRequest, PendingKeyframeRequest},
 };
 use crate::runtime::{
@@ -56,7 +60,7 @@ impl PendingTransmit {
 }
 
 pub(super) struct PendingRidReadiness {
-    pub(super) source_session_key: TransportSessionKey,
+    pub(super) source: ForwardedPacketSource,
     pub(super) source_transport_media_id: TransportMediaId,
     pub(super) rid: Rid,
     pub(super) is_keyframe: bool,
@@ -64,7 +68,7 @@ pub(super) struct PendingRidReadiness {
 }
 
 pub(super) struct PendingFirstVideoKeyframe {
-    pub(super) source_session_key: TransportSessionKey,
+    pub(super) source: ForwardedPacketSource,
     pub(super) source_transport_media_id: TransportMediaId,
     pub(super) observed_at: Instant,
 }
@@ -85,18 +89,11 @@ pub(in crate::runtime::rtc_engine) struct PacketLoopBuffers {
     pub(super) pending_transmit_count: usize,
     /// Media packets produced by local adapter sessions or inbound relays.
     pub(in crate::runtime::rtc_engine) pending_packets: Vec<ForwardedPacket>,
-    /// Shared relay packet cache for the current planned packet.
-    ///
-    /// Relay flush can have multiple relay destinations for one packet. The
-    /// planner orders forwards by packet index, so one cached packet plus its
-    /// index is enough to avoid dense scratch writes for local-only turns.
-    pub(super) relay_packet: Option<ForwardedPacket>,
-    pub(super) relay_packet_idx: Option<usize>,
     /// Raw keyframe feedback emitted by consumer sessions before source lookup.
     pub(in crate::runtime::rtc_engine) pending_keyframe_requests:
         Vec<(TransportSessionKey, PendingKeyframeRequest)>,
     /// Sessions ready for polling after dirty and timeout scheduling is merged.
-    pub(super) ready_sessions: Vec<TransportSessionKey>,
+    pub(super) ready_sessions: Vec<SessionHandle>,
     /// Source-keyed feedback after duplicate requests are merged.
     pub(super) coalesced_keyframe_requests: Vec<CoalescedKeyframeRequest>,
     /// Source/RID-keyed readiness work after packet-level liveness is updated.
@@ -122,8 +119,6 @@ impl PacketLoopBuffers {
             pending_transmits: Vec::with_capacity(64),
             pending_transmit_count: 0,
             pending_packets: Vec::with_capacity(32),
-            relay_packet: None,
-            relay_packet_idx: None,
             pending_keyframe_requests: Vec::with_capacity(8),
             ready_sessions: Vec::with_capacity(32),
             coalesced_keyframe_requests: Vec::with_capacity(8),
@@ -143,8 +138,6 @@ impl PacketLoopBuffers {
     pub(in crate::runtime::rtc_engine) fn clear(&mut self) {
         self.pending_transmit_count = 0;
         self.pending_packets.clear();
-        self.relay_packet = None;
-        self.relay_packet_idx = None;
         self.pending_keyframe_requests.clear();
         self.ready_sessions.clear();
         self.coalesced_keyframe_requests.clear();
@@ -180,7 +173,7 @@ impl PacketLoopBuffers {
 
     pub(super) fn push_rid_readiness(
         &mut self,
-        source_session_key: &TransportSessionKey,
+        source: &ForwardedPacketSource,
         source_transport_media_id: TransportMediaId,
         rid: Rid,
         is_keyframe: bool,
@@ -196,7 +189,7 @@ impl PacketLoopBuffers {
             return;
         }
         self.pending_rid_readiness.push(PendingRidReadiness {
-            source_session_key: source_session_key.clone(),
+            source: source.clone(),
             source_transport_media_id,
             rid,
             is_keyframe,
@@ -206,7 +199,7 @@ impl PacketLoopBuffers {
 
     pub(super) fn push_first_video_keyframe(
         &mut self,
-        source_session_key: &TransportSessionKey,
+        source: &ForwardedPacketSource,
         source_transport_media_id: TransportMediaId,
         observed_at: Instant,
     ) {
@@ -219,7 +212,7 @@ impl PacketLoopBuffers {
         }
         self.pending_first_video_keyframes
             .push(PendingFirstVideoKeyframe {
-                source_session_key: source_session_key.clone(),
+                source: source.clone(),
                 source_transport_media_id,
                 observed_at,
             });

--- a/crates/core/src/runtime/rtc_engine/packet_loop/forward_flush.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/forward_flush.rs
@@ -24,7 +24,7 @@ use tracing::{debug, warn};
 
 use super::{
     super::{
-        forwarded_packet::ForwardedPacket,
+        forwarded_packet::{ForwardedPacket, ForwardedPacketSource},
         forwarding_destination::{ForwardSendOutcome, ForwardingDestination, relay_enqueue_result},
         media_registry::RegisteredMediaHandle,
         relay_registry::RelayEnqueueOutcome,
@@ -59,8 +59,8 @@ pub(super) fn record_incoming_stats(
             if packet.route_control_mid().is_some() {
                 // MID proves which producer this packet belongs to. Persist the
                 // SSRC before the browser stops sending MID/RID extensions.
-                state.learn_producer_ssrc_binding(
-                    packet.source_session_key(),
+                state.learn_producer_ssrc_binding_from_forwarded_source(
+                    packet.source(),
                     transport_media_id,
                     packet.route_control_ssrc(),
                     packet.route_control_rid_extension(),
@@ -77,11 +77,10 @@ pub(super) fn record_incoming_stats(
                     .dirty_source_policy_channel_ids
                     .push(facts.room_instance_id);
             }
-            let metadata = facts.layer_metadata;
-            if let Some(rid) = metadata.rid() {
+            if let Some(rid) = facts.layer_metadata.rid() {
                 state.observe_producer_rid_packet(transport_media_id, rid, packet.received_at());
                 buffers.push_rid_readiness(
-                    packet.source_session_key(),
+                    packet.source(),
                     transport_media_id,
                     rid,
                     facts.decoder_refresh,
@@ -96,15 +95,18 @@ pub(super) fn record_incoming_stats(
                 )
                 .unwrap_or(false);
             if unlikely(first_ingress) {
+                let Some(source_session_key) = packet.source_session_key(state) else {
+                    continue;
+                };
                 debug!(
-                    user_id = ?packet.source_session_key().user_id(),
-                    media_worker_id = packet.source_session_key().media_worker_id(),
+                    user_id = ?source_session_key.user_id(),
+                    media_worker_id = source_session_key.media_worker_id(),
                     ?transport_media_id,
                     payload_bytes = facts.payload_len,
                     "observed first RTP ingress for published media"
                 );
                 buffers.push_first_video_keyframe(
-                    packet.source_session_key(),
+                    packet.source(),
                     transport_media_id,
                     packet.received_at(),
                 );
@@ -124,15 +126,33 @@ fn flush_pending_rid_readiness(
     buffers: &mut PacketLoopBuffers,
 ) {
     for pending in buffers.pending_rid_readiness.drain(..) {
-        if apply_source_rid_readiness(
-            state,
-            metrics,
-            &pending.source_session_key,
-            pending.source_transport_media_id,
-            pending.rid,
-            pending.is_keyframe,
-            pending.observed_at,
-        ) {
+        let changed = match &pending.source {
+            ForwardedPacketSource::Relayed(source_session_key) => apply_source_rid_readiness(
+                state,
+                metrics,
+                source_session_key,
+                pending.source_transport_media_id,
+                pending.rid,
+                pending.is_keyframe,
+                pending.observed_at,
+            ),
+            ForwardedPacketSource::Local(session_handle) => {
+                let Some(source_session_key) = state.users.key_for_handle(*session_handle).cloned()
+                else {
+                    continue;
+                };
+                apply_source_rid_readiness(
+                    state,
+                    metrics,
+                    &source_session_key,
+                    pending.source_transport_media_id,
+                    pending.rid,
+                    pending.is_keyframe,
+                    pending.observed_at,
+                )
+            }
+        };
+        if changed {
             buffers
                 .rid_readiness_changed_sources
                 .push(pending.source_transport_media_id);
@@ -155,7 +175,7 @@ fn flush_pending_first_video_keyframes(
         request_first_video_keyframe(
             state,
             metrics,
-            &pending.source_session_key,
+            &pending.source,
             pending.source_transport_media_id,
             pending.observed_at,
         );
@@ -172,22 +192,54 @@ fn flush_pending_first_video_keyframes(
 fn request_first_video_keyframe(
     state: &mut PacketLoopState,
     metrics: &impl RtcRouteControlMetrics,
+    source: &ForwardedPacketSource,
+    transport_media_id: TransportMediaId,
+    now: Instant,
+) {
+    match source {
+        ForwardedPacketSource::Relayed(source_session_key) => {
+            request_first_video_keyframe_for_session(
+                state,
+                metrics,
+                source_session_key,
+                transport_media_id,
+                now,
+            );
+        }
+        ForwardedPacketSource::Local(session_handle) => {
+            let Some(source_session_key) = state.users.key_for_handle(*session_handle).cloned()
+            else {
+                return;
+            };
+            request_first_video_keyframe_for_session(
+                state,
+                metrics,
+                &source_session_key,
+                transport_media_id,
+                now,
+            );
+        }
+    }
+}
+
+fn request_first_video_keyframe_for_session(
+    state: &mut PacketLoopState,
+    metrics: &impl RtcRouteControlMetrics,
     source_session_key: &TransportSessionKey,
     transport_media_id: TransportMediaId,
     now: Instant,
 ) {
-    if !source_is_video(state, source_session_key, transport_media_id) {
-        return;
+    if source_is_video(state, source_session_key, transport_media_id) {
+        request_keyframe_for_source(
+            state,
+            metrics,
+            source_session_key,
+            transport_media_id,
+            None,
+            KeyframeRequestKind::Pli,
+            now,
+        );
     }
-    request_keyframe_for_source(
-        state,
-        metrics,
-        source_session_key,
-        transport_media_id,
-        None,
-        KeyframeRequestKind::Pli,
-        now,
-    );
 }
 
 fn source_is_video(
@@ -264,8 +316,6 @@ pub(in crate::runtime::rtc_engine) fn flush_forward_routes(
     buffers: &mut PacketLoopBuffers,
 ) {
     let (forwards, pending_packets) = (&buffers.forwards, &mut buffers.pending_packets);
-    buffers.relay_packet = None;
-    buffers.relay_packet_idx = None;
     for (forward_idx, forward) in forwards.iter().enumerate() {
         let is_last_destination = forwards
             .get(forward_idx + 1)
@@ -277,22 +327,6 @@ pub(in crate::runtime::rtc_engine) fn flush_forward_routes(
         let destination = forward.destination();
         let destination_kind = destination.metrics_kind();
         let payload_len = packet.payload_len();
-        let relay_packet = match destination {
-            ForwardingDestination::Relay(_) => {
-                let Some(source_transport_media_id) =
-                    packet.resolve_source_transport_media_id(state)
-                else {
-                    continue;
-                };
-                if buffers.relay_packet_idx != Some(packet_idx) {
-                    buffers.relay_packet = Some(packet.share_for_relay(source_transport_media_id));
-                    buffers.relay_packet_idx = Some(packet_idx);
-                }
-                buffers.relay_packet.as_mut()
-            }
-            ForwardingDestination::LocalRtc(_) | ForwardingDestination::PacketSink(_) => None,
-        };
-        let packet = relay_packet.unwrap_or(packet);
         match destination.send(state, packet, is_last_destination) {
             Ok(ForwardSendOutcome::LocalRtc {
                 payload_bytes: Some(payload_len),

--- a/crates/core/src/runtime/rtc_engine/packet_loop/session_drain.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/session_drain.rs
@@ -23,7 +23,10 @@ use tokio::net::UdpSocket;
 use tracing::{trace, warn};
 
 use super::{
-    super::state::{PacketLoopState, RtcSessionState, RtcSnapshotState},
+    super::{
+        slots::SessionHandle,
+        state::{PacketLoopState, RtcSessionState, RtcSnapshotState},
+    },
     buffers::PacketLoopBuffers,
     event_observation::{log_rtc_event, observe_rtc_event},
     keyframe_requests::PendingKeyframeRequest,
@@ -55,14 +58,16 @@ pub(super) fn drain_ready_sessions(
 ) {
     state.collect_ready_sessions(now, &mut buffers.ready_sessions);
     let mut ready_sessions = take(&mut buffers.ready_sessions);
-    for user_id in ready_sessions.drain(..) {
+    for session_handle in ready_sessions.drain(..) {
         let session_timeout = {
-            let Some(session_state) = state.users.get_mut(&user_id) else {
+            let Some((session_key, session_state)) =
+                state.users.get_key_value_mut_by_handle(session_handle)
+            else {
                 continue;
             };
-            drain_single_session(&user_id, session_state, context, buffers)
+            drain_single_session(session_handle, session_key, session_state, context, buffers)
         };
-        state.update_session_timeout(&user_id, session_timeout);
+        state.update_session_timeout_by_handle(session_handle, session_timeout);
     }
     buffers.ready_sessions = ready_sessions;
 }
@@ -79,6 +84,7 @@ pub(super) fn drain_ready_sessions(
 ///
 /// Returns the next timeout requested by the session, if any.
 fn drain_single_session(
+    session_handle: SessionHandle,
     session_key: &TransportSessionKey,
     session_state: &mut RtcSessionState,
     context: &SessionDrainContext<'_>,
@@ -97,7 +103,7 @@ fn drain_single_session(
             Ok(Output::Event(Event::RtpPacket(packet))) => {
                 buffers.pending_packets.push(
                     super::super::forwarded_packet::ForwardedPacket::from_rtp_packet(
-                        session_key.clone(),
+                        session_handle,
                         packet,
                     ),
                 );

--- a/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
@@ -66,9 +66,11 @@ use crate::{
             slots::ConsumerStreamHandle,
             state::{PacketLoopState, RtcSnapshotState, SharedRtcSocket},
             test_support::{
-                DebugProbe, DebugProbeRequest, sample_forwarded_packet,
+                DebugProbe, DebugProbeRequest, collect_ready_session_keys,
+                sample_already_relayed_packet, sample_forwarded_packet,
                 sample_forwarded_packet_with_audio_activity, sample_forwarded_packet_with_rid,
-                sample_forwarded_packet_without_mid, test_transport_session_key,
+                sample_forwarded_packet_without_mid, sample_local_forwarded_packet,
+                test_transport_session_key,
             },
         },
     },
@@ -76,12 +78,21 @@ use crate::{
 
 struct CountingSink {
     packets: AtomicUsize,
+    last_session: Mutex<Option<TransportSessionKey>>,
 }
 
 impl CountingSink {
     fn new() -> Self {
         Self {
             packets: AtomicUsize::new(0),
+            last_session: Mutex::new(None),
+        }
+    }
+
+    fn last_session(&self) -> Option<TransportSessionKey> {
+        match self.last_session.lock() {
+            Ok(last_session) => last_session.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
         }
     }
 }
@@ -89,12 +100,16 @@ impl CountingSink {
 impl MediaPacketSink for CountingSink {
     fn record_packet(
         &self,
-        _session_key: &TransportSessionKey,
+        session_key: &TransportSessionKey,
         _transport_media_id: TransportMediaId,
         _received_at: Instant,
         _payload: &[u8],
     ) {
         self.packets.fetch_add(1, Ordering::Relaxed);
+        match self.last_session.lock() {
+            Ok(mut last_session) => *last_session = Some(session_key.clone()),
+            Err(poisoned) => *poisoned.into_inner() = Some(session_key.clone()),
+        }
     }
 }
 
@@ -153,9 +168,7 @@ impl DebugProbe for MarkSessionDirtyProbe {
 }
 
 fn drain_ready_sessions(state: &mut PacketLoopState) -> Vec<TransportSessionKey> {
-    let mut ready_sessions = Vec::new();
-    state.collect_ready_sessions(Instant::now(), &mut ready_sessions);
-    ready_sessions
+    collect_ready_session_keys(state, Instant::now())
 }
 
 fn populate_forward_routes(
@@ -627,8 +640,12 @@ fn flush_forward_routes_records_non_local_forwarding_volume_by_destination() {
     let metrics = RuntimeMetrics::default();
     let rtp_metrics = metrics.register_rtp_worker();
     let rtc_recorder = metrics.register_rtc_worker();
-    let packet = sample_forwarded_packet(source_session, "aud-up", b"payload")
-        .share_for_relay(source_transport_media_id);
+    let packet = sample_already_relayed_packet(
+        source_session,
+        source_transport_media_id,
+        "aud-up",
+        b"payload",
+    );
 
     buffers.pending_packets.push(packet);
     buffers.forwards.push(
@@ -685,6 +702,59 @@ fn flush_forward_routes_records_non_local_forwarding_volume_by_destination() {
 }
 
 #[test]
+fn flush_forward_routes_records_packet_sink_source_key_for_local_packet() {
+    let source_session = test_transport_session_key(130, 0, 131, UserId::Integer(132));
+    let source_transport_media_id = TransportMediaId::new(133);
+    let mut state = PacketLoopState::default();
+    assert!(
+        bootstrap::ensure_session_rtc_state(
+            &mut state.users,
+            &source_session,
+            SocketAddr::from(([127, 0, 0, 1], 9)),
+            Bitrate::from_mbps(10),
+            MediaCodecFlags::default(),
+        )
+        .is_ok()
+    );
+    let source_handle = state.users.handle_for_key(&source_session);
+    assert!(source_handle.is_some());
+    let Some(source_handle) = source_handle else {
+        return;
+    };
+    let sink = Arc::new(CountingSink::new());
+    let mut buffers = PacketLoopBuffers::new();
+    let metrics = RuntimeMetrics::default();
+    let rtp_metrics = metrics.register_rtp_worker();
+    let rtc_recorder = metrics.register_rtc_worker();
+
+    buffers.pending_packets.push(sample_local_forwarded_packet(
+        source_handle,
+        "aud-up",
+        b"payload",
+    ));
+    buffers.forwards.push(
+        super::super::forwarding_destination::PacketForward::from_packet_sink(
+            0,
+            source_transport_media_id,
+            RegisteredPacketSink::new(
+                into_packet_sink(Arc::<CountingSink>::clone(&sink)),
+                RtpForwardDestinationKind::Recording,
+            ),
+        ),
+    );
+
+    flush_forward_routes(
+        &mut state,
+        &metrics,
+        &rtp_metrics,
+        &rtc_recorder,
+        &mut buffers,
+    );
+
+    assert_eq!(sink.last_session(), Some(source_session));
+}
+
+#[test]
 fn flush_forward_routes_records_closed_relays_and_keeps_later_destinations() {
     let source_session = test_transport_session_key(119, 0, 120, UserId::Integer(121));
     let source_transport_media_id = TransportMediaId::new(122);
@@ -695,8 +765,12 @@ fn flush_forward_routes_records_closed_relays_and_keeps_later_destinations() {
     let metrics = RuntimeMetrics::default();
     let rtp_metrics = metrics.register_rtp_worker();
     let rtc_recorder = metrics.register_rtc_worker();
-    let packet = sample_forwarded_packet(source_session, "aud-up", b"payload")
-        .share_for_relay(source_transport_media_id);
+    let packet = sample_already_relayed_packet(
+        source_session,
+        source_transport_media_id,
+        "aud-up",
+        b"payload",
+    );
 
     drop(relay_rx);
     buffers.pending_packets.push(packet);
@@ -802,7 +876,6 @@ fn flush_forward_routes_marks_local_consumer_sessions_dirty() {
     );
 
     assert_eq!(drain_ready_sessions(&mut state), vec![consumer_session]);
-    assert!(buffers.relay_packet_idx.is_none());
     assert_eq!(metrics.snapshot().rtp_forwarded_packets_local_rtc(), 1);
 }
 
@@ -895,14 +968,12 @@ fn packet_loop_dirty_marks_are_unique_until_the_session_is_drained() {
     );
     state.mark_session_dirty(&session);
     state.mark_session_dirty(&session);
-    let mut ready_sessions = Vec::new();
-    state.collect_ready_sessions(now, &mut ready_sessions);
+    let ready_sessions = collect_ready_session_keys(&mut state, now);
 
     assert_eq!(ready_sessions, vec![session.clone()]);
 
-    ready_sessions.clear();
     state.mark_session_dirty(&session);
-    state.collect_ready_sessions(now, &mut ready_sessions);
+    let ready_sessions = collect_ready_session_keys(&mut state, now);
 
     assert_eq!(ready_sessions, vec![session]);
 }
@@ -1205,7 +1276,11 @@ fn drain_relay_packets_ingests_owned_forwarded_packets_from_the_mailbox() {
     let metrics = RuntimeMetrics::default();
     let rtc_metrics = metrics.register_rtc_worker();
 
-    mailbox.forward_packet(&packet, TransportMediaId::new(17));
+    mailbox.forward_packet(
+        &PacketLoopState::default(),
+        &packet,
+        TransportMediaId::new(17),
+    );
     drain_relay_packets(
         &mut relay_rx,
         &mut pending_packets,
@@ -1219,7 +1294,10 @@ fn drain_relay_packets_ingests_owned_forwarded_packets_from_the_mailbox() {
     let Some(forwarded) = forwarded else {
         return;
     };
-    assert_eq!(forwarded.source_session_key(), &source_session);
+    assert_eq!(
+        forwarded.source_session_key(&PacketLoopState::default()),
+        Some(&source_session)
+    );
     assert_eq!(forwarded.payload(), b"payload");
     assert_eq!(
         forwarded.resolve_source_transport_media_id(&PacketLoopState::default()),
@@ -1237,8 +1315,16 @@ fn drain_relay_packets_stops_at_the_configured_cap() {
     let metrics = RuntimeMetrics::default();
     let rtc_metrics = metrics.register_rtc_worker();
 
-    mailbox.forward_packet(&packet, TransportMediaId::new(18));
-    mailbox.forward_packet(&packet, TransportMediaId::new(18));
+    mailbox.forward_packet(
+        &PacketLoopState::default(),
+        &packet,
+        TransportMediaId::new(18),
+    );
+    mailbox.forward_packet(
+        &PacketLoopState::default(),
+        &packet,
+        TransportMediaId::new(18),
+    );
 
     let drained = drain_relay_packets(&mut relay_rx, &mut pending_packets, 1, &rtc_metrics);
 
@@ -1261,10 +1347,15 @@ fn flush_forward_routes_records_relay_overload_drops() {
     let metrics = RuntimeMetrics::default();
     let rtp_metrics = metrics.register_rtp_worker();
     let rtc_recorder = metrics.register_rtc_worker();
-    let packet = sample_forwarded_packet(source_session, "aud-up", b"payload")
-        .share_for_relay(source_transport_media_id);
+    let packet = sample_already_relayed_packet(
+        source_session,
+        source_transport_media_id,
+        "aud-up",
+        b"payload",
+    );
 
     relay_mailbox.forward_packet(
+        &state,
         &sample_forwarded_packet(
             test_transport_session_key(29, 0, 30, UserId::Integer(31)),
             "aud-up",

--- a/crates/core/src/runtime/rtc_engine/relay_registry/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/relay_registry/mod.rs
@@ -62,10 +62,11 @@ impl RelayPacketMailbox {
 
     pub(super) fn forward_packet(
         &self,
+        state: &PacketLoopState,
         packet: &ForwardedPacket,
         source_transport_media_id: TransportMediaId,
-    ) -> RelayEnqueueOutcome {
-        forward_packet_to_target(&self.tx, packet, source_transport_media_id)
+    ) -> Option<RelayEnqueueOutcome> {
+        forward_packet_to_target(state, &self.tx, packet, source_transport_media_id)
     }
 
     pub(super) fn backlog_depth(&self) -> usize {
@@ -76,16 +77,6 @@ impl RelayPacketMailbox {
 #[derive(Debug, Clone)]
 pub(super) struct InterNodeRelaySender {
     tx: mpsc::Sender<ForwardedPacket>,
-}
-
-impl InterNodeRelaySender {
-    pub(super) fn forward_packet(
-        &self,
-        packet: &ForwardedPacket,
-        source_transport_media_id: TransportMediaId,
-    ) -> RelayEnqueueOutcome {
-        forward_packet_to_target(&self.tx, packet, source_transport_media_id)
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -135,20 +126,25 @@ impl From<InterNodeRelaySender> for RelayTargetTransport {
 impl RelayTargetTransport {
     pub(super) fn forward_packet(
         &self,
+        state: &PacketLoopState,
         packet: &ForwardedPacket,
         source_transport_media_id: TransportMediaId,
-    ) -> RelayEnqueueReport {
+    ) -> Option<RelayEnqueueReport> {
         match self {
-            Self::IntraNodeMailbox(mailbox) => RelayEnqueueReport::new(
-                RelayTargetKind::IntraNode,
-                mailbox.forward_packet(packet, source_transport_media_id),
-                Some(mailbox.backlog_depth()),
-            ),
-            Self::InterNodeSender(sender) => RelayEnqueueReport::new(
-                RelayTargetKind::InterNode,
-                sender.forward_packet(packet, source_transport_media_id),
-                None,
-            ),
+            Self::IntraNodeMailbox(mailbox) => mailbox
+                .forward_packet(state, packet, source_transport_media_id)
+                .map(|outcome| {
+                    RelayEnqueueReport::new(
+                        RelayTargetKind::IntraNode,
+                        outcome,
+                        Some(mailbox.backlog_depth()),
+                    )
+                }),
+            Self::InterNodeSender(sender) => {
+                forward_packet_to_target(state, &sender.tx, packet, source_transport_media_id).map(
+                    |outcome| RelayEnqueueReport::new(RelayTargetKind::InterNode, outcome, None),
+                )
+            }
         }
     }
 
@@ -161,15 +157,17 @@ impl RelayTargetTransport {
 }
 
 fn forward_packet_to_target(
+    state: &PacketLoopState,
     tx: &mpsc::Sender<ForwardedPacket>,
     packet: &ForwardedPacket,
     source_transport_media_id: TransportMediaId,
-) -> RelayEnqueueOutcome {
-    match tx.try_send(packet.share_for_relay(source_transport_media_id)) {
+) -> Option<RelayEnqueueOutcome> {
+    let packet = packet.share_for_relay(state, source_transport_media_id)?;
+    Some(match tx.try_send(packet) {
         Ok(()) => RelayEnqueueOutcome::Enqueued,
         Err(mpsc::error::TrySendError::Full(_packet)) => RelayEnqueueOutcome::Overloaded,
         Err(mpsc::error::TrySendError::Closed(_packet)) => RelayEnqueueOutcome::Closed,
-    }
+    })
 }
 
 pub(super) fn sender_backlog_depth<T>(tx: &mpsc::Sender<T>) -> usize {

--- a/crates/core/src/runtime/rtc_engine/relay_registry/test_support.rs
+++ b/crates/core/src/runtime/rtc_engine/relay_registry/test_support.rs
@@ -4,7 +4,7 @@ use {
         ActiveRelayTarget, ForwardedPacket, InterNodeRelaySender, RELAY_MAILBOX_CAPACITY,
         RelayEnqueueOutcome, RelayPacketMailbox,
     },
-    crate::runtime::media_transport::TransportMediaId,
+    crate::runtime::{media_transport::TransportMediaId, rtc_engine::state::PacketLoopState},
     tokio::sync::mpsc,
 };
 
@@ -40,11 +40,12 @@ impl InterNodeRelaySender {
 impl ActiveRelayTarget {
     pub fn forward_packet(
         &self,
+        state: &PacketLoopState,
         packet: &ForwardedPacket,
         source_transport_media_id: TransportMediaId,
-    ) -> RelayEnqueueOutcome {
+    ) -> Option<RelayEnqueueOutcome> {
         self.target()
-            .forward_packet(packet, source_transport_media_id)
-            .outcome()
+            .forward_packet(state, packet, source_transport_media_id)
+            .map(super::RelayEnqueueReport::outcome)
     }
 }

--- a/crates/core/src/runtime/rtc_engine/slots.rs
+++ b/crates/core/src/runtime/rtc_engine/slots.rs
@@ -287,6 +287,16 @@ impl<K: Ord + Clone, V, Tag> KeyedSlotStore<K, V, Tag> {
     pub(super) fn get_mut_by_handle(&mut self, handle: SlotHandle<Tag>) -> Option<&mut V> {
         self.slots.get_mut(handle).map(|entry| &mut entry.value)
     }
+
+    /// mutably read by handle while borrowing the matching public key
+    pub(super) fn get_key_value_mut_by_handle(
+        &mut self,
+        handle: SlotHandle<Tag>,
+    ) -> Option<(&K, &mut V)> {
+        self.slots
+            .get_mut(handle)
+            .map(|entry| (&entry.key, &mut entry.value))
+    }
 }
 
 fn next_generation(generation: u64) -> u64 {

--- a/crates/core/src/runtime/rtc_engine/state/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/state/mod.rs
@@ -253,15 +253,12 @@ impl PacketLoopState {
     pub(super) fn collect_ready_sessions(
         &mut self,
         now: Instant,
-        ready_sessions: &mut Vec<TransportSessionKey>,
+        ready_sessions: &mut Vec<SessionHandle>,
     ) {
         for session_handle in self.dirty_sessions.drain(..) {
-            let Some(session_key) = self.users.key_for_handle(session_handle).cloned() else {
-                continue;
-            };
             if let Some(session_state) = self.users.get_mut_by_handle(session_handle) {
                 session_state.packet_loop_dirty = false;
-                ready_sessions.push(session_key);
+                ready_sessions.push(session_handle);
             }
         }
         let session_timeouts = &mut self.session_timeouts;
@@ -273,8 +270,8 @@ impl PacketLoopState {
         ) {
             if session_timeouts.get(&session_handle).copied() == Some(deadline) {
                 session_timeouts.remove(&session_handle);
-                if let Some(ready_session_key) = users.key_for_handle(session_handle).cloned() {
-                    ready_sessions.push(ready_session_key);
+                if users.key_for_handle(session_handle).is_some() {
+                    ready_sessions.push(session_handle);
                 }
             }
         }
@@ -282,11 +279,27 @@ impl PacketLoopState {
         ready_sessions.dedup();
     }
 
-    /// replace the next `str0m` timeout deadline for one session
+    /// replace the next `str0m` timeout deadline by worker-local handle
     ///
-    /// old heap entries are left in place and invalidated by
-    /// [`Self::session_timeouts`]
-    /// this keeps updates `O(log n)` without needing arbitrary heap removal
+    /// stale handles are ignored because the session has already left this
+    /// worker or the slot now belongs to a later generation
+    pub(super) fn update_session_timeout_by_handle(
+        &mut self,
+        session_handle: SessionHandle,
+        next_timeout: Option<Instant>,
+    ) {
+        if self.users.key_for_handle(session_handle).is_none() {
+            return;
+        }
+        self.session_timeouts.remove(&session_handle);
+        if let Some(next_timeout) = next_timeout {
+            self.session_timeouts.insert(session_handle, next_timeout);
+            self.timeout_queue
+                .push(Reverse((next_timeout, session_handle)));
+        }
+    }
+
+    #[cfg(test)]
     pub(super) fn update_session_timeout(
         &mut self,
         session_key: &TransportSessionKey,
@@ -295,12 +308,7 @@ impl PacketLoopState {
         let Some(session_handle) = self.users.handle_for_key(session_key) else {
             return;
         };
-        self.session_timeouts.remove(&session_handle);
-        if let Some(next_timeout) = next_timeout {
-            self.session_timeouts.insert(session_handle, next_timeout);
-            self.timeout_queue
-                .push(Reverse((next_timeout, session_handle)));
-        }
+        self.update_session_timeout_by_handle(session_handle, next_timeout);
     }
 
     /// return the earliest live `str0m` timeout deadline

--- a/crates/core/src/runtime/rtc_engine/test_support.rs
+++ b/crates/core/src/runtime/rtc_engine/test_support.rs
@@ -5,6 +5,9 @@ mod probe;
 #[path = "test_support/route_graph.rs"]
 mod route_graph;
 
+#[cfg(test)]
+use std::time::Instant;
+
 #[cfg(any(test, feature = "testing-transport"))]
 pub use probe::DebugRouteEntry;
 #[cfg(test)]
@@ -29,12 +32,26 @@ pub(in crate::runtime::rtc_engine) use route_graph::MediaWorkerScenario;
 #[cfg(any(test, feature = "internal-benchmarks"))]
 pub use super::forwarded_packet::test_support::sample_forwarded_packet;
 #[cfg(test)]
-pub use super::forwarded_packet::test_support::{
-    sample_forwarded_packet_with_audio_activity, sample_forwarded_packet_with_frame_mark,
-    sample_forwarded_packet_with_rid, sample_forwarded_packet_without_mid,
+pub(in crate::runtime::rtc_engine) use super::forwarded_packet::test_support::{
+    sample_already_relayed_packet, sample_forwarded_packet_with_audio_activity,
+    sample_forwarded_packet_with_frame_mark, sample_forwarded_packet_with_rid,
+    sample_forwarded_packet_without_mid, sample_local_forwarded_packet,
 };
 #[cfg(any(test, feature = "internal-benchmarks"))]
 use crate::runtime::{ConnectionId, RoomInstanceId, UserId, media_transport::TransportSessionKey};
+
+#[cfg(test)]
+pub(in crate::runtime::rtc_engine) fn collect_ready_session_keys(
+    state: &mut super::state::PacketLoopState,
+    now: Instant,
+) -> Vec<TransportSessionKey> {
+    let mut ready_handles = Vec::new();
+    state.collect_ready_sessions(now, &mut ready_handles);
+    ready_handles
+        .into_iter()
+        .filter_map(|session_handle| state.users.key_for_handle(session_handle).cloned())
+        .collect()
+}
 
 #[cfg(any(test, feature = "internal-benchmarks"))]
 #[must_use]

--- a/crates/core/src/runtime/rtc_engine/tests/forwarding_planner_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/forwarding_planner_tests.rs
@@ -26,8 +26,9 @@ use crate::runtime::{
         route_control::{PacketLayerGate, PacketOperatingPointGate},
         state::PacketLoopState,
         test_support::{
-            MediaWorkerScenario, sample_forwarded_packet, sample_forwarded_packet_with_frame_mark,
-            sample_forwarded_packet_with_rid, test_transport_session_key,
+            MediaWorkerScenario, sample_already_relayed_packet, sample_forwarded_packet,
+            sample_forwarded_packet_with_frame_mark, sample_forwarded_packet_with_rid,
+            test_transport_session_key,
         },
     },
 };
@@ -320,12 +321,13 @@ fn populate_forward_routes_keeps_relay_packets_out_of_recording_and_second_hop_r
         relay_mailbox.into(),
     );
     state.set_relay_target_active(source_transport_media_id, RelayTargetId::new(1), true);
-    let pending_packets = vec![
-        sample_forwarded_packet(producer_session, "aud-up", b"payload")
-            .share_for_relay(source_transport_media_id),
-    ];
+    let mut pending_packets = vec![sample_already_relayed_packet(
+        producer_session,
+        source_transport_media_id,
+        "aud-up",
+        b"payload",
+    )];
     let mut forwards = Vec::new();
-    let mut pending_packets = pending_packets;
 
     populate_forward_routes(
         &state,

--- a/crates/core/src/runtime/rtc_engine/tests/packet_loop_state_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/packet_loop_state_tests.rs
@@ -1,11 +1,8 @@
 use super::fixtures::*;
-use crate::runtime::rtc_engine::{bootstrap::ensure_session_rtc_state, state::PacketLoopState};
-
-fn collect_ready_sessions(state: &mut PacketLoopState, now: Instant) -> Vec<TransportSessionKey> {
-    let mut ready_sessions = Vec::new();
-    state.collect_ready_sessions(now, &mut ready_sessions);
-    ready_sessions
-}
+use crate::runtime::rtc_engine::{
+    bootstrap::ensure_session_rtc_state, state::PacketLoopState,
+    test_support::collect_ready_session_keys,
+};
 
 fn insert_live_session(state: &mut PacketLoopState, session_key: &TransportSessionKey) {
     assert!(matches!(
@@ -94,7 +91,7 @@ fn packet_loop_state_tracks_dirty_and_timed_out_sessions_separately() {
 
     assert_eq!(state.next_timeout_deadline(), Some(first_timeout));
 
-    let ready_sessions = collect_ready_sessions(&mut state, now + Duration::from_millis(25));
+    let ready_sessions = collect_ready_session_keys(&mut state, now + Duration::from_millis(25));
     assert!(ready_sessions.contains(&first_session_key));
     assert!(ready_sessions.contains(&second_session_key));
     assert_eq!(ready_sessions.len(), 2);
@@ -115,7 +112,7 @@ fn packet_loop_state_prefers_latest_session_timeout_deadline() {
 
     assert_eq!(state.next_timeout_deadline(), Some(updated_timeout));
 
-    let ready_sessions = collect_ready_sessions(&mut state, now + Duration::from_millis(15));
+    let ready_sessions = collect_ready_session_keys(&mut state, now + Duration::from_millis(15));
     assert_eq!(ready_sessions.len(), 1);
     assert!(ready_sessions.contains(&session_key));
     assert_eq!(state.next_timeout_deadline(), None);
@@ -132,7 +129,7 @@ fn packet_loop_state_deduplicates_repeated_dirty_session_marks_on_drain() {
     state.mark_session_dirty(&session_key);
     state.update_session_timeout(&session_key, Some(now));
 
-    let ready_sessions = collect_ready_sessions(&mut state, now);
+    let ready_sessions = collect_ready_session_keys(&mut state, now);
 
     assert_eq!(ready_sessions, vec![session_key]);
     assert!(!state.has_dirty_sessions());
@@ -152,7 +149,7 @@ fn packet_loop_state_clears_all_dirty_duplicates_for_removed_session() {
     state.mark_session_dirty(&removed_session_key);
     state.clear_session_schedule(&removed_session_key);
 
-    let ready_sessions = collect_ready_sessions(&mut state, now);
+    let ready_sessions = collect_ready_session_keys(&mut state, now);
 
     assert_eq!(ready_sessions, vec![retained_session_key]);
 }
@@ -167,7 +164,7 @@ fn packet_loop_state_ignores_stale_dirty_handle_after_session_replacement() {
     state.mark_session_dirty(&session_key);
     replace_live_session(&mut state, &session_key);
 
-    let ready_sessions = collect_ready_sessions(&mut state, now);
+    let ready_sessions = collect_ready_session_keys(&mut state, now);
 
     assert!(ready_sessions.is_empty());
 }
@@ -182,7 +179,7 @@ fn packet_loop_state_ignores_stale_timeout_handle_after_session_replacement() {
     state.update_session_timeout(&session_key, Some(now + Duration::from_millis(10)));
     replace_live_session(&mut state, &session_key);
 
-    let ready_sessions = collect_ready_sessions(&mut state, now + Duration::from_millis(11));
+    let ready_sessions = collect_ready_session_keys(&mut state, now + Duration::from_millis(11));
 
     assert!(ready_sessions.is_empty());
     assert_eq!(state.next_timeout_deadline(), None);

--- a/crates/core/src/runtime/rtc_engine/tests/relay_registry_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/relay_registry_tests.rs
@@ -50,7 +50,7 @@ fn worker_local_relay_targets_forward_packets_through_registered_mailboxes() {
     if let Some(relay_targets) = relay_targets {
         assert_eq!(relay_targets.len(), 1);
         if let Some(relay_target) = relay_targets.first() {
-            relay_target.forward_packet(&packet, source_transport_media_id);
+            relay_target.forward_packet(&state, &packet, source_transport_media_id);
         }
     }
 
@@ -92,7 +92,7 @@ fn worker_local_relay_targets_keep_multiple_target_mailboxes_per_source() {
     if let Some(relay_targets) = relay_targets {
         assert_eq!(relay_targets.len(), 2);
         for relay_target in relay_targets {
-            relay_target.forward_packet(&packet, source_transport_media_id);
+            relay_target.forward_packet(&state, &packet, source_transport_media_id);
         }
     }
 
@@ -248,7 +248,7 @@ fn worker_local_relay_targets_forward_packets_through_registered_inter_node_targ
     let Some(relay_target) = relay_targets.first() else {
         return;
     };
-    relay_target.forward_packet(&packet, source_transport_media_id);
+    relay_target.forward_packet(&state, &packet, source_transport_media_id);
 
     let forwarded = relay_rx.try_recv().ok();
     assert!(forwarded.is_some());
@@ -270,11 +270,19 @@ fn worker_local_relay_targets_report_overload_when_a_bounded_mailbox_is_full() {
     let packet = sample_forwarded_packet(session_key, "aud-up", b"payload");
 
     assert_eq!(
-        mailbox.forward_packet(&packet, source_transport_media_id),
-        RelayEnqueueOutcome::Enqueued
+        mailbox.forward_packet(
+            &PacketLoopState::default(),
+            &packet,
+            source_transport_media_id
+        ),
+        Some(RelayEnqueueOutcome::Enqueued)
     );
     assert_eq!(
-        mailbox.forward_packet(&packet, source_transport_media_id),
-        RelayEnqueueOutcome::Overloaded
+        mailbox.forward_packet(
+            &PacketLoopState::default(),
+            &packet,
+            source_transport_media_id
+        ),
+        Some(RelayEnqueueOutcome::Overloaded)
     );
 }

--- a/crates/core/src/runtime/rtc_engine/worker/handlers/media/tests.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/handlers/media/tests.rs
@@ -45,15 +45,15 @@ use crate::{
             relay_registry::{RelayPacketMailbox, RelayTargetId},
             route_control::{KeyframeRequestDecision, PacketLayerGate},
             state::PacketLoopState,
-            test_support::{MediaWorkerScenario, test_transport_session_key},
+            test_support::{
+                MediaWorkerScenario, collect_ready_session_keys, test_transport_session_key,
+            },
         },
     },
 };
 
 fn drain_ready_sessions(state: &mut PacketLoopState) -> Vec<TransportSessionKey> {
-    let mut ready_sessions = Vec::new();
-    state.collect_ready_sessions(Instant::now(), &mut ready_sessions);
-    ready_sessions
+    collect_ready_session_keys(state, Instant::now())
 }
 
 fn prepare_source_session(


### PR DESCRIPTION
local RTP forwading stored an owned TransportSessionKey in ForwardedPacket

that forced Event::RtpPacket to clone the Arc-backed user id on every local packet

this change make local forwarded pakets carry SessionHandle values across the worker-local packet path relay promotion, packet sinks and coalesced control effects resolve stable keys only at their side-effect boundaries relay packets still carry owned TransportSessionKey values so mailbox semantics do not change

the packet loop now stages ready sessions by handle forwarded packet source resolution lives on ForwardedPacketSource relay enqueue promotes at the relay send boundary without a duplicate scratch relay packet

performance:

the normal local RTP path no loger increments or decrements the Arc<UserId> refcount while staging ForwardedPacket dynamic SSRC binding updates existing session media through borrowed keys and does not clone the user id for unchanged bindings relay fanout materialises owned packet identity only at enqueue boundaries