### PR TITLE
[IMP] core: publish rtc observations without locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1308,7 @@ dependencies = [
 name = "o-sfu-core"
 version = "0.3.0"
 dependencies = [
+ "arc-swap",
  "bitflags",
  "futures-util",
  "o-sfu-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ version = "0.3.0" # SFU basic feature is ready and can be used as a substitute f
 
 [workspace.dependencies]
 anyhow = "1.0"
+arc-swap = "1.9.1"
 base64 = "0.22"
 futures-util = "0.3"
 o-sfu-protocol = { path = "crates/protocol" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ testing-transport = []
 worker-benchmarks = ["internal-benchmarks"]
 
 [dependencies]
+arc-swap.workspace = true
 bitflags = "2.6"
 futures-util.workspace = true
 o-sfu-rfc.workspace = true

--- a/crates/core/src/runtime/media_transport/test_support/mod.rs
+++ b/crates/core/src/runtime/media_transport/test_support/mod.rs
@@ -38,13 +38,15 @@ impl MediaTransport {
     ///
     /// This is a route-test hook for failure injection and is not a production
     /// control-plane operation.
-    pub fn debug_set_session_transport_health(
+    pub async fn debug_set_session_transport_health(
         &self,
         session_key: &TransportSessionKey,
         health: TransportSessionHealth,
     ) {
         if let Some(worker) = self.worker_for_user(session_key) {
-            worker.debug_set_session_transport_health(session_key, health);
+            worker
+                .debug_set_session_transport_health(session_key, health)
+                .await;
         }
     }
 

--- a/crates/core/src/runtime/rtc_engine/benchmark_support/ingress.rs
+++ b/crates/core/src/runtime/rtc_engine/benchmark_support/ingress.rs
@@ -1,6 +1,6 @@
 use std::{
     net::SocketAddr,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -11,9 +11,10 @@ use str0m::{
 
 use super::super::{
     bootstrap,
+    observation::{PacketLoopObservations, RtcObservationPublishers},
     packet_loop::{PacketRouteDatagram, route_packet_to_matching_session_at},
     routing_miss::DemuxRecoveryState,
-    state::{PacketLoopState, RtcSnapshotState},
+    state::PacketLoopState,
     test_support::test_transport_session_key,
 };
 use crate::{
@@ -43,7 +44,7 @@ enum IngressRoutingMode {
 pub struct IngressRoutingBenchFixture {
     mode: IngressRoutingMode,
     state: PacketLoopState,
-    snapshot_state: Arc<Mutex<RtcSnapshotState>>,
+    observations: PacketLoopObservations,
     demux: DemuxRecoveryState,
     _metrics: RuntimeMetrics,
     rtc_metrics: Arc<RtcMetricsRecorder>,
@@ -60,7 +61,7 @@ impl IngressRoutingBenchFixture {
         let candidate_addr = SocketAddr::from(([127, 0, 0, 1], 46_000));
         let session_key = test_transport_session_key(61, 0, 62, UserId::Integer(63));
         let mut state = PacketLoopState::default();
-        let snapshot_state = Arc::new(Mutex::new(RtcSnapshotState::default()));
+        let mut observations = PacketLoopObservations::new(RtcObservationPublishers::new());
         let metrics = RuntimeMetrics::default();
         let rtc_metrics = metrics.register_rtc_worker();
 
@@ -76,11 +77,7 @@ impl IngressRoutingBenchFixture {
             let _ = state
                 .remote_addr_demux
                 .remember_remote_addr(source_addr, &session_key);
-            if let Ok(mut snapshot) = snapshot_state.lock() {
-                let _ = snapshot
-                    .remote_addr_demux
-                    .remember_remote_addr(source_addr, &session_key);
-            }
+            observations.remember_remote_addr(source_addr, &session_key);
             state
                 .users
                 .get_mut(&session_key)
@@ -100,7 +97,7 @@ impl IngressRoutingBenchFixture {
         Self {
             mode: IngressRoutingMode::CachedAccepted,
             state,
-            snapshot_state,
+            observations,
             demux: DemuxRecoveryState::new(),
             _metrics: metrics,
             rtc_metrics,
@@ -126,13 +123,13 @@ impl IngressRoutingBenchFixture {
         let source_addr = SocketAddr::from(([127, 0, 0, 1], 46_011));
         let candidate_addr = SocketAddr::from(([127, 0, 0, 1], 46_010));
         let state = PacketLoopState::default();
-        let snapshot_state = Arc::new(Mutex::new(RtcSnapshotState::default()));
+        let observations = PacketLoopObservations::new(RtcObservationPublishers::new());
         let metrics = RuntimeMetrics::default();
         let rtc_metrics = metrics.register_rtc_worker();
         let mut fixture = Self {
             mode: IngressRoutingMode::UnknownSourceMiss,
             state,
-            snapshot_state,
+            observations,
             demux: DemuxRecoveryState::new(),
             _metrics: metrics,
             rtc_metrics,
@@ -159,7 +156,7 @@ impl IngressRoutingBenchFixture {
     fn route_once(&mut self) {
         route_packet_to_matching_session_at(
             &mut self.state,
-            &self.snapshot_state,
+            &mut self.observations,
             &mut self.demux,
             &self.rtc_metrics,
             PacketRouteDatagram::new(

--- a/crates/core/src/runtime/rtc_engine/bitrate.rs
+++ b/crates/core/src/runtime/rtc_engine/bitrate.rs
@@ -1,8 +1,8 @@
 //! Worker-local bitrate accounting for RTC media.
 //!
-//! The packet loop owns the write side and updates counters through atomics. The
-//! shared state lock protects only cold registration and snapshot maps, so
-//! operator polling cannot contend with per-packet writes.
+//! The packet loop owns the write side and updates counters through atomics.
+//! read-side snapshots are published atomically, so operator polling cannot
+//! block packet-loop registration or per-packet writes.
 
 use std::{
     collections::BTreeMap,
@@ -81,7 +81,7 @@ impl MediaBitrateCounter {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(super) struct SessionIncomingBitrates {
     per_media: BTreeMap<TransportMediaId, Arc<MediaBitrateCounter>>,
 }
@@ -99,8 +99,8 @@ impl SessionIncomingBitrates {
         )
     }
 
-    fn remove(&mut self, transport_media_id: TransportMediaId) {
-        self.per_media.remove(&transport_media_id);
+    fn remove(&mut self, transport_media_id: TransportMediaId) -> bool {
+        self.per_media.remove(&transport_media_id).is_some()
     }
 
     fn is_empty(&self) -> bool {
@@ -129,7 +129,7 @@ impl SessionIncomingBitrates {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct BitrateRegistry {
     pub(super) incoming_bitrates_by_session: BTreeMap<TransportSessionKey, SessionIncomingBitrates>,
     pub(super) egress_bitrates_by_session: BTreeMap<TransportSessionKey, Arc<MediaBitrateCounter>>,
@@ -152,31 +152,44 @@ impl BitrateRegistry {
         &mut self,
         session_key: &TransportSessionKey,
         now: Instant,
-    ) -> Arc<MediaBitrateCounter> {
-        Arc::clone(
+    ) -> (Arc<MediaBitrateCounter>, bool) {
+        let mut inserted = false;
+        let counter = Arc::clone(
             self.egress_bitrates_by_session
                 .entry(session_key.clone())
-                .or_insert_with(|| Arc::new(MediaBitrateCounter::new(now))),
-        )
+                .or_insert_with(|| {
+                    inserted = true;
+                    Arc::new(MediaBitrateCounter::new(now))
+                }),
+        );
+        (counter, inserted)
     }
 
     pub(super) fn remove_incoming_media(
         &mut self,
         session_key: &TransportSessionKey,
         transport_media_id: TransportMediaId,
-    ) {
+    ) -> bool {
         let Some(session_bitrates) = self.incoming_bitrates_by_session.get_mut(session_key) else {
-            return;
+            return false;
         };
-        session_bitrates.remove(transport_media_id);
+        let removed = session_bitrates.remove(transport_media_id);
         if session_bitrates.is_empty() {
             self.incoming_bitrates_by_session.remove(session_key);
         }
+        removed
     }
 
-    pub(super) fn remove_session(&mut self, session_key: &TransportSessionKey) {
-        self.incoming_bitrates_by_session.remove(session_key);
-        self.egress_bitrates_by_session.remove(session_key);
+    pub(super) fn remove_session(&mut self, session_key: &TransportSessionKey) -> bool {
+        let incoming_removed = self
+            .incoming_bitrates_by_session
+            .remove(session_key)
+            .is_some();
+        let egress_removed = self
+            .egress_bitrates_by_session
+            .remove(session_key)
+            .is_some();
+        incoming_removed || egress_removed
     }
 
     pub fn transport_bitrate_snapshot_at(
@@ -270,7 +283,7 @@ impl PacketLoopState {
 mod tests {
     use std::{
         sync::{
-            Arc, Mutex,
+            Arc,
             atomic::{AtomicBool, Ordering as AtomicOrdering},
         },
         thread,
@@ -335,8 +348,9 @@ mod tests {
         let now = Instant::now();
         let session_key = test_transport_session_key(0, 0, 0, UserId::Integer(7));
         let mut state = BitrateRegistry::default();
-        let counter = state.register_session_egress(&session_key, now);
+        let (counter, inserted) = state.register_session_egress(&session_key, now);
 
+        assert!(inserted);
         assert!(counter.record(now, 125));
 
         assert_eq!(
@@ -402,22 +416,26 @@ mod tests {
     }
 
     #[test]
-    fn packet_loop_counter_write_does_not_need_the_snapshot_lock() {
-        let mut shared_registry = BitrateRegistry::default();
+    fn cloned_registry_snapshot_observes_packet_loop_counter_writes() {
+        let mut registry = BitrateRegistry::default();
         let mut packet_loop_state = PacketLoopState::default();
         let now = Instant::now();
         let session_key = test_transport_session_key(1, 0, 2, UserId::Integer(3));
         let media_id = TransportMediaId::new(4);
-        let counter = shared_registry.register_incoming_media(&session_key, media_id, now);
+        let counter = registry.register_incoming_media(&session_key, media_id, now);
         packet_loop_state.register_incoming_bitrate_counter(media_id, counter);
-        let shared_registry = Mutex::new(shared_registry);
-        let Ok(_snapshot_guard) = shared_registry.lock() else {
-            return;
-        };
+        let snapshot = registry.clone();
 
         assert_eq!(
             packet_loop_state.record_incoming_bitrate(media_id, now, 32),
             Some(true)
+        );
+        assert_eq!(
+            snapshot.transport_bitrate_snapshot_at(&[session_key], now),
+            TransportBitrateSnapshot {
+                total: Bitrate::from_bps(256),
+                per_media: vec![(media_id, Bitrate::from_bps(256))],
+            }
         );
     }
 }

--- a/crates/core/src/runtime/rtc_engine/demux.rs
+++ b/crates/core/src/runtime/rtc_engine/demux.rs
@@ -162,7 +162,7 @@ pub(super) type MediaRouteKey = TransportMediaId;
 /// mutating methods keep reverse indexes in sync so session teardown can remove
 /// every tuple, ufrag and candidate hint owned by one session without scanning
 /// unrelated sessions
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct RemoteAddrDemux {
     /// learned UDP source tuple to session pin
     remote_addr_index: HashMap<SocketAddr, TransportSessionKey>,
@@ -326,32 +326,38 @@ impl RemoteAddrDemux {
     ///
     /// this is used when the cached path no longer passes `Rtc::accepts()` or
     /// when snapshot state mirrors a worker cleanup
-    pub(super) fn forget_remote_addr(&mut self, source_addr: SocketAddr) {
+    pub(super) fn forget_remote_addr(&mut self, source_addr: SocketAddr) -> bool {
         let Some(session_key) = self.remote_addr_index.remove(&source_addr) else {
-            return;
+            return false;
         };
         self.remove_remote_addr_from_session(&session_key, source_addr);
+        true
     }
 
     /// removes every learned UDP source tuple owned by a session
     ///
     /// session teardown calls this on both worker and snapshot demux state so
     /// stale source pins cannot route packets to a removed user
-    pub(super) fn forget_user_remote_addrs(&mut self, session_key: &TransportSessionKey) {
+    pub(super) fn forget_user_remote_addrs(&mut self, session_key: &TransportSessionKey) -> bool {
         let Some(session_addrs) = self.remote_addrs_by_session.remove(session_key) else {
-            return;
+            return false;
         };
         for source_addr in session_addrs {
             self.remote_addr_index.remove(&source_addr);
         }
+        true
     }
 
     /// removes the local ICE ufrag recovery hint for a session
-    pub(super) fn forget_user_local_ice_ufrag(&mut self, session_key: &TransportSessionKey) {
+    pub(super) fn forget_user_local_ice_ufrag(
+        &mut self,
+        session_key: &TransportSessionKey,
+    ) -> bool {
         let Some(local_ice_ufrag) = self.local_ice_ufrag_by_session.remove(session_key) else {
-            return;
+            return false;
         };
         self.local_ice_ufrag_index.remove(&local_ice_ufrag);
+        true
     }
 
     /// removes all remote candidate recovery hints owned by a session
@@ -359,10 +365,13 @@ impl RemoteAddrDemux {
     /// candidate address indexes can contain several sessions for one address
     /// cleanup removes only the target session from each fanout list and drops
     /// empty address entries afterward
-    pub(super) fn forget_user_remote_candidate_addrs(&mut self, session_key: &TransportSessionKey) {
+    pub(super) fn forget_user_remote_candidate_addrs(
+        &mut self,
+        session_key: &TransportSessionKey,
+    ) -> bool {
         let Some(candidate_addrs) = self.remote_candidate_addrs_by_session.remove(session_key)
         else {
-            return;
+            return false;
         };
         for candidate_addr in candidate_addrs {
             let should_remove_index_entry = self
@@ -376,6 +385,7 @@ impl RemoteAddrDemux {
                 self.remote_candidate_addr_index.remove(&candidate_addr);
             }
         }
+        true
     }
 
     #[cfg(test)]

--- a/crates/core/src/runtime/rtc_engine/fuzz_support.rs
+++ b/crates/core/src/runtime/rtc_engine/fuzz_support.rs
@@ -1,14 +1,15 @@
 use std::{
     net::SocketAddr,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
 use super::{
     bootstrap,
+    observation::{PacketLoopObservations, RtcObservationPublishers},
     packet_loop::{PacketRouteDatagram, route_packet_to_matching_session_at},
     routing_miss::DemuxRecoveryState,
-    state::{PacketLoopState, RtcSnapshotState},
+    state::PacketLoopState,
 };
 use crate::{
     Bitrate, MediaCodecFlags,
@@ -52,7 +53,7 @@ pub fn route_packet_loop_ingress_demux(
 
 struct IngressDemuxFuzzFixture {
     state: PacketLoopState,
-    snapshot_state: Arc<Mutex<RtcSnapshotState>>,
+    observations: PacketLoopObservations,
     demux: DemuxRecoveryState,
     rtc_metrics: Arc<RtcMetricsRecorder>,
     session_key: TransportSessionKey,
@@ -80,7 +81,7 @@ impl IngressDemuxFuzzFixture {
         let metrics = RuntimeMetrics::default();
         Self {
             state,
-            snapshot_state: Arc::new(Mutex::new(RtcSnapshotState::default())),
+            observations: PacketLoopObservations::new(RtcObservationPublishers::new()),
             demux: DemuxRecoveryState::new(),
             rtc_metrics: metrics.register_rtc_worker(),
             session_key,
@@ -95,11 +96,8 @@ impl IngressDemuxFuzzFixture {
             .state
             .remote_addr_demux
             .remember_remote_addr(self.source_addr, &self.session_key);
-        if let Ok(mut snapshot) = self.snapshot_state.lock() {
-            let _ = snapshot
-                .remote_addr_demux
-                .remember_remote_addr(self.source_addr, &self.session_key);
-        }
+        self.observations
+            .remember_remote_addr(self.source_addr, &self.session_key);
     }
 
     fn remove_session(&mut self) {
@@ -117,7 +115,7 @@ impl IngressDemuxFuzzFixture {
         let packet = packet.get(..MAX_PACKET_LEN).unwrap_or(packet);
         route_packet_to_matching_session_at(
             &mut self.state,
-            &self.snapshot_state,
+            &mut self.observations,
             &mut self.demux,
             &self.rtc_metrics,
             PacketRouteDatagram::new(self.source_addr, self.candidate_addr, packet, self.now),

--- a/crates/core/src/runtime/rtc_engine/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/mod.rs
@@ -45,6 +45,7 @@ mod local_forwarding;
 mod local_send_rewrite;
 mod media_registry;
 mod negotiated_capabilities;
+mod observation;
 mod packet_loop;
 mod relay_registry;
 mod route_control;

--- a/crates/core/src/runtime/rtc_engine/observation.rs
+++ b/crates/core/src/runtime/rtc_engine/observation.rs
@@ -1,0 +1,213 @@
+use std::{collections::BTreeSet, mem, net::SocketAddr, sync::Arc, time::Instant};
+
+use arc_swap::ArcSwap;
+
+use super::{
+    bitrate::{BitrateRegistry, MediaBitrateCounter},
+    state::{RtcSnapshotState, TransportSessionHealth},
+};
+use crate::runtime::{
+    RoomInstanceId,
+    media_transport::{
+        SourcePolicySignal, TransportMediaId, TransportQualitySample, TransportSessionKey,
+    },
+};
+
+#[derive(Clone)]
+pub(super) struct RtcObservationPublishers {
+    bitrate_registry: Arc<ArcSwap<BitrateRegistry>>,
+    snapshot_state: Arc<ArcSwap<RtcSnapshotState>>,
+}
+
+impl RtcObservationPublishers {
+    pub(super) fn new() -> Self {
+        Self {
+            bitrate_registry: Arc::new(ArcSwap::from_pointee(BitrateRegistry::default())),
+            snapshot_state: Arc::new(ArcSwap::from_pointee(RtcSnapshotState::default())),
+        }
+    }
+
+    pub(super) fn bitrate_registry(&self) -> Arc<ArcSwap<BitrateRegistry>> {
+        Arc::clone(&self.bitrate_registry)
+    }
+
+    pub(super) fn snapshot_state(&self) -> Arc<ArcSwap<RtcSnapshotState>> {
+        Arc::clone(&self.snapshot_state)
+    }
+}
+
+pub(super) struct PacketLoopObservations {
+    bitrate_registry: BitrateRegistry,
+    snapshot_state: RtcSnapshotState,
+    publishers: RtcObservationPublishers,
+    dirty_source_policy_rooms: BTreeSet<RoomInstanceId>,
+    bitrate_dirty: bool,
+    snapshot_dirty: bool,
+}
+
+impl PacketLoopObservations {
+    pub(super) fn new(publishers: RtcObservationPublishers) -> Self {
+        Self {
+            bitrate_registry: BitrateRegistry::default(),
+            snapshot_state: RtcSnapshotState::default(),
+            publishers,
+            dirty_source_policy_rooms: BTreeSet::new(),
+            bitrate_dirty: false,
+            snapshot_dirty: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn snapshot_state(&self) -> &RtcSnapshotState {
+        &self.snapshot_state
+    }
+
+    pub(super) fn add_session(&mut self, session_key: &TransportSessionKey) {
+        if self.snapshot_state.add_session(session_key) {
+            self.snapshot_dirty = true;
+        }
+    }
+
+    pub(super) fn remove_session(
+        &mut self,
+        session_key: &TransportSessionKey,
+    ) -> Option<TransportSessionHealth> {
+        let (previous, changed) = self.snapshot_state.remove_session(session_key);
+        if changed {
+            self.snapshot_dirty = true;
+        }
+        if self.bitrate_registry.remove_session(session_key) {
+            self.bitrate_dirty = true;
+        }
+        previous
+    }
+
+    pub(super) fn set_transport_health(
+        &mut self,
+        session_key: &TransportSessionKey,
+        health: TransportSessionHealth,
+    ) -> Option<TransportSessionHealth> {
+        let previous = self
+            .snapshot_state
+            .set_transport_health(session_key, health);
+        if previous != Some(health) {
+            self.snapshot_dirty = true;
+        }
+        previous
+    }
+
+    pub(super) fn set_receiver_bandwidth(
+        &mut self,
+        session_key: &TransportSessionKey,
+        estimate: crate::Bitrate,
+    ) {
+        if self
+            .snapshot_state
+            .set_receiver_bandwidth(session_key, estimate)
+            == Some(estimate)
+        {
+            return;
+        }
+        self.snapshot_dirty = true;
+        self.dirty_source_policy_rooms
+            .insert(session_key.room_instance_id());
+    }
+
+    pub(super) fn update_transport_quality(
+        &mut self,
+        session_key: &TransportSessionKey,
+        update: impl FnOnce(&mut TransportQualitySample),
+    ) {
+        self.snapshot_state
+            .update_transport_quality(session_key, update);
+        self.snapshot_dirty = true;
+    }
+
+    pub(super) fn remember_remote_addr(
+        &mut self,
+        source_addr: SocketAddr,
+        session_key: &TransportSessionKey,
+    ) -> bool {
+        let changed = self
+            .snapshot_state
+            .remote_addr_demux
+            .remember_remote_addr(source_addr, session_key);
+        if changed {
+            self.snapshot_dirty = true;
+        }
+        changed
+    }
+
+    pub(super) fn forget_remote_addr(&mut self, source_addr: SocketAddr) {
+        if self
+            .snapshot_state
+            .remote_addr_demux
+            .forget_remote_addr(source_addr)
+        {
+            self.snapshot_dirty = true;
+        }
+    }
+
+    pub(super) fn register_incoming_media(
+        &mut self,
+        session_key: &TransportSessionKey,
+        transport_media_id: TransportMediaId,
+        now: Instant,
+    ) -> Arc<MediaBitrateCounter> {
+        let counter =
+            self.bitrate_registry
+                .register_incoming_media(session_key, transport_media_id, now);
+        self.bitrate_dirty = true;
+        counter
+    }
+
+    pub(super) fn remove_incoming_media(
+        &mut self,
+        session_key: &TransportSessionKey,
+        transport_media_id: TransportMediaId,
+    ) {
+        if self
+            .bitrate_registry
+            .remove_incoming_media(session_key, transport_media_id)
+        {
+            self.bitrate_dirty = true;
+        }
+    }
+
+    pub(super) fn register_session_egress(
+        &mut self,
+        session_key: &TransportSessionKey,
+        now: Instant,
+    ) -> Arc<MediaBitrateCounter> {
+        let (counter, inserted) = self
+            .bitrate_registry
+            .register_session_egress(session_key, now);
+        if inserted {
+            self.bitrate_dirty = true;
+        }
+        counter
+    }
+
+    pub(super) fn publish_dirty_and_wake_policy(
+        &mut self,
+        source_policy_signal: &SourcePolicySignal,
+    ) {
+        if self.bitrate_dirty {
+            self.publishers
+                .bitrate_registry
+                .store(Arc::new(self.bitrate_registry.clone()));
+            self.bitrate_dirty = false;
+        }
+        if self.snapshot_dirty {
+            self.publishers
+                .snapshot_state
+                .store(Arc::new(self.snapshot_state.clone()));
+            self.snapshot_dirty = false;
+        }
+        if self.dirty_source_policy_rooms.is_empty() {
+            return;
+        }
+        let dirty_source_policy_rooms = mem::take(&mut self.dirty_source_policy_rooms);
+        source_policy_signal.mark_dirty_rooms(dirty_source_policy_rooms);
+    }
+}

--- a/crates/core/src/runtime/rtc_engine/packet_loop/event_observation.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/event_observation.rs
@@ -5,10 +5,7 @@
 //! that translation so session draining can stay focused on moving `str0m`
 //! outputs into packet-loop buffers.
 
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use o_sfu_telemetry::schema;
 use str0m::{
@@ -18,7 +15,7 @@ use str0m::{
 };
 use tracing::{debug, trace};
 
-use super::super::state::{RtcSnapshotState, TransportSessionHealth};
+use super::super::{observation::PacketLoopObservations, state::TransportSessionHealth};
 use crate::{
     Bitrate,
     runtime::{
@@ -26,7 +23,7 @@ use crate::{
             DiagnosticsStore, diagnostics_room_instance_id, health_json_value,
             maybe_health_json_value,
         },
-        media_transport::{SourcePolicySignal, TransportSessionKey},
+        media_transport::TransportSessionKey,
         metrics::{
             self, MediaQualityLossDirection, MediaQualitySample, RuntimeMetrics, TransportIceState,
         },
@@ -66,16 +63,14 @@ pub(super) fn log_rtc_event(session_key: &TransportSessionKey, event: &Event) {
     }
 }
 
-/// Project selected `str0m` events into metrics, snapshots and diagnostics.
+/// project selected `str0m` events into metrics, snapshots and diagnostics
 ///
-/// Snapshot writes are best-effort. If the snapshot lock is unavailable, the
-/// packet loop keeps running because the worker-owned `PacketLoopState`
-/// remains authoritative for media behavior.
+/// snapshot writes update worker-owned observation state
+/// the driver publishes changed snapshots after the current turn
 pub(super) fn observe_rtc_event(
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     diagnostics: &Arc<DiagnosticsStore>,
     metrics: &RuntimeMetrics,
-    source_policy_signal: &SourcePolicySignal,
     session_key: &TransportSessionKey,
     event: &Event,
 ) {
@@ -87,26 +82,23 @@ pub(super) fn observe_rtc_event(
             metrics.record_transport_dtls_connected();
         }
         Event::EgressBitrateEstimate(kind) => {
-            observe_receiver_bandwidth(snapshot_state, source_policy_signal, session_key, kind);
+            observe_receiver_bandwidth(observations, session_key, kind);
         }
         Event::PeerStats(stats) => {
-            observe_peer_quality(snapshot_state, metrics, session_key, stats);
+            observe_peer_quality(observations, metrics, session_key, stats);
         }
         Event::MediaIngressStats(stats) => {
-            observe_media_ingress_quality(snapshot_state, metrics, session_key, stats);
+            observe_media_ingress_quality(observations, metrics, session_key, stats);
         }
         Event::MediaEgressStats(stats) => {
-            observe_media_egress_quality(snapshot_state, metrics, session_key, stats);
+            observe_media_egress_quality(observations, metrics, session_key, stats);
         }
         _ => {}
     }
     let Some(health) = transport_health_from_event(event) else {
         return;
     };
-    let Ok(mut snapshot_state) = snapshot_state.lock() else {
-        return;
-    };
-    let previous = snapshot_state.set_transport_health(session_key, health);
+    let previous = observations.set_transport_health(session_key, health);
     metrics.record_transport_health_transition(
         previous.map(metrics::transport_health_state),
         Some(metrics::transport_health_state(health)),
@@ -127,7 +119,7 @@ pub(super) fn observe_rtc_event(
 }
 
 fn observe_peer_quality(
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     metrics: &RuntimeMetrics,
     session_key: &TransportSessionKey,
     stats: &PeerStats,
@@ -145,10 +137,7 @@ fn observe_peer_quality(
     if let Some(loss_ppm) = loss_fraction_ppm(stats.egress_loss_fraction) {
         metrics.record_media_quality_loss_ppm(MediaQualityLossDirection::Egress, loss_ppm);
     }
-    let Ok(mut snapshot_state) = snapshot_state.lock() else {
-        return;
-    };
-    snapshot_state.update_transport_quality(session_key, |sample| {
+    observations.update_transport_quality(session_key, |sample| {
         if let Some(bwe_bps) = stats.bwe_tx.map(|bwe| bwe.as_u64()) {
             sample.latest_bwe_bps = Some(bwe_bps);
         }
@@ -165,7 +154,7 @@ fn observe_peer_quality(
 }
 
 fn observe_media_ingress_quality(
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     metrics: &RuntimeMetrics,
     session_key: &TransportSessionKey,
     stats: &MediaIngressStats,
@@ -177,10 +166,7 @@ fn observe_media_ingress_quality(
     if let Some(loss_ppm) = loss_fraction_ppm(stats.loss) {
         metrics.record_media_quality_loss_ppm(MediaQualityLossDirection::Ingress, loss_ppm);
     }
-    let Ok(mut snapshot_state) = snapshot_state.lock() else {
-        return;
-    };
-    snapshot_state.update_transport_quality(session_key, |sample| {
+    observations.update_transport_quality(session_key, |sample| {
         if let Some(rtt_ms) = stats.rtt.map(duration_millis) {
             sample.rtt_ms = Some(rtt_ms);
         }
@@ -191,7 +177,7 @@ fn observe_media_ingress_quality(
 }
 
 fn observe_media_egress_quality(
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     metrics: &RuntimeMetrics,
     session_key: &TransportSessionKey,
     stats: &MediaEgressStats,
@@ -206,10 +192,7 @@ fn observe_media_egress_quality(
     if let Some(remote) = stats.remote.as_ref() {
         metrics.record_media_quality_jitter_rtp_timestamp_units(u64::from(remote.jitter));
     }
-    let Ok(mut snapshot_state) = snapshot_state.lock() else {
-        return;
-    };
-    snapshot_state.update_transport_quality(session_key, |sample| {
+    observations.update_transport_quality(session_key, |sample| {
         if let Some(rtt_ms) = stats.rtt.map(duration_millis) {
             sample.rtt_ms = Some(rtt_ms);
         }
@@ -242,28 +225,21 @@ fn duration_millis(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
-/// Store receiver bandwidth estimates and wake source-policy recomputation.
+/// store receiver bandwidth estimates and stage source-policy recomputation
 ///
-/// Bandwidth estimates can change source selection, but that policy is owned by
-/// the room layer. The packet loop records the latest estimate in the snapshot
-/// and marks the room dirty only when the value changed.
+/// bandwidth estimates can change source selection, but that policy is owned by
+/// the room layer
+/// the packet loop records the latest estimate in the snapshot and wakes the
+/// room only after the snapshot has been published
 fn observe_receiver_bandwidth(
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
-    source_policy_signal: &SourcePolicySignal,
+    observations: &mut PacketLoopObservations,
     session_key: &TransportSessionKey,
     kind: &BweKind,
 ) {
-    match kind {
-        BweKind::Twcc(bitrate) | BweKind::Remb(_, bitrate)
-            if let Ok(mut snapshot_state) = snapshot_state.lock() =>
-        {
-            let estimate = Bitrate::from_bps(bitrate.as_u64());
-            if snapshot_state.set_receiver_bandwidth(session_key, estimate) != Some(estimate) {
-                source_policy_signal.mark_dirty(session_key.room_instance_id());
-            }
-        }
-        _ => {}
-    }
+    let (BweKind::Twcc(bitrate) | BweKind::Remb(_, bitrate)) = kind else {
+        return;
+    };
+    observations.set_receiver_bandwidth(session_key, Bitrate::from_bps(bitrate.as_u64()));
 }
 
 /// Convert `str0m` ICE connection state into the metrics enum.

--- a/crates/core/src/runtime/rtc_engine/packet_loop/ingress_routing.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/ingress_routing.rs
@@ -18,13 +18,7 @@
 //! fail to recover and be dropped, but this module must not recover traffic that
 //! `str0m` would reject downstream.
 
-use std::{
-    fmt,
-    net::SocketAddr,
-    slice::Iter,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::{fmt, net::SocketAddr, slice::Iter, time::Instant};
 
 use str0m::{
     Input,
@@ -34,8 +28,9 @@ use str0m::{
 use tracing::{debug, trace, warn};
 
 use super::super::{
+    observation::PacketLoopObservations,
     routing_miss::{DemuxRecoveryState, PacketLoopRoutingMissKey},
-    state::{PacketLoopState, RtcSnapshotState},
+    state::PacketLoopState,
 };
 use crate::runtime::{
     media_transport::TransportSessionKey,
@@ -140,7 +135,7 @@ impl<'a> Iterator for CandidateSessionKeys<'a> {
 /// validity are separate concerns.
 pub(super) fn route_packet_to_matching_session(
     state: &mut PacketLoopState,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     demux: &mut DemuxRecoveryState,
     metrics: &RtcMetricsRecorder,
     source_addr: SocketAddr,
@@ -149,7 +144,7 @@ pub(super) fn route_packet_to_matching_session(
 ) {
     route_packet_to_matching_session_at(
         state,
-        snapshot_state,
+        observations,
         demux,
         metrics,
         PacketRouteDatagram::new(source_addr, candidate_addr, packet, Instant::now()),
@@ -158,14 +153,14 @@ pub(super) fn route_packet_to_matching_session(
 
 pub(in crate::runtime::rtc_engine) fn route_packet_to_matching_session_at(
     state: &mut PacketLoopState,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     demux: &mut DemuxRecoveryState,
     metrics: &RtcMetricsRecorder,
     datagram: PacketRouteDatagram<'_>,
 ) {
     match route_packet_with_cached_session(
         state,
-        snapshot_state,
+        observations,
         datagram.source_addr,
         datagram.candidate_addr,
         datagram.packet,
@@ -208,8 +203,8 @@ pub(in crate::runtime::rtc_engine) fn route_packet_to_matching_session_at(
         metrics.record_rtc_datagram_drop(RtcDatagramDropReason::SourceRateLimited);
         return;
     }
-    let route = PacketRouteContext {
-        snapshot_state,
+    let mut route = PacketRouteContext {
+        observations,
         metrics,
         source_addr: datagram.source_addr,
         candidate_addr: datagram.candidate_addr,
@@ -219,15 +214,15 @@ pub(in crate::runtime::rtc_engine) fn route_packet_to_matching_session_at(
     // With one live session, routing degenerates to one `accepts()` check.
     // No recovery index is needed to narrow the candidate set.
     if state.users.len() == 1 {
-        route_packet_by_single_session(state, demux, miss_key, &route);
+        route_packet_by_single_session(state, demux, miss_key, &mut route);
         return;
     }
-    route_packet_by_recovery_index(state, demux, miss_key, &route);
+    route_packet_by_recovery_index(state, demux, miss_key, &mut route);
 }
 
 fn route_packet_with_cached_session(
     state: &mut PacketLoopState,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     source_addr: SocketAddr,
     candidate_addr: SocketAddr,
     packet: &[u8],
@@ -240,12 +235,8 @@ fn route_packet_with_cached_session(
         return CachedRouteOutcome::NotMatched;
     };
     let Some(session_state) = state.users.get_mut(session_key) else {
-        state.remote_addr_demux.forget_remote_addr(source_addr);
-        if let Ok(mut snapshot) = snapshot_state.lock() {
-            // Stale pins must be cleared in the shared snapshot so that any
-            // control-plane observation stays consistent with the worker's
-            // routing discovery.
-            snapshot.remote_addr_demux.forget_remote_addr(source_addr);
+        if state.remote_addr_demux.forget_remote_addr(source_addr) {
+            observations.forget_remote_addr(source_addr);
         }
         return CachedRouteOutcome::NotMatched;
     };
@@ -267,12 +258,8 @@ fn route_packet_with_cached_session(
             media_worker_id = session_key.media_worker_id(),
             "indexed rtc source address no longer matched the cached user; clearing source-address pin"
         );
-        state.remote_addr_demux.forget_remote_addr(source_addr);
-        if let Ok(mut snapshot) = snapshot_state.lock() {
-            // Stale pins must be cleared in the shared snapshot so that any
-            // control-plane observation stays consistent with the worker's
-            // routing discovery.
-            snapshot.remote_addr_demux.forget_remote_addr(source_addr);
+        if state.remote_addr_demux.forget_remote_addr(source_addr) {
+            observations.forget_remote_addr(source_addr);
         }
         return CachedRouteOutcome::NotMatched;
     }
@@ -475,7 +462,7 @@ fn record_unknown_source_miss(
 }
 
 struct PacketRouteContext<'a> {
-    snapshot_state: &'a Arc<Mutex<RtcSnapshotState>>,
+    observations: &'a mut PacketLoopObservations,
     metrics: &'a RtcMetricsRecorder,
     source_addr: SocketAddr,
     candidate_addr: SocketAddr,
@@ -491,7 +478,7 @@ struct PacketRouteContext<'a> {
 fn route_packet_to_session(
     state: &mut PacketLoopState,
     session_key: &TransportSessionKey,
-    route: &PacketRouteContext<'_>,
+    route: &mut PacketRouteContext<'_>,
     input: Input<'_>,
     route_resolution: &'static str,
 ) -> bool {
@@ -518,13 +505,9 @@ fn route_packet_to_session(
     if state
         .remote_addr_demux
         .remember_remote_addr(route.source_addr, session_key)
-        && let Ok(mut snapshot) = route.snapshot_state.lock()
     {
-        // The worker is the source of truth for address pins. New pins must
-        // be mirrored in the snapshot state so they are visible to the rest
-        // of the application.
-        let _ = snapshot
-            .remote_addr_demux
+        route
+            .observations
             .remember_remote_addr(route.source_addr, session_key);
         match previous_session_key {
             Some(previous_session_key) => {
@@ -566,7 +549,7 @@ fn route_packet_by_single_session(
     state: &mut PacketLoopState,
     demux: &mut DemuxRecoveryState,
     miss_key: PacketLoopRoutingMissKey,
-    route: &PacketRouteContext<'_>,
+    route: &mut PacketRouteContext<'_>,
 ) {
     #[cfg(test)]
     demux.record_fallback_attempt();
@@ -615,7 +598,7 @@ fn route_packet_by_recovery_index(
     state: &mut PacketLoopState,
     demux: &mut DemuxRecoveryState,
     miss_key: PacketLoopRoutingMissKey,
-    route: &PacketRouteContext<'_>,
+    route: &mut PacketRouteContext<'_>,
 ) {
     #[cfg(test)]
     demux.record_fallback_attempt();

--- a/crates/core/src/runtime/rtc_engine/packet_loop/input.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/input.rs
@@ -186,7 +186,11 @@ impl PacketLoopControlInput {
     /// The caller remains responsible for invalidating demux recovery hints
     /// after dispatch. Both variants may change ownership indexes that demux
     /// recovery relies on.
-    pub(super) fn dispatch(self, state: &mut PacketLoopState, context: &WorkerCommandContext<'_>) {
+    pub(super) fn dispatch(
+        self,
+        state: &mut PacketLoopState,
+        context: &mut WorkerCommandContext<'_>,
+    ) {
         match self {
             Self::Command(command) => handle_worker_command(state, context, command),
             #[cfg(any(test, feature = "testing-transport"))]

--- a/crates/core/src/runtime/rtc_engine/packet_loop/loop_driver.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/loop_driver.rs
@@ -22,7 +22,7 @@
 use std::{
     io::{Error as IoError, ErrorKind},
     net::{IpAddr, SocketAddr},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -31,11 +31,11 @@ use tracing::warn;
 
 use super::{
     super::{
-        bitrate::BitrateRegistry,
         forwarded_packet::ForwardedPacket,
         forwarding_planner::populate_forward_routes_for_packet,
+        observation::{PacketLoopObservations, RtcObservationPublishers},
         routing_miss::DemuxRecoveryState,
-        state::{PacketLoopState, RtcSnapshotState},
+        state::PacketLoopState,
         worker::{WorkerCommandContext, drain_due_rid_keyframe_refreshes},
     },
     buffers::{MAX_RELAY_PACKETS_PER_ITERATION, PacketLoopBuffers, RECEIVE_BUFFER_LEN},
@@ -137,8 +137,7 @@ pub(super) struct PacketLoopTurn {
 /// making it clear that no await happens while the context exists
 pub(super) struct PacketLoopApplyContext<'a> {
     pub packet_loop_state: &'a mut PacketLoopState,
-    pub bitrate_registry: &'a Arc<Mutex<BitrateRegistry>>,
-    pub snapshot_state: &'a Arc<Mutex<RtcSnapshotState>>,
+    pub observations: &'a mut PacketLoopObservations,
     pub config: &'a PacketLoopConfig,
     pub demux: &'a mut DemuxRecoveryState,
     pub inputs: &'a mut PacketLoopInputReceivers,
@@ -166,7 +165,7 @@ impl PacketLoopTurn {
     pub fn pump(
         &mut self,
         state: &mut PacketLoopState,
-        snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+        observations: &mut PacketLoopObservations,
         config: &PacketLoopConfig,
         relay_rx: &mut mpsc::Receiver<ForwardedPacket>,
     ) -> Option<WaitPhaseSnapshot> {
@@ -187,14 +186,13 @@ impl PacketLoopTurn {
             self.buffers.pending_packets.push(packet);
         }
         let now = turn_started_at;
-        let session_drain_context = SessionDrainContext {
-            snapshot_state,
+        let mut session_drain_context = SessionDrainContext {
+            observations,
             diagnostics: &config.diagnostics,
             metrics: &config.metrics,
-            source_policy_signal: &config.source_policy_signal,
             socket: &socket,
         };
-        drain_ready_sessions(state, &session_drain_context, &mut self.buffers, now);
+        drain_ready_sessions(state, &mut session_drain_context, &mut self.buffers, now);
         drain_relay_packets(
             relay_rx,
             &mut self.buffers.pending_packets,
@@ -333,8 +331,7 @@ impl PacketLoopTurn {
             PacketLoopTurnInput::Control(command) => {
                 handle_control_input(
                     context.packet_loop_state,
-                    context.bitrate_registry,
-                    context.snapshot_state,
+                    context.observations,
                     context.config,
                     command,
                     context.demux,
@@ -512,8 +509,7 @@ const MAX_READY_NOW_INPUTS_BEFORE_YIELD: usize = 32;
 /// ingress indefinitely
 pub(in crate::runtime::rtc_engine) async fn run_packet_loop(
     config: PacketLoopConfig,
-    bitrate_registry: Arc<Mutex<BitrateRegistry>>,
-    snapshot_state: Arc<Mutex<RtcSnapshotState>>,
+    publishers: RtcObservationPublishers,
     mut inputs: PacketLoopInputReceivers,
 ) {
     // transport media ids must start from the worker-assigned range so relay
@@ -529,6 +525,7 @@ pub(in crate::runtime::rtc_engine) async fn run_packet_loop(
     // allocate while media is flowing
     let mut receive_buffer = [0_u8; RECEIVE_BUFFER_LEN];
     let mut turn = PacketLoopTurn::new(Instant::now());
+    let mut observations = PacketLoopObservations::new(publishers);
     let mut next_input = None;
 
     loop {
@@ -536,8 +533,7 @@ pub(in crate::runtime::rtc_engine) async fn run_packet_loop(
             turn.apply_input(
                 &mut PacketLoopApplyContext {
                     packet_loop_state: &mut packet_loop_state,
-                    bitrate_registry: &bitrate_registry,
-                    snapshot_state: &snapshot_state,
+                    observations: &mut observations,
                     config: &config,
                     demux: &mut demux,
                     inputs: &mut inputs,
@@ -549,10 +545,11 @@ pub(in crate::runtime::rtc_engine) async fn run_packet_loop(
 
         let snapshot = turn.pump(
             &mut packet_loop_state,
-            &snapshot_state,
+            &mut observations,
             &config,
             inputs.relay_rx(),
         );
+        observations.publish_dirty_and_wake_policy(&config.source_policy_signal);
 
         turn.flush_outputs(snapshot.as_ref(), &config.packet_loop_lag)
             .await;
@@ -587,7 +584,7 @@ fn route_received_datagram(
     // packet can mutate a session
     route_packet_to_matching_session(
         context.packet_loop_state,
-        context.snapshot_state,
+        context.observations,
         context.demux,
         &context.config.rtc_metrics,
         source_addr,
@@ -602,17 +599,15 @@ fn route_received_datagram(
 /// source tuple or ICE username fragment
 fn handle_control_input(
     packet_loop_state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     config: &PacketLoopConfig,
     command: PacketLoopControlInput,
     demux: &mut DemuxRecoveryState,
 ) {
     command.dispatch(
         packet_loop_state,
-        &WorkerCommandContext {
-            bitrate_registry,
-            snapshot_state,
+        &mut WorkerCommandContext {
+            observations,
             now: Instant::now(),
             public_ip: config.public_ip,
             max_bitrate_in: config.max_bitrate_in,
@@ -623,6 +618,7 @@ fn handle_control_input(
             codec_preferences: config.codec_preferences,
             media_quality_interval: config.media_quality_interval,
             metrics: &config.metrics,
+            source_policy_signal: &config.source_policy_signal,
         },
     );
     demux.clear_on_topology_change();

--- a/crates/core/src/runtime/rtc_engine/packet_loop/session_drain.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/session_drain.rs
@@ -10,13 +10,7 @@
 //! `PacketLoopBuffers`. It avoids scanning all sessions on every
 //! turn.
 
-use std::{
-    io::ErrorKind,
-    mem::take,
-    net::SocketAddr,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::{io::ErrorKind, mem::take, net::SocketAddr, sync::Arc, time::Instant};
 
 use str0m::{Event, Input, Output};
 use tokio::net::UdpSocket;
@@ -24,24 +18,22 @@ use tracing::{trace, warn};
 
 use super::{
     super::{
+        observation::PacketLoopObservations,
         slots::SessionHandle,
-        state::{PacketLoopState, RtcSessionState, RtcSnapshotState},
+        state::{PacketLoopState, RtcSessionState},
     },
     buffers::PacketLoopBuffers,
     event_observation::{log_rtc_event, observe_rtc_event},
     keyframe_requests::PendingKeyframeRequest,
 };
 use crate::runtime::{
-    diagnostics::DiagnosticsStore,
-    media_transport::{SourcePolicySignal, TransportSessionKey},
-    metrics::RuntimeMetrics,
+    diagnostics::DiagnosticsStore, media_transport::TransportSessionKey, metrics::RuntimeMetrics,
 };
 
 pub(super) struct SessionDrainContext<'a> {
-    pub(super) snapshot_state: &'a Arc<Mutex<RtcSnapshotState>>,
+    pub(super) observations: &'a mut PacketLoopObservations,
     pub(super) diagnostics: &'a Arc<DiagnosticsStore>,
     pub(super) metrics: &'a RuntimeMetrics,
-    pub(super) source_policy_signal: &'a SourcePolicySignal,
     pub(super) socket: &'a UdpSocket,
 }
 
@@ -52,7 +44,7 @@ pub(super) struct SessionDrainContext<'a> {
 /// ignored, which keeps teardown races harmless for already queued wakeups.
 pub(super) fn drain_ready_sessions(
     state: &mut PacketLoopState,
-    context: &SessionDrainContext<'_>,
+    context: &mut SessionDrainContext<'_>,
     buffers: &mut PacketLoopBuffers,
     now: Instant,
 ) {
@@ -87,7 +79,7 @@ fn drain_single_session(
     session_handle: SessionHandle,
     session_key: &TransportSessionKey,
     session_state: &mut RtcSessionState,
-    context: &SessionDrainContext<'_>,
+    context: &mut SessionDrainContext<'_>,
     buffers: &mut PacketLoopBuffers,
 ) -> Option<Instant> {
     loop {
@@ -123,10 +115,9 @@ fn drain_single_session(
             }
             Ok(Output::Event(event)) => {
                 observe_rtc_event(
-                    context.snapshot_state,
+                    context.observations,
                     context.diagnostics,
                     context.metrics,
-                    context.source_policy_signal,
                     session_key,
                     &event,
                 );

--- a/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
+++ b/crates/core/src/runtime/rtc_engine/packet_loop/tests.rs
@@ -9,6 +9,7 @@
 use std::{
     collections::BTreeSet,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    slice,
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -17,6 +18,8 @@ use std::{
 };
 
 use str0m::{
+    Event,
+    bwe::{Bitrate as Str0mBitrate, BweKind},
     crypto::from_feature_flags,
     ice::{StunMessage, TransId},
     media::{KeyframeRequestKind, MediaKind, Mid, Rid},
@@ -31,6 +34,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     buffers::{MAX_RELAY_PACKETS_PER_ITERATION, PacketLoopBuffers, RECEIVE_BUFFER_LEN},
+    event_observation::observe_rtc_event,
     forward_flush::{drain_relay_packets, flush_forward_routes, record_incoming_stats},
     ingress_routing::route_packet_to_matching_session,
     input::{PacketLoopInputReceivers, PacketLoopMailboxInput},
@@ -58,7 +62,6 @@ use crate::{
             RoomPacketSinkRegistry,
         },
         rtc_engine::{
-            bitrate::BitrateRegistry,
             bootstrap,
             commands::{
                 RemoteSourceControl, RouteControlRequest, RtcMediaControlCommand, RtcWorkerCommand,
@@ -66,16 +69,17 @@ use crate::{
             demux::{MediaRouteDestination, MediaRouteEntry},
             forwarding_destination::PacketForward,
             media_registry::RegisteredMediaHandle,
+            observation::{PacketLoopObservations, RtcObservationPublishers},
             relay_registry::{RelayPacketMailbox, RelayTargetId},
             route_control::{KeyframeRequestDecision, PacketLayerGate},
             slots::ConsumerStreamHandle,
-            state::{PacketLoopState, RtcSnapshotState, SharedRtcSocket},
+            state::{PacketLoopState, SharedRtcSocket, TransportSessionHealth},
             test_support::{
-                DebugProbe, DebugProbeRequest, collect_ready_session_keys,
-                sample_already_relayed_packet, sample_forwarded_packet,
-                sample_forwarded_packet_with_audio_activity, sample_forwarded_packet_with_rid,
-                sample_forwarded_packet_without_mid, sample_local_forwarded_packet,
-                test_transport_session_key,
+                DebugProbe, DebugProbeRequest, SetSessionTransportHealthProbe,
+                collect_ready_session_keys, handle_debug_probe, sample_already_relayed_packet,
+                sample_forwarded_packet, sample_forwarded_packet_with_audio_activity,
+                sample_forwarded_packet_with_rid, sample_forwarded_packet_without_mid,
+                sample_local_forwarded_packet, test_transport_session_key,
             },
         },
     },
@@ -120,7 +124,7 @@ impl MediaPacketSink for CountingSink {
 
 struct IngressRoutingHarness {
     packet_loop_state: PacketLoopState,
-    snapshot_state: Arc<Mutex<RtcSnapshotState>>,
+    observations: PacketLoopObservations,
     demux: super::super::routing_miss::DemuxRecoveryState,
     metrics: RuntimeMetrics,
     rtc_metrics: Arc<RtcMetricsRecorder>,
@@ -134,7 +138,7 @@ impl IngressRoutingHarness {
         let rtc_metrics = metrics.register_rtc_worker();
         Self {
             packet_loop_state: PacketLoopState::default(),
-            snapshot_state: Arc::new(Mutex::new(RtcSnapshotState::default())),
+            observations: PacketLoopObservations::new(RtcObservationPublishers::new()),
             demux: super::super::routing_miss::DemuxRecoveryState::new(),
             metrics,
             rtc_metrics,
@@ -146,12 +150,24 @@ impl IngressRoutingHarness {
     fn route(&mut self, packet: &[u8]) {
         route_packet_to_matching_session(
             &mut self.packet_loop_state,
-            &self.snapshot_state,
+            &mut self.observations,
             &mut self.demux,
             &self.rtc_metrics,
             self.source_addr,
             self.candidate_addr,
             packet,
+        );
+    }
+
+    fn remember_remote_addr(&mut self, session_key: &TransportSessionKey) {
+        assert!(
+            self.packet_loop_state
+                .remote_addr_demux
+                .remember_remote_addr(self.source_addr, session_key)
+        );
+        assert!(
+            self.observations
+                .remember_remote_addr(self.source_addr, session_key)
         );
     }
 }
@@ -166,7 +182,7 @@ impl DebugProbe for MarkSessionDirtyProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &super::super::worker::WorkerCommandContext<'_>,
+        _context: &mut super::super::worker::WorkerCommandContext<'_>,
     ) -> Self::Output {
         state.mark_session_dirty(&self.session_key);
     }
@@ -445,6 +461,26 @@ fn packet_loop_config_for_test() -> PacketLoopConfig {
     }
 }
 
+fn worker_command_context_for_test<'a>(
+    observations: &'a mut PacketLoopObservations,
+    config: &'a PacketLoopConfig,
+) -> super::super::worker::WorkerCommandContext<'a> {
+    super::super::worker::WorkerCommandContext {
+        observations,
+        now: Instant::now(),
+        public_ip: config.public_ip,
+        max_bitrate_in: config.max_bitrate_in,
+        max_bitrate_out: config.max_bitrate_out,
+        video_bitrate_limits: config.video_bitrate_limits,
+        rtc_port_range: config.rtc_port_range,
+        codec_flags: config.codec_flags,
+        codec_preferences: config.codec_preferences,
+        media_quality_interval: config.media_quality_interval,
+        metrics: &config.metrics,
+        source_policy_signal: &config.source_policy_signal,
+    }
+}
+
 fn valid_rtp_packet(sequence_number: u16, ssrc: u32) -> Vec<u8> {
     let sequence_number = sequence_number.to_be_bytes();
     let ssrc = ssrc.to_be_bytes();
@@ -462,6 +498,78 @@ fn valid_rtp_packet(sequence_number: u16, ssrc: u32) -> Vec<u8> {
         ssrc[2],
         ssrc[3],
     ]
+}
+
+#[test]
+fn receiver_bandwidth_wake_waits_for_snapshot_publication() {
+    let publishers = RtcObservationPublishers::new();
+    let mut observations = PacketLoopObservations::new(publishers.clone());
+    let source_policy_signal = SourcePolicySignal::default();
+    let subscription = source_policy_signal.subscribe();
+    let session_key = test_transport_session_key(70, 0, 71, UserId::Integer(72));
+    let diagnostics = Arc::new(DiagnosticsStore::default());
+    let metrics = RuntimeMetrics::default();
+    let receiver_bandwidth = || {
+        publishers
+            .snapshot_state()
+            .load()
+            .receiver_bandwidth_snapshot(slice::from_ref(&session_key))
+            .per_session
+    };
+
+    observe_rtc_event(
+        &mut observations,
+        &diagnostics,
+        &metrics,
+        &session_key,
+        &Event::EgressBitrateEstimate(BweKind::Twcc(Str0mBitrate::bps(320_000))),
+    );
+
+    assert!(subscription.take_pending_updates().is_empty());
+    assert!(receiver_bandwidth().is_empty());
+
+    observations.publish_dirty_and_wake_policy(&source_policy_signal);
+
+    assert!(
+        subscription
+            .take_pending_updates()
+            .contains(&session_key.room_instance_id())
+    );
+    assert_eq!(
+        receiver_bandwidth(),
+        vec![(session_key.clone(), Bitrate::from_bps(320_000))]
+    );
+}
+
+#[test]
+fn debug_probe_response_waits_for_observation_publication() {
+    let publishers = RtcObservationPublishers::new();
+    let mut observations = PacketLoopObservations::new(publishers.clone());
+    let mut state = PacketLoopState::default();
+    let config = packet_loop_config_for_test();
+    let session_key = test_transport_session_key(73, 0, 74, UserId::Integer(75));
+    let (response_tx, mut response_rx) = oneshot::channel();
+
+    handle_debug_probe(
+        &mut state,
+        &mut worker_command_context_for_test(&mut observations, &config),
+        DebugProbeRequest::new(
+            SetSessionTransportHealthProbe {
+                session_key: session_key.clone(),
+                health: TransportSessionHealth::Disconnected,
+            },
+            response_tx,
+        ),
+    );
+
+    assert!(response_rx.try_recv().is_ok());
+    assert_eq!(
+        publishers
+            .snapshot_state()
+            .load()
+            .transport_health(&session_key),
+        Some(TransportSessionHealth::Disconnected)
+    );
 }
 
 fn serialize_stun_message(message: &StunMessage<'_>, password: Option<&[u8]>) -> Option<Vec<u8>> {
@@ -602,22 +710,7 @@ fn indexed_route_stays_cached_without_touching_recent_miss_state() -> Result<(),
         .get_mut(&session_key)
         .map(|session_state| session_state.rtc.direct_api().local_ice_credentials())
         .ok_or("session state missing after creation")?;
-    assert!(
-        harness
-            .packet_loop_state
-            .remote_addr_demux
-            .remember_remote_addr(harness.source_addr, &session_key)
-    );
-    {
-        let Ok(mut snapshot) = harness.snapshot_state.lock() else {
-            return Err("snapshot state lock poisoned");
-        };
-        assert!(
-            snapshot
-                .remote_addr_demux
-                .remember_remote_addr(harness.source_addr, &session_key)
-        );
-    }
+    harness.remember_remote_addr(&session_key);
 
     let username = format!("{}:remote-ufrag", local_ice_credentials.ufrag);
     let packet = serialize_stun_message(
@@ -651,17 +744,14 @@ fn indexed_route_stays_cached_without_touching_recent_miss_state() -> Result<(),
             .session_key_for_remote_addr(harness.source_addr),
         Some(&session_key)
     );
-    {
-        let Ok(snapshot) = harness.snapshot_state.lock() else {
-            return Err("snapshot state lock poisoned");
-        };
-        assert_eq!(
-            snapshot
-                .remote_addr_demux
-                .session_key_for_remote_addr(harness.source_addr),
-            Some(&session_key)
-        );
-    }
+    assert_eq!(
+        harness
+            .observations
+            .snapshot_state()
+            .remote_addr_demux
+            .session_key_for_remote_addr(harness.source_addr),
+        Some(&session_key)
+    );
     assert!(harness.demux.should_skip_scan(miss_key, &packet));
     assert!(harness.demux.is_tracking_source(harness.source_addr));
     let snapshot = harness.metrics.snapshot();
@@ -672,26 +762,11 @@ fn indexed_route_stays_cached_without_touching_recent_miss_state() -> Result<(),
 }
 
 #[test]
-fn stale_indexed_route_clears_worker_and_snapshot_pins() -> Result<(), &'static str> {
+fn stale_indexed_route_clears_worker_and_snapshot_pins() {
     let mut harness = IngressRoutingHarness::new(45_048, 45_047);
     let stale_session_key = test_transport_session_key(51, 0, 58, UserId::Integer(59));
 
-    assert!(
-        harness
-            .packet_loop_state
-            .remote_addr_demux
-            .remember_remote_addr(harness.source_addr, &stale_session_key)
-    );
-    {
-        let Ok(mut snapshot) = harness.snapshot_state.lock() else {
-            return Err("snapshot state lock poisoned");
-        };
-        assert!(
-            snapshot
-                .remote_addr_demux
-                .remember_remote_addr(harness.source_addr, &stale_session_key)
-        );
-    }
+    harness.remember_remote_addr(&stale_session_key);
 
     harness.route(&valid_rtp_packet(11, 111));
 
@@ -702,22 +777,18 @@ fn stale_indexed_route_clears_worker_and_snapshot_pins() -> Result<(), &'static 
             .session_key_for_remote_addr(harness.source_addr)
             .is_none()
     );
-    {
-        let Ok(snapshot) = harness.snapshot_state.lock() else {
-            return Err("snapshot state lock poisoned");
-        };
-        assert!(
-            snapshot
-                .remote_addr_demux
-                .session_key_for_remote_addr(harness.source_addr)
-                .is_none()
-        );
-    }
+    assert!(
+        harness
+            .observations
+            .snapshot_state()
+            .remote_addr_demux
+            .session_key_for_remote_addr(harness.source_addr)
+            .is_none()
+    );
     assert_eq!(harness.demux.fallback_attempts(), 1);
     let snapshot = harness.metrics.snapshot();
     assert_eq!(snapshot.rtc_datagram_fallback_scans(), 1);
     assert_eq!(snapshot.rtc_datagram_drops_no_user(), 1);
-    Ok(())
 }
 
 #[test]
@@ -1097,8 +1168,7 @@ fn packet_loop_wakes_immediately_when_forwarding_marks_a_session_dirty() {
 async fn packet_loop_waits_for_one_control_then_pumps_before_the_next_control()
 -> Result<(), &'static str> {
     let mut state = PacketLoopState::default();
-    let snapshot_state = Arc::new(Mutex::new(RtcSnapshotState::default()));
-    let bitrate_registry = Arc::new(Mutex::new(BitrateRegistry::default()));
+    let mut observations = PacketLoopObservations::new(RtcObservationPublishers::new());
     let config = packet_loop_config_for_test();
     let mut demux = super::super::routing_miss::DemuxRecoveryState::new();
     let mut receive_buffer = [0_u8; RECEIVE_BUFFER_LEN];
@@ -1164,8 +1234,7 @@ async fn packet_loop_waits_for_one_control_then_pumps_before_the_next_control()
     turn.apply_input(
         &mut PacketLoopApplyContext {
             packet_loop_state: &mut state,
-            bitrate_registry: &bitrate_registry,
-            snapshot_state: &snapshot_state,
+            observations: &mut observations,
             config: &config,
             demux: &mut demux,
             inputs: &mut inputs,
@@ -1179,7 +1248,7 @@ async fn packet_loop_waits_for_one_control_then_pumps_before_the_next_control()
     assert!(state.has_dirty_sessions());
 
     let snapshot = turn
-        .pump(&mut state, &snapshot_state, &config, inputs.relay_rx())
+        .pump(&mut state, &mut observations, &config, inputs.relay_rx())
         .ok_or("packet loop should keep the socket snapshot")?;
 
     assert!(!state.has_dirty_sessions());

--- a/crates/core/src/runtime/rtc_engine/state/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/state/mod.rs
@@ -683,9 +683,9 @@ impl PartialOrd for PendingRidKeyframeRefresh {
 ///
 /// this state mirrors facts that diagnostics, placement and transport policy
 /// need without exposing mutable [`PacketLoopState`]
-/// it is protected by a cold-path mutex while packet-path state remains
-/// worker-owned and single-threaded
-#[derive(Debug, Default)]
+/// packet-loop-owned state is published through immutable atomic snapshots
+/// so readers cannot block the worker
+#[derive(Debug, Default, Clone)]
 pub struct RtcSnapshotState {
     /// demux hints visible to diagnostics and recovery tooling
     pub(super) remote_addr_demux: RemoteAddrDemux,
@@ -701,8 +701,8 @@ pub struct RtcSnapshotState {
 
 impl RtcSnapshotState {
     /// mark a session as visible in read-side RTC state
-    pub(super) fn add_session(&mut self, session_key: &TransportSessionKey) {
-        self.live_sessions.insert(session_key.clone());
+    pub(super) fn add_session(&mut self, session_key: &TransportSessionKey) -> bool {
+        self.live_sessions.insert(session_key.clone())
     }
 
     /// remove every read-side fact owned by one session
@@ -712,16 +712,25 @@ impl RtcSnapshotState {
     pub(super) fn remove_session(
         &mut self,
         session_key: &TransportSessionKey,
-    ) -> Option<TransportSessionHealth> {
-        self.live_sessions.remove(session_key);
-        self.remote_addr_demux.forget_user_remote_addrs(session_key);
-        self.remote_addr_demux
+    ) -> (Option<TransportSessionHealth>, bool) {
+        let mut changed = self.live_sessions.remove(session_key);
+        changed |= self.remote_addr_demux.forget_user_remote_addrs(session_key);
+        changed |= self
+            .remote_addr_demux
             .forget_user_local_ice_ufrag(session_key);
-        self.remote_addr_demux
+        changed |= self
+            .remote_addr_demux
             .forget_user_remote_candidate_addrs(session_key);
-        self.receiver_bandwidth_by_session.remove(session_key);
-        self.transport_quality_by_session.remove(session_key);
-        self.transport_health_by_session.remove(session_key)
+        changed |= self
+            .receiver_bandwidth_by_session
+            .remove(session_key)
+            .is_some();
+        changed |= self
+            .transport_quality_by_session
+            .remove(session_key)
+            .is_some();
+        let previous = self.transport_health_by_session.remove(session_key);
+        (previous, changed || previous.is_some())
     }
 
     /// replace the latest transport health observation for one session

--- a/crates/core/src/runtime/rtc_engine/test_support.rs
+++ b/crates/core/src/runtime/rtc_engine/test_support.rs
@@ -22,7 +22,7 @@ pub use probe::{DebugPacketGate, DebugRouteDestination};
 #[cfg(any(test, feature = "testing-transport"))]
 pub(super) use probe::{
     DebugProbe, DebugProbeRequest, RouteEntryByConsumerMidProbe, RtcWorkerDebugChannels,
-    RtcWorkerDebugHandle, handle_debug_probe,
+    RtcWorkerDebugHandle, SetSessionTransportHealthProbe, handle_debug_probe,
 };
 #[cfg(any(test, feature = "testing-transport"))]
 pub(super) use probe::{ObserveAudioActivityProbe, RouteEntryByMediaIdProbe, RouteEntryProbe};

--- a/crates/core/src/runtime/rtc_engine/test_support/probe.rs
+++ b/crates/core/src/runtime/rtc_engine/test_support/probe.rs
@@ -36,6 +36,8 @@ use {
     std::{net::SocketAddr, time::Instant},
 };
 
+#[cfg(any(test, feature = "testing-transport"))]
+use crate::runtime::rtc_engine::state::TransportSessionHealth;
 use crate::runtime::{
     media_transport::{TransportMediaId, TransportSessionKey},
     rtc_engine::{
@@ -117,8 +119,7 @@ impl RtcWorkerDebugChannels {
 ///
 /// [`Self::inspect`] runs on the packet-loop worker with exclusive access to
 /// [`PacketLoopState`]
-/// it may also use [`WorkerCommandContext`] for shared
-/// cold-path side stores such as snapshots or bitrate registries
+/// it may also use [`WorkerCommandContext`] for worker-owned observations
 pub(in crate::runtime::rtc_engine) trait DebugProbe:
     Send + 'static
 {
@@ -128,7 +129,7 @@ pub(in crate::runtime::rtc_engine) trait DebugProbe:
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        context: &WorkerCommandContext<'_>,
+        context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output;
 }
 
@@ -138,7 +139,11 @@ pub(in crate::runtime::rtc_engine) trait DebugProbe:
 /// the call site and the concrete probe implementation keep the exact response
 /// type through [`DebugProbe::Output`]
 trait ErasedDebugProbe: Send {
-    fn inspect(self: Box<Self>, state: &mut PacketLoopState, context: &WorkerCommandContext<'_>);
+    fn inspect(
+        self: Box<Self>,
+        state: &mut PacketLoopState,
+        context: &mut WorkerCommandContext<'_>,
+    );
 }
 
 struct DebugProbeEnvelope<P>
@@ -153,9 +158,15 @@ impl<P> ErasedDebugProbe for DebugProbeEnvelope<P>
 where
     P: DebugProbe,
 {
-    fn inspect(self: Box<Self>, state: &mut PacketLoopState, context: &WorkerCommandContext<'_>) {
+    fn inspect(
+        self: Box<Self>,
+        state: &mut PacketLoopState,
+        context: &mut WorkerCommandContext<'_>,
+    ) {
         let Self { probe, response } = *self;
-        let _ = response.send(probe.inspect(state, context));
+        let output = probe.inspect(state, context);
+        context.publish_observations();
+        let _ = response.send(output);
     }
 }
 
@@ -177,7 +188,7 @@ impl DebugProbeRequest {
         }
     }
 
-    pub fn inspect(self, state: &mut PacketLoopState, context: &WorkerCommandContext<'_>) {
+    pub fn inspect(self, state: &mut PacketLoopState, context: &mut WorkerCommandContext<'_>) {
         self.probe.inspect(state, context);
     }
 }
@@ -185,7 +196,7 @@ impl DebugProbeRequest {
 /// dispatches one test probe against the authoritative worker state
 pub(in crate::runtime::rtc_engine) fn handle_debug_probe(
     state: &mut PacketLoopState,
-    context: &WorkerCommandContext<'_>,
+    context: &mut WorkerCommandContext<'_>,
     probe: DebugProbeRequest,
 ) {
     probe.inspect(state, context);
@@ -203,7 +214,7 @@ impl DebugProbe for ResolveMidProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state.resolve_mid(self.transport_media_id)
     }
@@ -221,14 +232,14 @@ impl DebugProbe for RemoteAddrOwnerProbe {
     fn inspect(
         self,
         _state: &mut PacketLoopState,
-        context: &WorkerCommandContext<'_>,
+        context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
-        context.snapshot_state.lock().ok().and_then(|snapshot| {
-            snapshot
-                .remote_addr_demux
-                .session_key_for_remote_addr(self.source_addr)
-                .cloned()
-        })
+        context
+            .observations
+            .snapshot_state()
+            .remote_addr_demux
+            .session_key_for_remote_addr(self.source_addr)
+            .cloned()
     }
 }
 
@@ -242,13 +253,34 @@ impl DebugProbe for HasAnyRemoteAddrSessionProbe {
     fn inspect(
         self,
         _state: &mut PacketLoopState,
-        context: &WorkerCommandContext<'_>,
+        context: &mut WorkerCommandContext<'_>,
+    ) -> Self::Output {
+        !context
+            .observations
+            .snapshot_state()
+            .remote_addr_demux
+            .is_empty()
+    }
+}
+
+#[cfg(any(test, feature = "testing-transport"))]
+pub(in crate::runtime::rtc_engine) struct SetSessionTransportHealthProbe {
+    pub session_key: TransportSessionKey,
+    pub health: TransportSessionHealth,
+}
+
+#[cfg(any(test, feature = "testing-transport"))]
+impl DebugProbe for SetSessionTransportHealthProbe {
+    type Output = Option<TransportSessionHealth>;
+
+    fn inspect(
+        self,
+        _state: &mut PacketLoopState,
+        context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         context
-            .snapshot_state
-            .lock()
-            .ok()
-            .is_some_and(|snapshot| !snapshot.remote_addr_demux.is_empty())
+            .observations
+            .set_transport_health(&self.session_key, self.health)
     }
 }
 
@@ -265,15 +297,14 @@ impl DebugProbe for RememberRemoteAddrProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        context: &WorkerCommandContext<'_>,
+        context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         if state
             .remote_addr_demux
             .remember_remote_addr(self.source_addr, &self.session_key)
-            && let Ok(mut snapshot) = context.snapshot_state.lock()
         {
-            let _ = snapshot
-                .remote_addr_demux
+            context
+                .observations
                 .remember_remote_addr(self.source_addr, &self.session_key);
         }
     }
@@ -292,7 +323,7 @@ impl DebugProbe for SessionStreamRxSsrcProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state
             .users
@@ -319,7 +350,7 @@ impl DebugProbe for SessionStreamTxSsrcProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state
             .users
@@ -345,7 +376,7 @@ impl DebugProbe for SessionMaxBitrateInProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state
             .users
@@ -366,7 +397,7 @@ impl DebugProbe for SessionMaxBitrateOutProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state
             .users
@@ -388,7 +419,7 @@ impl DebugProbe for RouteEntryProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state
             .source_transport_media_id_for_mid(&self.source_session_key, self.source_mid)
@@ -409,7 +440,7 @@ impl DebugProbe for RouteEntryByConsumerMidProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state
             .consumer_source_transport_media_id_for_mid(
@@ -434,7 +465,7 @@ impl DebugProbe for RouteEntryByMediaIdProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         debug_route_entry(state, self.source_transport_media_id)
     }
@@ -455,14 +486,13 @@ impl DebugProbe for RecordIncomingMediaProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        context: &WorkerCommandContext<'_>,
+        context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         if state
             .record_incoming_bitrate(self.transport_media_id, self.now, self.payload_bytes)
             .is_none()
-            && let Ok(mut bitrate) = context.bitrate_registry.lock()
         {
-            let counter = bitrate.register_incoming_media(
+            let counter = context.observations.register_incoming_media(
                 &self.session_key,
                 self.transport_media_id,
                 self.now,
@@ -488,7 +518,7 @@ impl DebugProbe for ObserveAudioActivityProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state.route_control.observe_audio_activity(
             self.transport_media_id,
@@ -511,7 +541,7 @@ impl DebugProbe for RelayTargetCountProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state.relay_target_count_for_source(self.source_transport_media_id)
     }
@@ -529,7 +559,7 @@ impl DebugProbe for ActiveRelayTargetCountProbe {
     fn inspect(
         self,
         state: &mut PacketLoopState,
-        _context: &WorkerCommandContext<'_>,
+        _context: &mut WorkerCommandContext<'_>,
     ) -> Self::Output {
         state.active_relay_target_count_for_source(self.source_transport_media_id)
     }

--- a/crates/core/src/runtime/rtc_engine/tests/lifecycle_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/lifecycle_tests.rs
@@ -138,10 +138,12 @@ async fn rtc_transport_close_session_cleans_transport_health_snapshot() {
             .is_ok()
     );
 
-    adapter.debug_set_session_transport_health(
-        &session_key,
-        super::super::state::TransportSessionHealth::Disconnected,
-    );
+    adapter
+        .debug_set_session_transport_health(
+            &session_key,
+            super::super::state::TransportSessionHealth::Disconnected,
+        )
+        .await;
     let metrics_snapshot = adapter.metrics.snapshot();
     assert_eq!(metrics_snapshot.connected_transport_users(), 0);
     assert_eq!(metrics_snapshot.disconnected_transport_users(), 1);
@@ -245,10 +247,12 @@ async fn rtc_transport_distinguishes_same_session_id_across_channels() {
             .is_ok()
     );
 
-    adapter.debug_set_session_transport_health(
-        &second_session_key,
-        super::super::state::TransportSessionHealth::Disconnected,
-    );
+    adapter
+        .debug_set_session_transport_health(
+            &second_session_key,
+            super::super::state::TransportSessionHealth::Disconnected,
+        )
+        .await;
     assert!(
         adapter
             .close_session_with_outcome(&first_session_key)

--- a/crates/core/src/runtime/rtc_engine/tests/media_flow_tests.rs
+++ b/crates/core/src/runtime/rtc_engine/tests/media_flow_tests.rs
@@ -573,15 +573,10 @@ async fn rtc_incoming_bitrate_snapshot_expires_after_one_second() {
     let Some(worker_handle) = adapter.worker_handle().ok().flatten() else {
         return;
     };
-    let snapshot = {
-        let Ok(bitrate_registry) = worker_handle.bitrate_registry.lock() else {
-            return;
-        };
-        bitrate_registry.transport_bitrate_snapshot_at(
-            slice::from_ref(&session_key),
-            now + Duration::from_secs(2),
-        )
-    };
+    let snapshot = worker_handle
+        .bitrate_registry
+        .load()
+        .transport_bitrate_snapshot_at(slice::from_ref(&session_key), now + Duration::from_secs(2));
     assert_eq!(snapshot.total, Bitrate::zero());
     assert!(snapshot.per_media.is_empty());
 }

--- a/crates/core/src/runtime/rtc_engine/worker/handlers/dispatcher.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/handlers/dispatcher.rs
@@ -2,13 +2,12 @@
 //!
 //! This module exists to keep the mailbox match in one place while the actual
 //! state mutation lives in focused submodules. It should stay simple:
-//!  decode one worker command, forward it to the owning module, and passe
+//!  decode one worker command then forward it to the owning module and pass
 //! through the immutable runtime context that those handlers need.
 
 use std::{
     collections::BTreeSet,
     net::IpAddr,
-    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -18,9 +17,9 @@ use tokio::sync::oneshot;
 use super::publication;
 use super::{
     super::super::{
-        bitrate::BitrateRegistry,
         commands::{RtcMediaControlCommand, RtcWorkerCommand},
-        state::{PacketLoopState, RtcSnapshotState},
+        observation::PacketLoopObservations,
+        state::PacketLoopState,
     },
     media,
     negotiation::{self, OfferBootstrapConfig},
@@ -31,15 +30,15 @@ use crate::{
     runtime::{
         RoomInstanceId,
         media_transport::{
-            ActiveSpeakerSource, ActiveSpeakerSourceDiagnostic, TransportAdapterError,
+            ActiveSpeakerSource, ActiveSpeakerSourceDiagnostic, SourcePolicySignal,
+            TransportAdapterError,
         },
         metrics::RuntimeMetrics,
     },
 };
 
 pub struct WorkerCommandContext<'a> {
-    pub bitrate_registry: &'a Arc<Mutex<BitrateRegistry>>,
-    pub snapshot_state: &'a Arc<Mutex<RtcSnapshotState>>,
+    pub observations: &'a mut PacketLoopObservations,
     pub now: Instant,
     pub public_ip: IpAddr,
     pub max_bitrate_in: Bitrate,
@@ -50,6 +49,14 @@ pub struct WorkerCommandContext<'a> {
     pub codec_preferences: CodecPreferences,
     pub media_quality_interval: Option<Duration>,
     pub metrics: &'a RuntimeMetrics,
+    pub source_policy_signal: &'a SourcePolicySignal,
+}
+
+impl WorkerCommandContext<'_> {
+    pub(in crate::runtime::rtc_engine) fn publish_observations(&mut self) {
+        self.observations
+            .publish_dirty_and_wake_policy(self.source_policy_signal);
+    }
 }
 
 /// Dispatch one production worker command against the worker-local RTC state.
@@ -58,7 +65,7 @@ pub struct WorkerCommandContext<'a> {
 /// runs on the packet-loop task that owns the worker.
 pub fn handle_worker_command(
     state: &mut PacketLoopState,
-    context: &WorkerCommandContext<'_>,
+    context: &mut WorkerCommandContext<'_>,
     command: RtcWorkerCommand,
 ) {
     match command {
@@ -74,14 +81,7 @@ pub fn handle_worker_command(
         RtcWorkerCommand::CloseSession {
             session_key,
             response,
-        } => session::respond_close_session(
-            state,
-            context.bitrate_registry,
-            context.snapshot_state,
-            &session_key,
-            context.metrics,
-            response,
-        ),
+        } => session::respond_close_session(state, context, &session_key, response),
         #[cfg(test)]
         RtcWorkerCommand::ResolveNegotiatedProducerParameters {
             session_key,
@@ -101,26 +101,14 @@ pub fn handle_worker_command(
         | RtcWorkerCommand::AddRecvMedia { .. }
         | RtcWorkerCommand::AddSendMedia { .. }
         | RtcWorkerCommand::MediaControl(_) => {
-            handle_media_command(
-                state,
-                context.bitrate_registry,
-                media::RecvMediaPolicy {
-                    max_bitrate_in: context.max_bitrate_in,
-                    video_bitrate_limits: context.video_bitrate_limits,
-                    codec_flags: context.codec_flags,
-                    codec_preferences: context.codec_preferences,
-                },
-                context.metrics,
-                context.now,
-                command,
-            );
+            handle_media_command(state, context, command);
         }
     }
 }
 
 fn handle_negotiation_command(
     state: &mut PacketLoopState,
-    context: &WorkerCommandContext<'_>,
+    context: &mut WorkerCommandContext<'_>,
     command: RtcWorkerCommand,
 ) {
     match command {
@@ -129,8 +117,7 @@ fn handle_negotiation_command(
             response,
         } => negotiation::respond_create_initial_session_offer(
             state,
-            context.bitrate_registry,
-            context.snapshot_state,
+            context,
             OfferBootstrapConfig {
                 public_ip: context.public_ip,
                 max_bitrate_out: context.max_bitrate_out,
@@ -212,10 +199,7 @@ fn respond_expired_active_speaker_room_instance_ids(
 
 fn handle_media_command(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
-    recv_media_policy: media::RecvMediaPolicy,
-    metrics: &RuntimeMetrics,
-    now: Instant,
+    context: &mut WorkerCommandContext<'_>,
     command: RtcWorkerCommand,
 ) {
     match command {
@@ -223,27 +207,31 @@ fn handle_media_command(
             session_key,
             transport_media_id,
             response,
-        } => media::respond_remove_media(
-            state,
-            bitrate_registry,
-            &session_key,
-            transport_media_id,
-            response,
-        ),
+        } => {
+            media::respond_remove_media(state, context, &session_key, transport_media_id, response);
+        }
         RtcWorkerCommand::AddRecvMedia {
             session_key,
             media_kind,
             rtp_parameters,
             response,
-        } => media::respond_add_recv_media(
-            state,
-            bitrate_registry,
-            recv_media_policy,
-            &session_key,
-            media_kind,
-            &rtp_parameters,
-            response,
-        ),
+        } => {
+            let policy = media::RecvMediaPolicy {
+                max_bitrate_in: context.max_bitrate_in,
+                video_bitrate_limits: context.video_bitrate_limits,
+                codec_flags: context.codec_flags,
+                codec_preferences: context.codec_preferences,
+            };
+            media::respond_add_recv_media(
+                state,
+                context,
+                policy,
+                &session_key,
+                media_kind,
+                &rtp_parameters,
+                response,
+            );
+        }
         RtcWorkerCommand::AddSendMedia {
             consumer_session_key,
             media_kind,
@@ -262,11 +250,11 @@ fn handle_media_command(
                 consumer_rtp_parameters: &consumer_rtp_parameters,
                 active,
             },
-            now,
+            context.now,
             response,
         ),
         RtcWorkerCommand::MediaControl(command) => {
-            handle_media_route_control_command(state, metrics, now, command);
+            handle_media_route_control_command(state, context.metrics, context.now, command);
         }
         _ => {}
     }

--- a/crates/core/src/runtime/rtc_engine/worker/handlers/media/lifecycle.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/handlers/media/lifecycle.rs
@@ -11,10 +11,7 @@
 //!   to hand out a second local offer while the previous one still awaits an
 //!   answer
 
-use std::{
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::time::Instant;
 
 use o_sfu_router::MediaStream as RouterRtpParameters;
 use str0m::{
@@ -27,16 +24,16 @@ use tracing::{debug, warn};
 use super::{
     super::{
         super::super::{
-            bitrate::BitrateRegistry,
             commands::RtcWorkerResponse,
             media_registry::{
                 DecoderRefreshCodec, RegisteredMediaHandle, RemoteSourceRegistration,
             },
+            observation::PacketLoopObservations,
             simulcast,
             slots::ConsumerStreamHandle,
             state::{PacketLoopState, PendingRecvStream, RtcSessionState},
         },
-        negotiation,
+        WorkerCommandContext, negotiation,
     },
     control::{
         ConsumerRouteRegistration, ensure_route_source_registered, register_consumer_route,
@@ -109,36 +106,35 @@ impl RemoteSourceRollback {
 
 pub fn respond_remove_media(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
+    context: &mut WorkerCommandContext<'_>,
     session_key: &TransportSessionKey,
     transport_media_id: TransportMediaId,
     response: RtcWorkerResponse<()>,
 ) {
-    let _ = response.send(worker_remove_media(
-        state,
-        bitrate_registry,
-        session_key,
-        transport_media_id,
-    ));
+    let result = worker_remove_media(state, context.observations, session_key, transport_media_id);
+    context.publish_observations();
+    let _ = response.send(result);
 }
 
 pub fn respond_add_recv_media(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
+    context: &mut WorkerCommandContext<'_>,
     policy: RecvMediaPolicy,
     session_key: &TransportSessionKey,
     media_kind: MediaKind,
     rtp_parameters: &RouterRtpParameters,
     response: RtcWorkerResponse<TransportMediaId>,
 ) {
-    let _ = response.send(worker_add_recv_media(
+    let result = worker_add_recv_media(
         state,
-        bitrate_registry,
+        context.observations,
         policy,
         session_key,
         media_kind,
         rtp_parameters,
-    ));
+    );
+    context.publish_observations();
+    let _ = response.send(result);
 }
 
 pub fn respond_add_send_media(
@@ -165,7 +161,7 @@ pub fn respond_resolve_media_mid(
 /// SDP, route, and remote-source side effect that still points at it.
 fn worker_remove_media(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
+    observations: &mut PacketLoopObservations,
     session_key: &TransportSessionKey,
     transport_media_id: TransportMediaId,
 ) -> Result<(), TransportAdapterError> {
@@ -183,7 +179,7 @@ fn worker_remove_media(
             mid = ?handle.mid(),
             "released unnegotiated producer media without staging sdp removal"
         );
-        return unregister_media_handle(state, bitrate_registry, transport_media_id);
+        return unregister_media_handle(state, observations, transport_media_id);
     }
     if let Err(error) =
         stage_last_mid_removal_before_unregistering_handle(state, transport_media_id, &handle)
@@ -201,12 +197,12 @@ fn worker_remove_media(
             "released unnegotiated producer media after removal staging failed"
         );
     }
-    unregister_media_handle(state, bitrate_registry, transport_media_id)
+    unregister_media_handle(state, observations, transport_media_id)
 }
 
 fn unregister_media_handle(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
+    observations: &mut PacketLoopObservations,
     transport_media_id: TransportMediaId,
 ) -> Result<(), TransportAdapterError> {
     let Some(handle) = state.remove_media_handle(transport_media_id) else {
@@ -214,9 +210,7 @@ fn unregister_media_handle(
     };
     match handle {
         RegisteredMediaHandle::Producer { session_key, mid } => {
-            if let Ok(mut bitrate) = bitrate_registry.lock() {
-                bitrate.remove_incoming_media(&session_key, transport_media_id);
-            }
+            observations.remove_incoming_media(&session_key, transport_media_id);
             if let Some(session_state) = state.users.get_mut(&session_key) {
                 session_state
                     .sdp_negotiation
@@ -366,7 +360,7 @@ fn worker_stage_native_media_removal(
 /// point every addition must stage the next renegotiation offer first.
 fn worker_add_recv_media(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
+    observations: &mut PacketLoopObservations,
     policy: RecvMediaPolicy,
     session_key: &TransportSessionKey,
     media_kind: MediaKind,
@@ -410,11 +404,9 @@ fn worker_add_recv_media(
         session_key: session_key.clone(),
         mid,
     });
-    if let Ok(mut bitrate) = bitrate_registry.lock() {
-        let counter =
-            bitrate.register_incoming_media(session_key, transport_media_id, Instant::now());
-        state.register_incoming_bitrate_counter(transport_media_id, counter);
-    }
+    let counter =
+        observations.register_incoming_media(session_key, transport_media_id, Instant::now());
+    state.register_incoming_bitrate_counter(transport_media_id, counter);
     debug!(
         user_id = ?session_key.user_id(),
         media_worker_id = session_key.media_worker_id(),

--- a/crates/core/src/runtime/rtc_engine/worker/handlers/media/tests.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/handlers/media/tests.rs
@@ -6,8 +6,8 @@
 mod fixtures;
 
 use std::{
-    net::SocketAddr,
-    sync::{Arc, Mutex},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -30,26 +30,48 @@ use super::{
     respond_add_send_media, respond_remove_media, respond_set_consumer_packet_gates,
 };
 use crate::{
-    Bitrate, MediaCodecFlags,
+    Bitrate, CodecPreferences, MediaCodecFlags, RtcPortRange, VideoBitrateLimits,
     runtime::{
         UserId,
         media_transport::{
-            TransportAdapterError, TransportConsumerRoute, TransportMediaId, TransportSessionKey,
-            TransportSourceKey,
+            SourcePolicySignal, TransportAdapterError, TransportConsumerRoute, TransportMediaId,
+            TransportSessionKey, TransportSourceKey,
         },
         metrics::{RuntimeMetrics, test_support::RuntimeMetricsSnapshotTestExt},
         rtc_engine::{
-            bitrate::BitrateRegistry,
             bootstrap,
             commands::{ConsumerPacketGateCommand, RemoteSourceControl, RouteControlRequest},
             media_registry::{RegisteredMediaHandle, RemoteSourceRegistration},
+            observation::{PacketLoopObservations, RtcObservationPublishers},
             relay_registry::{RelayPacketMailbox, RelayTargetId},
             route_control::{KeyframeRequestDecision, PacketLayerGate},
             state::PacketLoopState,
             test_support::{MediaWorkerScenario, test_transport_session_key},
+            worker::WorkerCommandContext,
         },
     },
 };
+
+fn worker_command_context_for_test<'a>(
+    observations: &'a mut PacketLoopObservations,
+    metrics: &'a RuntimeMetrics,
+    source_policy_signal: &'a SourcePolicySignal,
+) -> WorkerCommandContext<'a> {
+    WorkerCommandContext {
+        observations,
+        now: Instant::now(),
+        public_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        max_bitrate_in: Bitrate::from_mbps(8),
+        max_bitrate_out: Bitrate::from_mbps(10),
+        video_bitrate_limits: VideoBitrateLimits::default(),
+        rtc_port_range: RtcPortRange::new(40_000, 49_999),
+        codec_flags: MediaCodecFlags::default(),
+        codec_preferences: CodecPreferences::default(),
+        media_quality_interval: None,
+        metrics,
+        source_policy_signal,
+    }
+}
 
 #[test]
 fn remote_keyframe_requests_drop_when_the_relay_target_is_inactive() {
@@ -1123,12 +1145,14 @@ fn remove_media_releases_unnegotiated_producer_when_removal_cannot_stage() {
     let mut state = PacketLoopState::default();
     let transport_media_id =
         prepare_already_absent_producer_registration(&mut state, &session_key, producer_mid, None);
-    let bitrate_registry = Arc::new(Mutex::new(BitrateRegistry::default()));
+    let mut observations = PacketLoopObservations::new(RtcObservationPublishers::new());
+    let metrics = RuntimeMetrics::default();
+    let source_policy_signal = SourcePolicySignal::default();
     let (response_tx, response_rx) = oneshot::channel();
 
     respond_remove_media(
         &mut state,
-        &bitrate_registry,
+        &mut worker_command_context_for_test(&mut observations, &metrics, &source_policy_signal),
         &session_key,
         transport_media_id,
         response_tx,
@@ -1153,12 +1177,14 @@ fn remove_media_keeps_negotiated_handle_when_removal_cannot_stage() {
         producer_mid,
         Some(negotiated_parameters),
     );
-    let bitrate_registry = Arc::new(Mutex::new(BitrateRegistry::default()));
+    let mut observations = PacketLoopObservations::new(RtcObservationPublishers::new());
+    let metrics = RuntimeMetrics::default();
+    let source_policy_signal = SourcePolicySignal::default();
     let (response_tx, response_rx) = oneshot::channel();
 
     respond_remove_media(
         &mut state,
-        &bitrate_registry,
+        &mut worker_command_context_for_test(&mut observations, &metrics, &source_policy_signal),
         &session_key,
         transport_media_id,
         response_tx,

--- a/crates/core/src/runtime/rtc_engine/worker/handlers/negotiation.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/handlers/negotiation.rs
@@ -10,7 +10,6 @@ use std::{
     collections::BTreeMap,
     mem,
     net::{IpAddr, SocketAddr},
-    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -26,10 +25,9 @@ use tracing::debug;
 
 use super::{
     super::super::{
-        bitrate::BitrateRegistry,
-        bootstrap, simulcast,
-        state::{PacketLoopState, RtcSnapshotState},
+        bootstrap, observation::PacketLoopObservations, simulcast, state::PacketLoopState,
     },
+    WorkerCommandContext,
     publication::refresh_negotiated_producer_parameters,
 };
 use crate::{
@@ -60,19 +58,15 @@ pub(super) struct OfferBootstrapConfig<'a> {
 
 pub(super) fn respond_create_initial_session_offer(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    context: &mut WorkerCommandContext<'_>,
     config: OfferBootstrapConfig<'_>,
     session_key: &TransportSessionKey,
     response: oneshot::Sender<Result<SessionOffer, TransportAdapterError>>,
 ) {
-    let _ = response.send(worker_create_initial_session_offer(
-        state,
-        bitrate_registry,
-        snapshot_state,
-        config,
-        session_key,
-    ));
+    let result =
+        worker_create_initial_session_offer(state, context.observations, config, session_key);
+    context.publish_observations();
+    let _ = response.send(result);
 }
 
 pub(super) fn respond_create_session_renegotiation_offer(
@@ -109,12 +103,11 @@ pub(super) fn respond_apply_session_answer(
 /// flight, callers must use the renegotiation path instead.
 fn worker_create_initial_session_offer(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     config: OfferBootstrapConfig<'_>,
     session_key: &TransportSessionKey,
 ) -> Result<SessionOffer, TransportAdapterError> {
-    ensure_session_ready_for_offer(state, bitrate_registry, snapshot_state, config, session_key)?;
+    ensure_session_ready_for_offer(state, observations, config, session_key)?;
     if state.session_has_registered_media(session_key) {
         return Err(TransportAdapterError::UnsupportedFeature);
     }
@@ -465,8 +458,7 @@ pub(super) fn offered_codecs(
 
 fn ensure_session_ready_for_offer(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     config: OfferBootstrapConfig<'_>,
     session_key: &TransportSessionKey,
 ) -> Result<(), TransportAdapterError> {
@@ -487,13 +479,9 @@ fn ensure_session_ready_for_offer(
         config.codec_flags,
         config.media_quality_interval,
     )?;
-    if let Ok(mut snapshot) = snapshot_state.lock() {
-        snapshot.add_session(session_key);
-    }
-    if let Ok(mut bitrate) = bitrate_registry.lock() {
-        let counter = bitrate.register_session_egress(session_key, Instant::now());
-        state.register_egress_bitrate_counter(session_key.clone(), counter);
-    }
+    observations.add_session(session_key);
+    let counter = observations.register_session_egress(session_key, Instant::now());
+    state.register_egress_bitrate_counter(session_key.clone(), counter);
     if let Some(session_state) = state.users.get(session_key) {
         let local_ice_ufrag_changed = state
             .remote_addr_demux

--- a/crates/core/src/runtime/rtc_engine/worker/handlers/session.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/handlers/session.rs
@@ -5,20 +5,17 @@
 //! state, bitrate tracking, and lifetime metrics without leaving
 //! packet-loop-visible stuff behind
 
-use std::{
-    collections::BTreeSet,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::{collections::BTreeSet, time::Instant};
 
 use tokio::sync::oneshot;
 
 use super::{
     super::super::{
-        bitrate::BitrateRegistry,
         commands::{CloseSessionOutcome, CloseSessionState},
-        state::{PacketLoopState, RtcSnapshotState},
+        observation::PacketLoopObservations,
+        state::PacketLoopState,
     },
+    WorkerCommandContext,
     media::{refresh_source_packet_gate, remove_source_route},
 };
 use crate::runtime::{
@@ -28,26 +25,19 @@ use crate::runtime::{
 
 pub(super) fn respond_close_session(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    context: &mut WorkerCommandContext<'_>,
     session_key: &TransportSessionKey,
-    metrics: &RuntimeMetrics,
     response: oneshot::Sender<Result<CloseSessionOutcome, TransportAdapterError>>,
 ) {
-    let close_outcome = worker_close_session(
-        state,
-        bitrate_registry,
-        snapshot_state,
-        session_key,
-        metrics,
-    );
+    let close_outcome =
+        worker_close_session(state, context.observations, session_key, context.metrics);
+    context.publish_observations();
     let _ = response.send(Ok(close_outcome));
 }
 
 fn worker_close_session(
     state: &mut PacketLoopState,
-    bitrate_registry: &Arc<Mutex<BitrateRegistry>>,
-    snapshot_state: &Arc<Mutex<RtcSnapshotState>>,
+    observations: &mut PacketLoopObservations,
     session_key: &TransportSessionKey,
     metrics: &RuntimeMetrics,
 ) -> CloseSessionOutcome {
@@ -64,12 +54,8 @@ fn worker_close_session(
         .remote_addr_demux
         .forget_user_remote_candidate_addrs(session_key);
     let removed_media_handles = state.remove_session_media_handles(session_key);
-    let removed_media_ids = removed_media_handles
-        .iter()
-        .map(|(transport_media_id, _handle)| *transport_media_id)
-        .collect::<Vec<_>>();
     let mut affected_route_sources = BTreeSet::new();
-    for source_transport_media_id in &removed_media_ids {
+    for (source_transport_media_id, _handle) in &removed_media_handles {
         remove_source_route(state, *source_transport_media_id);
     }
     state
@@ -96,16 +82,8 @@ fn worker_close_session(
     if state.users.is_empty() {
         state.shared_socket = None;
     }
-    if let Ok(mut snapshot) = snapshot_state.lock() {
-        let previous = snapshot.remove_session(session_key);
-        metrics.record_transport_health_transition(
-            previous.map(metrics::transport_health_state),
-            None,
-        );
-    }
-    if let Ok(mut bitrate) = bitrate_registry.lock() {
-        bitrate.remove_session(session_key);
-    }
+    let previous = observations.remove_session(session_key);
+    metrics.record_transport_health_transition(previous.map(metrics::transport_health_state), None);
     if let Some(removed_session) = removed_session {
         metrics.record_transport_user_lifetime(
             Instant::now().saturating_duration_since(removed_session.started_at),

--- a/crates/core/src/runtime/rtc_engine/worker/lifecycle.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/lifecycle.rs
@@ -33,11 +33,7 @@
 //! observability methods in this file deliberately avoid lazy boot
 //! a worker that has never started has no packet observations, so the snapshot
 //! surface returns empty or default values instead of creating transport state
-use std::{
-    collections::BTreeSet,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::{collections::BTreeSet, sync::Arc, time::Instant};
 
 use tokio::{
     runtime::Handle,
@@ -48,23 +44,20 @@ use tracing::info;
 
 use super::{
     super::{
-        bitrate::BitrateRegistry,
         commands::{RtcWorkerCommand, RtcWorkerResponse},
+        observation::RtcObservationPublishers,
         packet_loop::{self, PacketLoopConfig},
         relay_registry::{RELAY_MAILBOX_CAPACITY, RelayPacketMailbox, sender_backlog_depth},
         state::TransportSessionHealth,
     },
     RtcWorker, RtcWorkerHandle,
 };
-use crate::{
-    Bitrate,
-    runtime::{
-        RoomInstanceId,
-        media_transport::{
-            ActiveSpeakerSource, ActiveSpeakerSourceDiagnostic, ReceiverBandwidthSnapshot,
-            TransportAdapterError, TransportBitrateSnapshot, TransportPlacementPressureSnapshot,
-            TransportQualitySnapshot, TransportSessionKey, TransportWorkerPressureSnapshot,
-        },
+use crate::runtime::{
+    RoomInstanceId,
+    media_transport::{
+        ActiveSpeakerSource, ActiveSpeakerSourceDiagnostic, ReceiverBandwidthSnapshot,
+        TransportAdapterError, TransportBitrateSnapshot, TransportPlacementPressureSnapshot,
+        TransportQualitySnapshot, TransportSessionKey, TransportWorkerPressureSnapshot,
     },
 };
 
@@ -199,10 +192,7 @@ impl RtcWorker {
         #[cfg(any(test, feature = "testing-transport"))]
         let debug_channels = super::super::test_support::RtcWorkerDebugChannels::new();
         let (relay_tx, relay_rx) = mpsc::channel(RELAY_MAILBOX_CAPACITY);
-        // observability reads these side channels without entering the packet
-        // loop, while authoritative state stays owned by the worker task
-        let bitrate_registry = Arc::new(Mutex::new(BitrateRegistry::default()));
-        let snapshot_state = Arc::new(Mutex::new(super::super::state::RtcSnapshotState::default()));
+        let publishers = RtcObservationPublishers::new();
         let packet_loop_lag = Arc::new(packet_loop::PacketLoopLagSnapshot::new(Instant::now()));
         let shutdown_token = CancellationToken::new();
         let worker_handle = RtcWorkerHandle {
@@ -210,8 +200,8 @@ impl RtcWorker {
             #[cfg(any(test, feature = "testing-transport"))]
             debug_handle: debug_channels.handle(),
             relay_mailbox: RelayPacketMailbox::new(relay_tx),
-            bitrate_registry: Arc::clone(&bitrate_registry),
-            snapshot_state: Arc::clone(&snapshot_state),
+            bitrate_registry: publishers.bitrate_registry(),
+            snapshot_state: publishers.snapshot_state(),
             packet_loop_lag: Arc::clone(&packet_loop_lag),
             shutdown_token: shutdown_token.clone(),
         };
@@ -254,8 +244,7 @@ impl RtcWorker {
                 rtc_metrics: Arc::clone(&self.rtc_metrics),
                 packet_loop_lag,
             },
-            bitrate_registry,
-            snapshot_state,
+            publishers,
             packet_loop_inputs,
         ));
         Ok(worker_handle)
@@ -326,9 +315,7 @@ impl RtcWorker {
         let Some(worker_handle) = self.worker_handle().ok().flatten() else {
             return TransportBitrateSnapshot::default();
         };
-        let Ok(bitrate_registry) = worker_handle.bitrate_registry.lock() else {
-            return TransportBitrateSnapshot::default();
-        };
+        let bitrate_registry = worker_handle.bitrate_registry.load();
         bitrate_registry.transport_bitrate_snapshot_at(session_keys, Instant::now())
     }
 
@@ -344,10 +331,10 @@ impl RtcWorker {
         let Some(worker_handle) = self.worker_handle().ok().flatten() else {
             return ReceiverBandwidthSnapshot::default();
         };
-        let Ok(snapshot_state) = worker_handle.snapshot_state.lock() else {
-            return ReceiverBandwidthSnapshot::default();
-        };
-        snapshot_state.receiver_bandwidth_snapshot(session_keys)
+        worker_handle
+            .snapshot_state
+            .load()
+            .receiver_bandwidth_snapshot(session_keys)
     }
 
     /// reads sampled media quality from the worker snapshot state
@@ -358,10 +345,10 @@ impl RtcWorker {
         let Some(worker_handle) = self.worker_handle().ok().flatten() else {
             return TransportQualitySnapshot::default();
         };
-        let Ok(snapshot_state) = worker_handle.snapshot_state.lock() else {
-            return TransportQualitySnapshot::default();
-        };
-        snapshot_state.transport_quality_snapshot(session_keys)
+        worker_handle
+            .snapshot_state
+            .load()
+            .transport_quality_snapshot(session_keys)
     }
 
     /// builds a placement-pressure snapshot for selected sessions
@@ -377,10 +364,10 @@ impl RtcWorker {
             return TransportPlacementPressureSnapshot::default();
         };
         let now = Instant::now();
-        let egress_bitrate = match worker_handle.bitrate_registry.lock() {
-            Ok(bitrate_registry) => bitrate_registry.egress_bitrate_snapshot_at(session_keys, now),
-            Err(_error) => Bitrate::zero(),
-        };
+        let egress_bitrate = worker_handle
+            .bitrate_registry
+            .load()
+            .egress_bitrate_snapshot_at(session_keys, now);
         let packet_loop_lag_ms = worker_handle.packet_loop_lag.packet_loop_lag_ms_at(now);
         let command_backlog_depth = sender_backlog_depth(&worker_handle.command_tx);
         let relay_mailbox_depth = worker_handle.relay_mailbox.backlog_depth();
@@ -414,10 +401,10 @@ impl RtcWorker {
             );
         };
         let now = Instant::now();
-        let egress_bitrate = match worker_handle.bitrate_registry.lock() {
-            Ok(bitrate_registry) => bitrate_registry.total_egress_bitrate_snapshot_at(now),
-            Err(_error) => Bitrate::zero(),
-        };
+        let egress_bitrate = worker_handle
+            .bitrate_registry
+            .load()
+            .total_egress_bitrate_snapshot_at(now);
         let packet_loop_lag_ms = worker_handle.packet_loop_lag.packet_loop_lag_ms_at(now);
         let command_backlog_depth = sender_backlog_depth(&worker_handle.command_tx);
         let relay_mailbox_depth = worker_handle.relay_mailbox.backlog_depth();
@@ -440,17 +427,17 @@ impl RtcWorker {
 
     /// reads the latest transport health side-channel entry for one session
     ///
-    /// `None` means the worker is missing, the snapshot lock is unavailable or
-    /// no health event has been observed for the session
+    /// `None` means the worker is missing or no health event has been observed
+    /// for the session
     pub fn session_transport_health(
         &self,
         session_key: &TransportSessionKey,
     ) -> Option<TransportSessionHealth> {
         let worker_handle = self.worker_handle().ok().flatten()?;
-        let Ok(snapshot_state) = worker_handle.snapshot_state.lock() else {
-            return None;
-        };
-        snapshot_state.transport_health(session_key)
+        worker_handle
+            .snapshot_state
+            .load()
+            .transport_health(session_key)
     }
 
     /// asks the packet loop for its current active-speaker source snapshot
@@ -565,15 +552,14 @@ mod tests {
         let (command_tx, _command_rx) = mpsc::channel(1);
         let (relay_tx, _relay_rx) = mpsc::channel(RELAY_MAILBOX_CAPACITY);
         let debug_channels = super::super::super::test_support::RtcWorkerDebugChannels::new();
+        let publishers = RtcObservationPublishers::new();
 
         let worker_handle = RtcWorkerHandle {
             command_tx,
             debug_handle: debug_channels.handle(),
             relay_mailbox: RelayPacketMailbox::new(relay_tx),
-            bitrate_registry: Arc::new(Mutex::new(BitrateRegistry::default())),
-            snapshot_state: Arc::new(Mutex::new(
-                super::super::super::state::RtcSnapshotState::default(),
-            )),
+            bitrate_registry: publishers.bitrate_registry(),
+            snapshot_state: publishers.snapshot_state(),
             packet_loop_lag,
             shutdown_token: CancellationToken::new(),
         };

--- a/crates/core/src/runtime/rtc_engine/worker/mod.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/mod.rs
@@ -48,6 +48,7 @@ use std::{
     time::Duration,
 };
 
+use arc_swap::ArcSwap;
 #[cfg(feature = "internal-benchmarks")]
 pub(in crate::runtime::rtc_engine) use handlers::worker_set_consumer_packet_gates_for_benchmark;
 pub(super) use handlers::{
@@ -109,8 +110,8 @@ impl RtcSendMediaSource {
 ///
 /// the handle is cloned by cold-path worker methods so they can enqueue work
 /// without holding the worker publication lock across `.await`
-/// it contains command channels plus the read-mostly snapshot state that can be
-/// observed without entering the packet-loop task
+/// it contains command channels plus atomically published read-mostly snapshots
+/// that can be observed without entering the packet-loop task
 ///
 /// dropping this handle does not stop the worker
 /// shutdown is explicit through `shutdown_token` after the worker reports that
@@ -121,8 +122,8 @@ pub struct RtcWorkerHandle {
     #[cfg(any(test, feature = "testing-transport"))]
     pub(super) debug_handle: super::test_support::RtcWorkerDebugHandle,
     pub(super) relay_mailbox: RelayPacketMailbox,
-    pub bitrate_registry: Arc<Mutex<BitrateRegistry>>,
-    pub snapshot_state: Arc<Mutex<RtcSnapshotState>>,
+    pub bitrate_registry: Arc<ArcSwap<BitrateRegistry>>,
+    pub snapshot_state: Arc<ArcSwap<RtcSnapshotState>>,
     pub(super) packet_loop_lag: Arc<PacketLoopLagSnapshot>,
     pub(super) shutdown_token: CancellationToken,
 }

--- a/crates/core/src/runtime/rtc_engine/worker/test_support.rs
+++ b/crates/core/src/runtime/rtc_engine/worker/test_support.rs
@@ -1,11 +1,14 @@
-#[cfg(test)]
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-#[cfg(test)]
-use std::sync::Arc;
 use std::time::Instant;
+#[cfg(test)]
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 use str0m::media::Mid;
 
+#[cfg(any(test, feature = "testing-transport"))]
+use super::super::test_support::SetSessionTransportHealthProbe;
 #[cfg(test)]
 use super::super::test_support::{
     ActiveRelayTargetCountProbe, HasAnyRemoteAddrSessionProbe, RecordIncomingMediaProbe,
@@ -44,18 +47,20 @@ impl RtcWorker {
         RtcWorkerTestBuilder::default()
     }
 
-    pub fn debug_set_session_transport_health(
+    pub async fn debug_set_session_transport_health(
         &self,
         session_key: &TransportSessionKey,
         health: TransportSessionHealth,
     ) {
-        let Some(worker_handle) = self.worker_handle().ok().flatten() else {
+        let Some(previous) = self
+            .probe_debug_worker(SetSessionTransportHealthProbe {
+                session_key: session_key.clone(),
+                health,
+            })
+            .await
+        else {
             return;
         };
-        let Ok(mut snapshot_state) = worker_handle.snapshot_state.lock() else {
-            return;
-        };
-        let previous = snapshot_state.set_transport_health(session_key, health);
         self.metrics.record_transport_health_transition(
             previous.map(metrics::transport_health_state),
             Some(metrics::transport_health_state(health)),

--- a/src/runtime/websocket_server/tests/session_lifecycle_tests.rs
+++ b/src/runtime/websocket_server/tests/session_lifecycle_tests.rs
@@ -159,10 +159,13 @@ async fn websocket_closes_when_rtc_transport_disconnects() {
     let Some(connection_id) = connection_id else {
         return;
     };
-    server.media_transport.debug_set_session_transport_health(
-        &room.transport_user_key(&core_user_id, connection_id),
-        TransportSessionHealth::Disconnected,
-    );
+    server
+        .media_transport
+        .debug_set_session_transport_health(
+            &room.transport_user_key(&core_user_id, connection_id),
+            TransportSessionHealth::Disconnected,
+        )
+        .await;
 
     let close_code = timeout(Duration::from_secs(1), read_close_code(&mut websocket)).await;
     assert!(
@@ -217,10 +220,13 @@ async fn websocket_closes_when_rtc_transport_disconnects_during_initial_negotiat
     let Some(connection_id) = connection_id else {
         return;
     };
-    server.media_transport.debug_set_session_transport_health(
-        &room.transport_user_key(&core_user_id, connection_id),
-        TransportSessionHealth::Disconnected,
-    );
+    server
+        .media_transport
+        .debug_set_session_transport_health(
+            &room.transport_user_key(&core_user_id, connection_id),
+            TransportSessionHealth::Disconnected,
+        )
+        .await;
 
     let close_code = timeout(Duration::from_secs(1), read_close_code(&mut websocket)).await;
     assert!(

--- a/tests/fuzz/Cargo.lock
+++ b/tests/fuzz/Cargo.lock
@@ -48,6 +48,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1194,7 @@ dependencies = [
 name = "o-sfu-core"
 version = "0.3.0"
 dependencies = [
+ "arc-swap",
  "bitflags",
  "futures-util",
  "o-sfu-model",


### PR DESCRIPTION
The RTC packet loop owns transport state, but the previous bitrate and snapshot mirrors were shared through blocking mutexes. A cold diagnostics or placement reader could therefore delay worker control handling and packet-loop event observation even though those mirrors are not authoritative media state

This change keeps canonical bitrate and RTC snapshot state inside the packet loop, then publishes immutable read-side snapshots through ArcSwap. Snapshot readers keep synchronous APIs, while the packet loop no longer takes blocking mutex locks for observation publication