### PR TITLE
[FIX] tests: migrate benchmarks to gungraun

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -17,6 +17,8 @@ allow-licenses:
   - Unicode-3.0
   - Unlicense
 allow-dependencies-licenses:
+  - pkg:cargo/bincode-next
+  - pkg:cargo/gungraun
   - pkg:cargo/o-sfu
   - pkg:cargo/o-sfu-cluster
   - pkg:cargo/o-sfu-core

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2" # v2.3.8
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -39,7 +39,7 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2" # v2.3.8
     with:
       # Example of specifying custom arguments
       scan-args: |-

--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -165,7 +165,7 @@ jobs:
               if (!Array.isArray(both) || both.length !== 2) {
                 return null;
               }
-              // iai-callgrind reports comparison metrics as [head, base] for the Both variant
+              // Gungraun reports comparison metrics as [head, base] for the Both variant
               const head = metricValue(both[0]);
               const base = metricValue(both[1]);
               const labels = benchmarkLabels(summary);

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -112,10 +112,10 @@ jobs:
         # Swatinem/rust-cache v2
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
-          shared-key: rust-1.95-callgrind
+          shared-key: rust-1.95-gungraun
 
-      - name: Install iai-callgrind runner
-        run: cargo install iai-callgrind-runner --version 0.16.1 --locked
+      - name: Install Gungraun runner
+        run: cargo install gungraun-runner --version 0.19.0 --locked
 
       - name: Configure manual investigation options
         id: investigation
@@ -185,13 +185,13 @@ jobs:
           callgrind_args='${{ steps.investigation.outputs.callgrind-args }}'
           tools='${{ steps.investigation.outputs.tools }}'
           if [[ -n "$callgrind_args" ]]; then
-            export IAI_CALLGRIND_CALLGRIND_ARGS="$callgrind_args"
+            export GUNGRAUN_CALLGRIND_ARGS="$callgrind_args"
           fi
           if [[ -n "$tools" ]]; then
-            export IAI_CALLGRIND_TOOLS="$tools"
+            export GUNGRAUN_TOOLS="$tools"
           fi
 
-          # iai-callgrind stores the named baseline under target/iai for the next step in this same job
+          # Gungraun stores the named baseline under target/gungraun for the next step in this same job
           git checkout --force "${{ steps.refs.outputs.base-ref }}"
           cargo bench --locked -p o-sfu-tests --bench packet_loop_callgrind -- --save-baseline=base --save-summary=json
 
@@ -200,10 +200,10 @@ jobs:
           callgrind_args='${{ steps.investigation.outputs.callgrind-args }}'
           tools='${{ steps.investigation.outputs.tools }}'
           if [[ -n "$callgrind_args" ]]; then
-            export IAI_CALLGRIND_CALLGRIND_ARGS="$callgrind_args"
+            export GUNGRAUN_CALLGRIND_ARGS="$callgrind_args"
           fi
           if [[ -n "$tools" ]]; then
-            export IAI_CALLGRIND_TOOLS="$tools"
+            export GUNGRAUN_TOOLS="$tools"
           fi
 
           # the head run loads the saved base baseline and emits JSON summaries with base-versus-head deltas
@@ -219,13 +219,13 @@ jobs:
           flamegraphs='${{ steps.investigation.outputs.flamegraphs }}'
           tools='${{ steps.investigation.outputs.tools }}'
           if [[ -n "$callgrind_args" ]]; then
-            export IAI_CALLGRIND_CALLGRIND_ARGS="$callgrind_args"
+            export GUNGRAUN_CALLGRIND_ARGS="$callgrind_args"
           fi
           if [[ -n "$flamegraphs" ]]; then
             export O_SFU_CALLGRIND_FLAMEGRAPHS="$flamegraphs"
           fi
           if [[ -n "$tools" ]]; then
-            export IAI_CALLGRIND_TOOLS="$tools"
+            export GUNGRAUN_TOOLS="$tools"
           fi
 
           # this target is diagnostic only
@@ -239,7 +239,7 @@ jobs:
         run: |
           # collect summaries even after failures so the PR comment and artifact show what happened
           mkdir -p performance-artifacts
-          mapfile -t summary_files < <(find target/iai -type f -name '*.json' | sort)
+          mapfile -t summary_files < <(find target/gungraun -type f -name '*.json' | sort)
           if ((${#summary_files[@]})); then
             jq -s '.' "${summary_files[@]}" > performance-artifacts/callgrind-summary.json
           else
@@ -264,10 +264,10 @@ jobs:
         # actions/upload-artifact v4
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          # keep the raw iai-callgrind output available for local inspection when the summary is not enough
+          # keep the raw Gungraun output available for local inspection when the summary is not enough
           name: packet-loop-callgrind-${{ github.run_id }}
           path: |
-            target/iai/**
+            target/gungraun/**
             performance-artifacts/callgrind-summary.json
             performance-artifacts/callgrind-refs.env
           if-no-files-found: warn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,12 +203,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
  "serde",
+ "unty-next",
 ]
 
 [[package]]
@@ -752,6 +753,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gungraun"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a710656785d3ed71a73a1007956874d6ebfdbc2f8660c492bb8d838c91e3f085"
+dependencies = [
+ "bincode-next",
+ "cty",
+ "derive_more",
+ "gungraun-macros",
+ "gungraun-runner",
+ "valgrind-requests",
+]
+
+[[package]]
+name = "gungraun-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc6269e89921872ec32af29af3a992618b9bd2ef47cbf3704af476066cb7182"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "gungraun-runner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12016920cc6ba0a8aefe276c8f19421a3bf7a125385e25697658b9dd66bde024"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,49 +917,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iai-callgrind"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
-dependencies = [
- "bincode",
- "bindgen",
- "cc",
- "cfg-if",
- "cty",
- "derive_more",
- "iai-callgrind-macros",
- "iai-callgrind-runner",
- "regex",
- "strum",
- "version-compare",
-]
-
-[[package]]
-name = "iai-callgrind-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
-dependencies = [
- "derive_more",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
-]
-
-[[package]]
-name = "iai-callgrind-runner"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1402,7 +1399,7 @@ dependencies = [
  "anyhow",
  "base64",
  "futures-util",
- "iai-callgrind",
+ "gungraun",
  "o-sfu",
  "o-sfu-core",
  "o-sfu-protocol",
@@ -2095,18 +2092,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2590,6 +2587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "unty-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa66022bbd1ab992fad72bdedcfd07a0023b6f5ecc83d50121e39e3a3caed41"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,16 +2622,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "valgrind-requests"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796c44118a551cc842f2ce6fce4983b86e282ec99b6b5e80b09dfeab830e7755"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if",
+ "cty",
+ "regex",
+ "rustc_version",
+ "strum",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version-compare"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"

--- a/crates/client/package-lock.json
+++ b/crates/client/package-lock.json
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -40,10 +40,10 @@ o-sfu-core = { path = "../crates/core", features = ["internal-benchmarks"] }
 # the manual worker benchmark uses Callgrind client requests only on the ubuntu runner
 # non-linux developer targets compile the same benchmark with no-op hooks
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dev-dependencies]
-iai-callgrind = { version = "0.16.1", features = ["client_requests"] }
+gungraun = { version = "0.19.0", features = ["client_requests"] }
 
 [target.'cfg(not(all(target_arch = "x86_64", target_os = "linux")))'.dev-dependencies]
-iai-callgrind = "0.16.1"
+gungraun = "0.19.0"
 
 [lints]
 workspace = true

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,7 +23,7 @@ npm --prefix crates/client run verify
 
 ## Packet-loop Callgrind benchmarks
 
-uses `iai-callgrind` for deterministic instruction-count checks of
+uses `gungraun` for deterministic instruction-count checks of
 packet-loop hot-path slices
 
 Build the target without running Valgrind:
@@ -44,13 +44,13 @@ Compare local changes against that baseline:
 cargo bench --locked -p o-sfu-tests --bench packet_loop_callgrind -- --baseline=local --save-summary=json
 ```
 
-profiles and summaries are written under `target/iai`. the current scenarios
+profiles and summaries are written under `target/gungraun`. the current scenarios
 cover local route-planning fanout, relay-mailbox enqueue pressure, cached
 ingress demux, repeated unknown-source misses, large-packet recent-miss cache
 routing, routing-miss fingerprinting, packet-sink fanout, selected-RID
 readiness and keyframe-request coalescing
 
-local Callgrind execution requires `iai-callgrind-runner` plus Valgrind. on
+local Callgrind execution requires `gungraun-runner` plus Valgrind. on
 hosts without Valgrind support, use `--no-run` as the local build check and run
 the baseline comparison on Linux
 

--- a/tests/benchmarks/packet_loop_callgrind.rs
+++ b/tests/benchmarks/packet_loop_callgrind.rs
@@ -17,12 +17,14 @@
 
 #![allow(
     clippy::exit,
-    reason = "iai-callgrind's generated benchmark harness exits with the measured runner status"
+    clippy::must_use_candidate,
+    clippy::needless_pass_by_value,
+    reason = "Gungraun's generated harness owns setup values, returns measured outputs and exits with the runner status"
 )]
 
 use std::hint::black_box;
 
-use iai_callgrind::{
+use gungraun::{
     Callgrind, EventKind, LibraryBenchmarkConfig, library_benchmark, library_benchmark_group, main,
 };
 use o_sfu_core::server::transport::benchmark_support::{

--- a/tests/benchmarks/packet_loop_worker_callgrind.rs
+++ b/tests/benchmarks/packet_loop_worker_callgrind.rs
@@ -21,7 +21,9 @@
 
 #![allow(
     clippy::exit,
-    reason = "iai-callgrind's generated benchmark harness exits with the measured runner status"
+    clippy::must_use_candidate,
+    clippy::needless_pass_by_value,
+    reason = "Gungraun's generated harness owns setup values, returns measured outputs and exits with the runner status"
 )]
 
 use std::{env, hint::black_box};
@@ -30,8 +32,8 @@ use std::{env, hint::black_box};
 // other targets compile no-op hooks so local checks do not require supported
 // valgrind client requests
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-use iai_callgrind::client_requests::callgrind::{start_instrumentation, stop_instrumentation};
-use iai_callgrind::{
+use gungraun::client_requests::callgrind::{start_instrumentation, stop_instrumentation};
+use gungraun::{
     Callgrind, EntryPoint, FlamegraphConfig, LibraryBenchmarkConfig, library_benchmark,
     library_benchmark_group, main,
 };


### PR DESCRIPTION
gungraun is the successor to iai-callgrind