### PR TITLE
[FIX] core: avoid redundant active-audio policy wakes

### DIFF
--- a/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
@@ -1250,6 +1250,118 @@ fn silent_audio_packets_are_dropped_from_routed_fanout_after_transport_activity_
 }
 
 #[test]
+fn repeated_active_audio_packets_do_not_republish_source_policy_dirty_room() {
+    let producer_session = test_transport_session_key(39, 0, 40, UserId::Integer(41));
+    let room_instance_id = producer_session.room_instance_id();
+    let mut state = PacketLoopState::default();
+    state.register_media_handle(RegisteredMediaHandle::Producer {
+        session_key: producer_session.clone(),
+        mid: Mid::from("aud-up"),
+    });
+    let metrics = RuntimeMetrics::default();
+    let rtp_metrics = metrics.register_rtp_worker();
+    let source_policy_signal = SourcePolicySignal::default();
+    let subscription = source_policy_signal.subscribe();
+    let mut buffers = PacketLoopBuffers::new();
+
+    buffers
+        .pending_packets
+        .push(sample_forwarded_packet_with_audio_activity(
+            producer_session.clone(),
+            "aud-up",
+            Some(true),
+            Some(-30),
+            b"payload",
+        ));
+    record_incoming_stats(
+        &mut state,
+        &source_policy_signal,
+        &metrics,
+        &rtp_metrics,
+        &mut buffers,
+    );
+    assert_eq!(
+        subscription.take_pending_updates(),
+        BTreeSet::from([room_instance_id])
+    );
+
+    buffers.clear();
+    buffers
+        .pending_packets
+        .push(sample_forwarded_packet_with_audio_activity(
+            producer_session,
+            "aud-up",
+            Some(true),
+            Some(-30),
+            b"payload",
+        ));
+    record_incoming_stats(
+        &mut state,
+        &source_policy_signal,
+        &metrics,
+        &rtp_metrics,
+        &mut buffers,
+    );
+    assert!(subscription.take_pending_updates().is_empty());
+}
+
+#[test]
+fn active_audio_rank_change_publishes_source_policy_dirty_room() {
+    let first_producer_session = test_transport_session_key(42, 0, 43, UserId::Integer(44));
+    let second_producer_session = test_transport_session_key(42, 0, 45, UserId::Integer(46));
+    let room_instance_id = first_producer_session.room_instance_id();
+    let mut state = PacketLoopState::default();
+    let first_transport_media_id = state.register_media_handle(RegisteredMediaHandle::Producer {
+        session_key: first_producer_session.clone(),
+        mid: Mid::from("aud-first"),
+    });
+    let second_transport_media_id = state.register_media_handle(RegisteredMediaHandle::Producer {
+        session_key: second_producer_session,
+        mid: Mid::from("aud-second"),
+    });
+    let shared_observed_at = Instant::now();
+    assert!(state.route_control.observe_audio_activity(
+        first_transport_media_id,
+        Some(true),
+        Some(-30),
+        shared_observed_at,
+    ));
+    assert!(state.route_control.observe_audio_activity(
+        second_transport_media_id,
+        Some(true),
+        Some(-10),
+        shared_observed_at,
+    ));
+    let metrics = RuntimeMetrics::default();
+    let rtp_metrics = metrics.register_rtp_worker();
+    let source_policy_signal = SourcePolicySignal::default();
+    let subscription = source_policy_signal.subscribe();
+    let mut buffers = PacketLoopBuffers::new();
+
+    buffers
+        .pending_packets
+        .push(sample_forwarded_packet_with_audio_activity(
+            first_producer_session,
+            "aud-first",
+            Some(true),
+            Some(-1),
+            b"payload",
+        ));
+    record_incoming_stats(
+        &mut state,
+        &source_policy_signal,
+        &metrics,
+        &rtp_metrics,
+        &mut buffers,
+    );
+
+    assert_eq!(
+        subscription.take_pending_updates(),
+        BTreeSet::from([room_instance_id])
+    );
+}
+
+#[test]
 fn packet_loop_buffers_coalesce_source_policy_dirty_rooms_before_signal_flush() {
     let mut buffers = PacketLoopBuffers::new();
     let signal = SourcePolicySignal::default();

--- a/crates/core/src/runtime/rtc_engine/route_control/state.rs
+++ b/crates/core/src/runtime/rtc_engine/route_control/state.rs
@@ -17,7 +17,11 @@
 //! active-speaker audio policy is intersected afterward because a silent source
 //! policy must be able to block every downstream route
 
-use std::{cmp::Reverse, collections::BTreeMap, time::Instant};
+use std::{
+    cmp::Reverse,
+    collections::{BTreeMap, btree_map::Entry},
+    time::Instant,
+};
 
 use str0m::media::Rid;
 use tracing::debug;
@@ -127,7 +131,7 @@ impl RouteControlState {
                 .insert(source_transport_media_id, source_control);
             debug!(
                 ?source_transport_media_id,
-                effective_packet_gate = ?self.effective_packet_gate_for_log(source_transport_media_id),
+                effective_packet_gate = ?self.effective_packet_gate_for_source(source_transport_media_id),
                 "updated source packet gate"
             );
             return;
@@ -137,7 +141,7 @@ impl RouteControlState {
         }
         debug!(
             ?source_transport_media_id,
-            effective_packet_gate = ?self.effective_packet_gate_for_log(source_transport_media_id),
+            effective_packet_gate = ?self.effective_packet_gate_for_source(source_transport_media_id),
             "updated source packet gate"
         );
     }
@@ -155,31 +159,37 @@ impl RouteControlState {
         audio_level_dbov: Option<i8>,
         now: Instant,
     ) -> bool {
-        let should_remove =
-            if let Some(source_control) = self.sources.get_mut(&source_transport_media_id) {
-                if !source_control.observe_audio_activity(voice_activity, audio_level_dbov, now) {
-                    return false;
-                }
-                source_control.is_empty()
-            } else {
-                if voice_activity.is_none() && audio_level_dbov.is_none() {
-                    return false;
-                }
-                let mut source_control = SourceRouteControl::default();
-                if !source_control.observe_audio_activity(voice_activity, audio_level_dbov, now) {
-                    return false;
-                }
-                if source_control.is_empty() {
-                    return false;
-                }
-                self.sources
-                    .insert(source_transport_media_id, source_control);
-                return true;
-            };
+        if let Entry::Vacant(entry) = self.sources.entry(source_transport_media_id) {
+            if voice_activity.is_none() && audio_level_dbov.is_none() {
+                return false;
+            }
+            let mut source_control = SourceRouteControl::default();
+            if !source_control.observe_audio_activity(voice_activity, audio_level_dbov, now) {
+                return false;
+            }
+            if source_control.is_empty() {
+                return false;
+            }
+            entry.insert(source_control);
+            return true;
+        }
+        let previous_active_speakers = self.room_policy_ranked_active_speaker_sources(now);
+        let previous_packet_gate = self.effective_packet_gate_for_source(source_transport_media_id);
+        let Some(source_control) = self.sources.get_mut(&source_transport_media_id) else {
+            return false;
+        };
+        if !source_control.observe_audio_activity(voice_activity, audio_level_dbov, now) {
+            return false;
+        }
+        let should_remove = source_control.is_empty();
         if should_remove {
             self.sources.remove(&source_transport_media_id);
         }
-        true
+        previous_packet_gate != self.effective_packet_gate_for_source(source_transport_media_id)
+            || !same_active_speaker_order(
+                &previous_active_speakers,
+                &self.room_policy_ranked_active_speaker_sources(now),
+            )
     }
 
     /// installs the packet gate requested by one relay target
@@ -256,19 +266,34 @@ impl RouteControlState {
     /// returns active-speaker sources currently inside their hold window
     ///
     /// results are ordered by most recent speech observation first
-    /// transport media id is used as a deterministic tie-breaker so room policy
-    /// sees stable ordering when packets share the same timestamp
+    /// transport media id is used as a deterministic tie-breaker so transport
+    /// snapshots stay stable when packets share the same timestamp
     pub fn active_speaker_sources(&self, now: Instant) -> Vec<ActiveSpeakerSource> {
-        let mut sources = self
-            .sources
+        let mut sources = self.active_speaker_sources_unsorted(now);
+        sources.sort_unstable_by_key(|source| {
+            (
+                Reverse(source.observed_at()),
+                source.transport_media_id().as_u64(),
+            )
+        });
+        sources
+    }
+
+    fn active_speaker_sources_unsorted(&self, now: Instant) -> Vec<ActiveSpeakerSource> {
+        self.sources
             .iter()
             .filter_map(|(source_transport_media_id, source_control)| {
                 source_control.active_speaker_source(*source_transport_media_id, now)
             })
-            .collect::<Vec<_>>();
-        sources.sort_by_key(|source| {
+            .collect()
+    }
+
+    fn room_policy_ranked_active_speaker_sources(&self, now: Instant) -> Vec<ActiveSpeakerSource> {
+        let mut sources = self.active_speaker_sources_unsorted(now);
+        sources.sort_unstable_by_key(|source| {
             (
                 Reverse(source.observed_at()),
+                Reverse(source.last_audio_level_dbov().unwrap_or(i8::MIN)),
                 source.transport_media_id().as_u64(),
             )
         });
@@ -341,13 +366,11 @@ impl RouteControlState {
         &self,
         source_transport_media_id: TransportMediaId,
     ) -> Option<PacketLayerGate> {
-        self.sources
-            .get(&source_transport_media_id)
-            .and_then(SourceRouteControl::effective_packet_gate)
+        self.effective_packet_gate_for_source(source_transport_media_id)
     }
 
-    /// computes the gate shown in route-control update logs
-    fn effective_packet_gate_for_log(
+    /// computes the gate installed for one route-control source
+    fn effective_packet_gate_for_source(
         &self,
         source_transport_media_id: TransportMediaId,
     ) -> Option<PacketLayerGate> {
@@ -355,6 +378,12 @@ impl RouteControlState {
             .get(&source_transport_media_id)
             .and_then(SourceRouteControl::effective_packet_gate)
     }
+}
+
+fn same_active_speaker_order(left: &[ActiveSpeakerSource], right: &[ActiveSpeakerSource]) -> bool {
+    left.iter()
+        .map(|source| source.transport_media_id())
+        .eq(right.iter().map(|source| source.transport_media_id()))
 }
 
 /// all route-control state known for one source media id

--- a/crates/core/src/runtime/rtc_engine/tests/route_control_state_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/route_control_state_tests.rs
@@ -13,6 +13,14 @@ use crate::runtime::media_transport::{
     ActiveSpeakerActivityReason, ActiveSpeakerActivityState, ActiveSpeakerSource, TransportMediaId,
 };
 
+fn active_speaker_ids(state: &RouteControlState, now: Instant) -> Vec<TransportMediaId> {
+    state
+        .active_speaker_sources(now)
+        .into_iter()
+        .map(ActiveSpeakerSource::transport_media_id)
+        .collect()
+}
+
 #[test]
 fn route_control_absorbs_repeated_keyframe_requests_within_the_window() {
     let mut state = RouteControlState::default();
@@ -213,7 +221,7 @@ fn route_control_vad_true_promotes_active_speaker_immediately() {
     let source_transport_media_id = TransportMediaId::new(28);
     let now = Instant::now();
 
-    state.observe_audio_activity(source_transport_media_id, Some(true), Some(-90), now);
+    assert!(state.observe_audio_activity(source_transport_media_id, Some(true), Some(-90), now));
 
     let snapshot = state.active_speaker_sources(now);
     assert_eq!(snapshot.len(), 1);
@@ -238,6 +246,111 @@ fn route_control_vad_true_promotes_active_speaker_immediately() {
         diagnostics.first().map(|diagnostic| diagnostic.reason()),
         Some(ActiveSpeakerActivityReason::Vad)
     );
+}
+
+#[test]
+fn route_control_vad_true_refresh_extends_deadline_without_dirtying_room_policy() {
+    let mut state = RouteControlState::default();
+    let source_transport_media_id = TransportMediaId::new(33);
+    let now = Instant::now();
+
+    assert!(state.observe_audio_activity(source_transport_media_id, Some(true), None, now));
+    let first_deadline = state.next_active_speaker_deadline(now).unwrap();
+    let refresh_at = now + Duration::from_millis(20);
+
+    assert!(!state.observe_audio_activity(source_transport_media_id, Some(true), None, refresh_at));
+    assert_eq!(
+        state.next_active_speaker_deadline(refresh_at),
+        Some(first_deadline + Duration::from_millis(20))
+    );
+    assert_eq!(
+        active_speaker_ids(&state, refresh_at),
+        vec![source_transport_media_id]
+    );
+}
+
+#[test]
+fn route_control_vad_false_inside_hold_window_does_not_dirty_room_policy() {
+    let mut state = RouteControlState::default();
+    let source_transport_media_id = TransportMediaId::new(34);
+    let now = Instant::now();
+
+    assert!(state.observe_audio_activity(source_transport_media_id, Some(true), None, now));
+
+    assert!(!state.observe_audio_activity(
+        source_transport_media_id,
+        Some(false),
+        None,
+        now + Duration::from_millis(100)
+    ));
+    assert_eq!(
+        state.effective_packet_gate(source_transport_media_id),
+        Some(PacketLayerGate::Open)
+    );
+    assert_eq!(
+        active_speaker_ids(&state, now + Duration::from_millis(100)),
+        vec![source_transport_media_id]
+    );
+}
+
+#[test]
+fn route_control_newer_speaker_order_change_dirties_room_policy() {
+    let mut state = RouteControlState::default();
+    let first_source_transport_media_id = TransportMediaId::new(35);
+    let second_source_transport_media_id = TransportMediaId::new(36);
+    let now = Instant::now();
+
+    assert!(state.observe_audio_activity(first_source_transport_media_id, Some(true), None, now));
+    assert!(state.observe_audio_activity(
+        second_source_transport_media_id,
+        Some(true),
+        None,
+        now + Duration::from_millis(10)
+    ));
+    assert_eq!(
+        active_speaker_ids(&state, now + Duration::from_millis(10)),
+        vec![
+            second_source_transport_media_id,
+            first_source_transport_media_id
+        ]
+    );
+
+    assert!(state.observe_audio_activity(
+        first_source_transport_media_id,
+        Some(true),
+        None,
+        now + Duration::from_millis(20)
+    ));
+    assert_eq!(
+        active_speaker_ids(&state, now + Duration::from_millis(20)),
+        vec![
+            first_source_transport_media_id,
+            second_source_transport_media_id
+        ]
+    );
+}
+
+#[test]
+fn route_control_same_timestamp_audio_level_rank_change_dirties_room_policy() {
+    let mut state = RouteControlState::default();
+    let first_source_transport_media_id = TransportMediaId::new(37);
+    let second_source_transport_media_id = TransportMediaId::new(38);
+    let now = Instant::now();
+
+    state.observe_audio_activity(first_source_transport_media_id, Some(true), Some(-30), now);
+    state.observe_audio_activity(second_source_transport_media_id, Some(true), Some(-10), now);
+    assert!(state.observe_audio_activity(
+        first_source_transport_media_id,
+        Some(true),
+        Some(-1),
+        now
+    ));
+    assert!(!state.observe_audio_activity(
+        first_source_transport_media_id,
+        Some(true),
+        Some(-1),
+        now
+    ));
 }
 
 #[test]
@@ -415,11 +528,7 @@ fn route_control_active_speaker_order_is_deterministic_for_equal_observations() 
     state.observe_audio_activity(first_source_transport_media_id, Some(true), None, now);
 
     assert_eq!(
-        state
-            .active_speaker_sources(now)
-            .into_iter()
-            .map(ActiveSpeakerSource::transport_media_id)
-            .collect::<Vec<_>>(),
+        active_speaker_ids(&state, now),
         vec![
             first_source_transport_media_id,
             second_source_transport_media_id


### PR DESCRIPTION
Active audio packets refreshed transport-owned hold-window timestamps and made the packet loop mark room source policy dirty even when room policy would make the same decision.

This change compares room-policy visible packet gates plus active-speaker order instead of full transport audio state. Hold-window refreshes still extend the expiry deadline, but no longer wake room policy when membership and ordering are unchanged.