### PR TITLE
FIX] core: scope feedback keyframes to routed layers

### DIFF
--- a/crates/core/src/engine/media_transport/rtc/benchmark_support/video.rs
+++ b/crates/core/src/engine/media_transport/rtc/benchmark_support/video.rs
@@ -8,7 +8,6 @@ use tokio::sync::mpsc;
 
 use super::super::{
     commands::{RemoteSourceControl, RtcWorkerCommand},
-    media_registry::RegisteredMediaHandle,
     packet_loop::{PacketLoopBuffers, PendingKeyframeRequest, flush_pending_keyframe_requests_at},
     relay_registry::RelayTargetId,
     route_control::PacketLayerGate,
@@ -143,6 +142,8 @@ impl KeyframeCoalescingBenchFixture {
             ),
         );
 
+        let mut scenario = MediaWorkerScenario::new(&mut state);
+        scenario.existing_source(source_transport_media_id);
         for request_idx in 0..KEYFRAME_COALESCING_REQUESTS_I64 {
             let connection_offset = u64::try_from(request_idx).unwrap_or(0);
             let consumer_session = test_transport_session_key(
@@ -152,11 +153,7 @@ impl KeyframeCoalescingBenchFixture {
                 UserId::Integer(20_000 + request_idx),
             );
             let mid = Mid::from(format!("cam-down-{request_idx}").as_str());
-            state.register_media_handle(RegisteredMediaHandle::Consumer {
-                session_key: consumer_session.clone(),
-                mid,
-                source_transport_media_id,
-            });
+            scenario.destination(source_transport_media_id, consumer_session.clone(), mid);
             let kind = if request_idx == KEYFRAME_COALESCING_REQUESTS_I64 - 1 {
                 KeyframeRequestKind::Fir
             } else {

--- a/crates/core/src/engine/media_transport/rtc/demux.rs
+++ b/crates/core/src/engine/media_transport/rtc/demux.rs
@@ -117,10 +117,12 @@ impl MediaRouteEntry {
     /// removes one destination while preserving the active-count invariant
     ///
     /// callers pass the index they found under the same mutable route borrow
-    /// this keeps teardown precise without scanning a second time inside the
-    /// helper
+    /// destination order is not semantically observable, so removal keeps the
+    /// vector dense by moving the final destination into the cleared slot
+    /// callers that cache destination indexes must repair the moved destination
+    /// before feedback can use the cache again
     pub(super) fn remove_destination(&mut self, index: usize) -> MediaRouteDestination {
-        let destination = self.destinations.remove(index);
+        let destination = self.destinations.swap_remove(index);
         self.active_destination_count -= usize::from(destination.active);
         destination
     }

--- a/crates/core/src/engine/media_transport/rtc/media_registry.rs
+++ b/crates/core/src/engine/media_transport/rtc/media_registry.rs
@@ -70,6 +70,34 @@ pub(super) enum RegisteredMediaHandle {
     },
 }
 
+/// producer-side keyframe target derived from consumer RTCP feedback
+///
+/// packet-loop feedback arrives in consumer-local terms, so callers must
+/// resolve it through the current route before forwarding a refresh request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ConsumerKeyframeTarget {
+    /// source that owns the producer stream to refresh
+    pub(super) source_transport_media_id: TransportMediaId,
+    /// producer RID selected by the route or carried by ungated feedback
+    pub(super) rid: Option<Rid>,
+}
+
+/// consumer MID lookup entry with its route destination slot
+///
+/// `destination_index` is a cached slot inside the source route
+/// route teardown must clear or repair it whenever
+/// [`super::demux::MediaRouteEntry::remove_destination`] moves another
+/// destination into the removed slot
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConsumerMidBinding {
+    /// consumer media section that owns this MID
+    consumer_transport_media_id: TransportMediaId,
+    /// source route that should contain this consumer destination
+    source_transport_media_id: TransportMediaId,
+    /// cached slot inside the source route, absent when the route is gone
+    destination_index: Option<usize>,
+}
+
 impl RegisteredMediaHandle {
     /// returns the session that owns the browser media section
     pub(super) fn session_key(&self) -> &TransportSessionKey {
@@ -222,7 +250,7 @@ pub(super) struct SessionMediaLookup {
     producer_mids: TinyLookup<Mid, TransportMediaId>,
     producer_ssrcs: TinyLookup<Ssrc, TransportMediaId>,
     producer_ssrc_rids: TinyLookup<Ssrc, Rid>,
-    consumer_mids: TinyLookup<Mid, TransportMediaId>,
+    consumer_mids: TinyLookup<Mid, ConsumerMidBinding>,
 }
 
 impl SessionMediaLookup {
@@ -367,6 +395,12 @@ impl<K: Eq, V: Copy> TinyLookup<K, V> {
             .find_map(|(entry_key, value)| (entry_key == key).then_some(*value))
     }
 
+    fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.entries
+            .iter_mut()
+            .find_map(|(entry_key, value)| (entry_key == key).then_some(value))
+    }
+
     fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
@@ -377,8 +411,8 @@ impl PacketLoopState {
     ///
     /// producers gain a `(session, MID)` lookup and an empty SSRC set
     /// ssrc bindings are filled later by negotiation or dynamic RTP header discovery
-    /// consumers gain a `(session, MID)` lookup to their source media id so RTCP
-    /// feedback can be mapped back to the producer route
+    /// consumers gain a `(session, MID)` lookup to their own media id so RTCP
+    /// feedback can be mapped through the active route destination
     pub(super) fn register_media_handle(
         &mut self,
         handle: RegisteredMediaHandle,
@@ -402,9 +436,14 @@ impl PacketLoopState {
         {
             let session_lookup = self.session_media.entry(session_key.clone()).or_default();
             session_lookup.insert_owned_media(transport_media_id);
-            session_lookup
-                .consumer_mids
-                .insert(*mid, *source_transport_media_id);
+            session_lookup.consumer_mids.insert(
+                *mid,
+                ConsumerMidBinding {
+                    consumer_transport_media_id: transport_media_id,
+                    source_transport_media_id: *source_transport_media_id,
+                    destination_index: None,
+                },
+            );
         }
         self.mid_registry.insert(transport_media_id, handle);
         transport_media_id
@@ -868,10 +907,7 @@ impl PacketLoopState {
         );
     }
 
-    /// resolve the source media id that feeds a consumer MID
-    ///
-    /// rtcp feedback arrives from the consumer session, so the packet loop uses
-    /// this lookup to route keyframe requests back to the correct source
+    #[cfg(any(test, feature = "testing-transport"))]
     pub(super) fn consumer_source_transport_media_id_for_mid(
         &self,
         consumer_session_key: &TransportSessionKey,
@@ -880,6 +916,86 @@ impl PacketLoopState {
         self.session_media
             .get(consumer_session_key)
             .and_then(|consumer_lookup| consumer_lookup.consumer_mids.get(&consumer_mid))
+            .map(|binding| binding.source_transport_media_id)
+    }
+
+    /// resolve consumer RTCP feedback to the currently active producer target
+    ///
+    /// this is the packet-loop feedback path
+    /// missing indexes, removed routes and inactive routes are treated as stale
+    /// feedback because those can race with teardown after `str0m` emits a
+    /// request
+    ///
+    /// selected destination gates override the feedback RID so RID-less browser
+    /// PLI stays scoped to the routed simulcast layer
+    #[inline]
+    pub(super) fn active_consumer_keyframe_target_for_mid(
+        &self,
+        consumer_session_key: &TransportSessionKey,
+        consumer_mid: Mid,
+        feedback_rid: Option<Rid>,
+    ) -> Option<ConsumerKeyframeTarget> {
+        let binding = self
+            .session_media
+            .get(consumer_session_key)?
+            .consumer_mids
+            .get(&consumer_mid)?;
+        let route_entry = self
+            .media_route_index
+            .get(&binding.source_transport_media_id)?;
+        // a miss means feedback raced with route teardown or index repair
+        let destination = route_entry.destinations.get(binding.destination_index?)?;
+        debug_assert_eq!(&destination.dest_session, consumer_session_key);
+        debug_assert_eq!(
+            destination.dest_transport_media_id,
+            binding.consumer_transport_media_id
+        );
+        if !route_entry.source_active || !destination.active {
+            return None;
+        }
+        let rid = match destination.packet_gate {
+            PacketLayerGate::Rid(rid) => Some(rid),
+            PacketLayerGate::OperatingPoint(operating_point) => operating_point.rid(),
+            // while blocked, the pending gate names the layer that needs a refresh
+            PacketLayerGate::Block => Some(
+                destination
+                    .pending_packet_gate
+                    .as_ref()
+                    .and_then(PacketLayerGate::selected_rid)?,
+            ),
+            // open routes have no layer policy, so preserve the feedback RID
+            PacketLayerGate::Open => feedback_rid,
+        };
+        Some(ConsumerKeyframeTarget {
+            source_transport_media_id: binding.source_transport_media_id,
+            rid,
+        })
+    }
+
+    /// updates the cached destination slot for one consumer MID binding
+    ///
+    /// callers pass both sides of the route identity so a late repair from an
+    /// old route cannot relink a MID to a different source
+    pub(super) fn set_consumer_destination_index(
+        &mut self,
+        consumer_session_key: &TransportSessionKey,
+        consumer_mid: Mid,
+        consumer_transport_media_id: TransportMediaId,
+        source_transport_media_id: TransportMediaId,
+        destination_index: Option<usize>,
+    ) {
+        let Some(binding) = self
+            .session_media
+            .get_mut(consumer_session_key)
+            .and_then(|consumer_lookup| consumer_lookup.consumer_mids.get_mut(&consumer_mid))
+        else {
+            return;
+        };
+        if binding.consumer_transport_media_id == consumer_transport_media_id
+            && binding.source_transport_media_id == source_transport_media_id
+        {
+            binding.destination_index = destination_index;
+        }
     }
 
     /// resolve the room that owns a local or remote source media id

--- a/crates/core/src/engine/media_transport/rtc/packet_loop/keyframe_requests.rs
+++ b/crates/core/src/engine/media_transport/rtc/packet_loop/keyframe_requests.rs
@@ -8,10 +8,10 @@
 //!
 //! Keyframe requests are route-control feedback, not room policy. The room
 //! decides which sources and layers a user should receive. This module only
-//! makes sure the currently routed producer gets a bounded, source-keyed request
-//! stream.
+//! makes sure the currently routed producer gets a bounded, source/RID keyed
+//! request stream.
 
-use std::time::Instant;
+use std::{cmp::Ordering, time::Instant};
 
 use str0m::media::{KeyframeRequest, KeyframeRequestKind, Mid, Rid};
 use tracing::debug;
@@ -77,11 +77,11 @@ pub(super) enum ResolvedKeyframeRoute {
     },
 }
 
-/// Source-keyed keyframe request after route resolution.
+/// Source and RID keyed keyframe request after route resolution.
 ///
 /// Multiple consumers can ask for the same source during one packet-loop turn.
-/// Coalescing keeps the request stream proportional to source media instead of
-/// fanout count and upgrades request kind when a stronger request is observed.
+/// Coalescing keeps duplicate feedback bounded without merging distinct
+/// simulcast layers into one source-wide request.
 #[derive(Clone, Copy)]
 pub(super) struct CoalescedKeyframeRequest {
     source_transport_media_id: TransportMediaId,
@@ -89,30 +89,11 @@ pub(super) struct CoalescedKeyframeRequest {
     kind: KeyframeRequestKind,
 }
 
-impl CoalescedKeyframeRequest {
-    fn new(
-        source_transport_media_id: TransportMediaId,
-        rid: Option<Rid>,
-        kind: KeyframeRequestKind,
-    ) -> Self {
-        Self {
-            source_transport_media_id,
-            rid,
-            kind,
-        }
-    }
-
-    fn coalesce(&mut self, rid: Option<Rid>, kind: KeyframeRequestKind) {
-        self.rid = self.rid.or(rid);
-        self.kind = coalesce_keyframe_kind(self.kind, kind);
-    }
-}
-
 /// Resolve and flush every keyframe request staged during the current turn.
 ///
 /// Requests are drained from packet-loop buffers, resolved from consumer-local
-/// MID to source transport media id, sorted by source and coalesced before any
-/// request is dispatched. Missing source state means the route changed before
+/// MID to source transport media id and selected producer RID before any
+/// request is dispatched. Missing route state means the route changed before
 /// the feedback was flushed and is treated as a benign stale request.
 pub(super) fn flush_pending_keyframe_requests(
     state: &mut PacketLoopState,
@@ -122,6 +103,10 @@ pub(super) fn flush_pending_keyframe_requests(
     flush_pending_keyframe_requests_at(state, metrics, buffers, Instant::now());
 }
 
+/// resolves and flushes staged keyframe requests at a supplied time
+///
+/// tests and benchmarks pass `now` explicitly so route-control throttling stays
+/// deterministic
 pub(in crate::engine::media_transport::rtc) fn flush_pending_keyframe_requests_at(
     state: &mut PacketLoopState,
     metrics: &impl RtcRouteControlMetrics,
@@ -131,28 +116,73 @@ pub(in crate::engine::media_transport::rtc) fn flush_pending_keyframe_requests_a
     let pending_keyframe_requests = &mut buffers.pending_keyframe_requests;
     let coalesced_requests = &mut buffers.coalesced_keyframe_requests;
     coalesced_requests.clear();
+    let mut has_rid = false;
+    let mut same_request: Option<CoalescedKeyframeRequest> = None;
     for (consumer_session_key, request) in pending_keyframe_requests.drain(..) {
-        let Some(source_transport_media_id) = state.consumer_source_transport_media_id_for_mid(
+        let Some(target) = state.active_consumer_keyframe_target_for_mid(
             &consumer_session_key,
             request.consumer_mid,
+            request.consumer_rid,
         ) else {
             continue;
         };
-        coalesced_requests.push(CoalescedKeyframeRequest::new(
-            source_transport_media_id,
-            request.consumer_rid,
-            request.kind,
-        ));
+        let resolved_request = CoalescedKeyframeRequest {
+            source_transport_media_id: target.source_transport_media_id,
+            rid: target.rid,
+            kind: request.kind,
+        };
+        has_rid |= resolved_request.rid.is_some();
+        // most turns carry repeated feedback for one target
+        // keep that path out of sorting
+        if coalesced_requests.is_empty() {
+            match &mut same_request {
+                Some(current)
+                    if current.source_transport_media_id
+                        == resolved_request.source_transport_media_id
+                        && current.rid == resolved_request.rid =>
+                {
+                    current.kind = coalesce_keyframe_kind(current.kind, resolved_request.kind);
+                }
+                Some(_) => {
+                    if let Some(current) = same_request.take() {
+                        coalesced_requests.push(current);
+                    }
+                    coalesced_requests.push(resolved_request);
+                }
+                None => {
+                    same_request = Some(resolved_request);
+                }
+            }
+        } else {
+            coalesced_requests.push(resolved_request);
+        }
     }
-    coalesced_requests.sort_by_key(|request| request.source_transport_media_id);
+    if coalesced_requests.is_empty() {
+        if let Some(request) = same_request {
+            flush_coalesced_keyframe_request(state, metrics, request, now);
+        }
+        return;
+    }
+    if has_rid {
+        // rid-scoped batches need the full source/RID key to avoid widening
+        // simulcast feedback
+        coalesced_requests.sort_unstable_by(|left, right| {
+            left.source_transport_media_id
+                .cmp(&right.source_transport_media_id)
+                .then_with(|| compare_keyframe_rids(left.rid, right.rid))
+        });
+    } else {
+        coalesced_requests.sort_unstable_by_key(|request| request.source_transport_media_id);
+    }
     let mut current_request: Option<CoalescedKeyframeRequest> = None;
     for coalesced_request in coalesced_requests.drain(..) {
         match &mut current_request {
             Some(current)
                 if current.source_transport_media_id
-                    == coalesced_request.source_transport_media_id =>
+                    == coalesced_request.source_transport_media_id
+                    && current.rid == coalesced_request.rid =>
             {
-                current.coalesce(coalesced_request.rid, coalesced_request.kind);
+                current.kind = coalesce_keyframe_kind(current.kind, coalesced_request.kind);
             }
             Some(_) => {
                 if let Some(request) = current_request.take() {
@@ -170,7 +200,11 @@ pub(in crate::engine::media_transport::rtc) fn flush_pending_keyframe_requests_a
     }
 }
 
-/// Dispatch one source-keyed keyframe request.
+fn compare_keyframe_rids(left: Option<Rid>, right: Option<Rid>) -> Ordering {
+    left.as_deref().cmp(&right.as_deref())
+}
+
+/// Dispatch one source/RID keyed keyframe request.
 ///
 /// Local producers are marked through the worker's normal keyframe request path.
 /// Remote producers pass through route-control de-duplication before the request

--- a/crates/core/src/engine/media_transport/rtc/packet_loop/tests.rs
+++ b/crates/core/src/engine/media_transport/rtc/packet_loop/tests.rs
@@ -222,21 +222,47 @@ fn insert_open_route(
     consumer_stream: ConsumerStreamHandle,
     consumer_mid: Mid,
 ) {
-    let mut route_entry = MediaRouteEntry::new(true);
-    route_entry.push_destination(MediaRouteDestination {
-        dest_session: consumer_session.clone(),
-        dest_transport_media_id: consumer_transport_media_id,
-        dest_stream: consumer_stream,
-        dest_mid: consumer_mid,
-        dest_payload_type: None,
-        nackable: true,
-        active: true,
-        packet_gate: PacketLayerGate::Open,
-        pending_packet_gate: None,
-    });
-    state
-        .media_route_index
-        .insert(source_transport_media_id, route_entry);
+    insert_consumer_route_fixture(
+        state,
+        source_transport_media_id,
+        MediaRouteDestination {
+            dest_session: consumer_session.clone(),
+            dest_transport_media_id: consumer_transport_media_id,
+            dest_stream: consumer_stream,
+            dest_mid: consumer_mid,
+            dest_payload_type: None,
+            nackable: true,
+            active: true,
+            packet_gate: PacketLayerGate::Open,
+            pending_packet_gate: None,
+        },
+    );
+}
+
+fn insert_consumer_route_fixture(
+    state: &mut PacketLoopState,
+    source_transport_media_id: TransportMediaId,
+    destination: MediaRouteDestination,
+) {
+    let dest_session = destination.dest_session.clone();
+    let dest_mid = destination.dest_mid;
+    let dest_transport_media_id = destination.dest_transport_media_id;
+    let destination_index = {
+        let route_entry = state
+            .media_route_index
+            .entry(source_transport_media_id)
+            .or_insert_with(|| MediaRouteEntry::new(true));
+        let destination_index = route_entry.destinations.len();
+        route_entry.push_destination(destination);
+        destination_index
+    };
+    state.set_consumer_destination_index(
+        &dest_session,
+        dest_mid,
+        dest_transport_media_id,
+        source_transport_media_id,
+        Some(destination_index),
+    );
 }
 
 fn register_producer_media(
@@ -276,14 +302,64 @@ fn local_keyframe_source(
 fn register_consumer_media(
     state: &mut PacketLoopState,
     consumer_session: &TransportSessionKey,
-    consumer_mid: &str,
+    consumer_mid: Mid,
     source_transport_media_id: TransportMediaId,
 ) -> TransportMediaId {
     state.register_media_handle(RegisteredMediaHandle::Consumer {
         session_key: consumer_session.clone(),
-        mid: Mid::from(consumer_mid),
+        mid: consumer_mid,
         source_transport_media_id,
     })
+}
+
+fn register_consumer_route_fixture(
+    state: &mut PacketLoopState,
+    consumer_session: &TransportSessionKey,
+    consumer_mid: &str,
+    source_transport_media_id: TransportMediaId,
+    active: bool,
+    packet_gate: PacketLayerGate,
+    pending_packet_gate: Option<PacketLayerGate>,
+) {
+    let consumer_mid = Mid::from(consumer_mid);
+    let consumer_transport_media_id = register_consumer_media(
+        state,
+        consumer_session,
+        consumer_mid,
+        source_transport_media_id,
+    );
+    insert_consumer_route_fixture(
+        state,
+        source_transport_media_id,
+        MediaRouteDestination {
+            dest_session: consumer_session.clone(),
+            dest_transport_media_id: consumer_transport_media_id,
+            dest_stream: ConsumerStreamHandle::default(),
+            dest_mid: consumer_mid,
+            dest_payload_type: None,
+            nackable: true,
+            active,
+            packet_gate,
+            pending_packet_gate,
+        },
+    );
+}
+
+fn register_open_consumer_route_fixture(
+    state: &mut PacketLoopState,
+    consumer_session: &TransportSessionKey,
+    consumer_mid: &str,
+    source_transport_media_id: TransportMediaId,
+) {
+    register_consumer_route_fixture(
+        state,
+        consumer_session,
+        consumer_mid,
+        source_transport_media_id,
+        true,
+        PacketLayerGate::Open,
+        None,
+    );
 }
 
 fn push_keyframe_request(
@@ -292,11 +368,21 @@ fn push_keyframe_request(
     consumer_mid: &str,
     kind: KeyframeRequestKind,
 ) {
+    push_keyframe_request_with_rid(buffers, consumer_session, consumer_mid, None, kind);
+}
+
+fn push_keyframe_request_with_rid(
+    buffers: &mut PacketLoopBuffers,
+    consumer_session: TransportSessionKey,
+    consumer_mid: &str,
+    feedback_rid: Option<Rid>,
+    kind: KeyframeRequestKind,
+) {
     buffers.pending_keyframe_requests.push((
         consumer_session,
         PendingKeyframeRequest {
             consumer_mid: Mid::from(consumer_mid),
-            consumer_rid: None,
+            consumer_rid: feedback_rid,
             kind,
         },
     ));
@@ -319,6 +405,177 @@ fn remote_keyframe_source(
         .register_remote_source(&source, RemoteSourceControl::new(control_tx, target_id))
         .expect("remote source should register");
     control_rx
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "test setup helpers should fail loudly when a saturated remote keyframe fixture cannot be built"
+)]
+#[allow(
+    clippy::panic,
+    reason = "test assertion helpers should fail loudly when the command shape is wrong"
+)]
+fn recv_remote_keyframe_request(
+    control_rx: &mut mpsc::Receiver<RtcWorkerCommand>,
+) -> (
+    TransportSourceKey,
+    RelayTargetId,
+    Option<Rid>,
+    KeyframeRequestKind,
+) {
+    match control_rx.try_recv() {
+        Ok(RtcWorkerCommand::MediaControl(RtcMediaControlCommand::Apply {
+            request:
+                RouteControlRequest::RequestRemoteKeyframe {
+                    source,
+                    target_id,
+                    rid,
+                    kind,
+                },
+            response: None,
+        })) => (source, target_id, rid, kind),
+        Ok(_) => panic!("expected a remote keyframe request"),
+        Err(mpsc::error::TryRecvError::Empty) => {
+            panic!("expected a remote keyframe request but channel was empty")
+        }
+        Err(mpsc::error::TryRecvError::Disconnected) => {
+            panic!("expected a remote keyframe request but channel was disconnected")
+        }
+    }
+}
+
+fn assert_remote_keyframe_request(
+    control_rx: &mut mpsc::Receiver<RtcWorkerCommand>,
+    source_session: &TransportSessionKey,
+    source_transport_media_id: TransportMediaId,
+    target_id: RelayTargetId,
+    rid: Option<Rid>,
+    kind: KeyframeRequestKind,
+) {
+    let (source, actual_target_id, actual_rid, actual_kind) =
+        recv_remote_keyframe_request(control_rx);
+    assert_eq!(source.session_key(), source_session);
+    assert_eq!(source.transport_media_id(), source_transport_media_id);
+    assert_eq!(actual_target_id, target_id);
+    assert_eq!(actual_rid, rid);
+    assert_eq!(actual_kind, kind);
+}
+
+#[allow(
+    clippy::panic,
+    reason = "test assertion helpers should fail loudly when an unexpected command is queued"
+)]
+fn assert_no_remote_keyframe_request(control_rx: &mut mpsc::Receiver<RtcWorkerCommand>) {
+    match control_rx.try_recv() {
+        Err(mpsc::error::TryRecvError::Empty) => {}
+        Err(mpsc::error::TryRecvError::Disconnected) => {
+            panic!("remote keyframe command channel disconnected")
+        }
+        Ok(_) => panic!("unexpected remote keyframe request"),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RouteFeedbackGate {
+    Open,
+    Rid(&'static str),
+    RidWithPending {
+        effective: &'static str,
+        pending: &'static str,
+    },
+    Block,
+    BlockWithPending(&'static str),
+}
+
+impl RouteFeedbackGate {
+    fn gates(self) -> (PacketLayerGate, Option<PacketLayerGate>) {
+        match self {
+            Self::Open => (PacketLayerGate::Open, None),
+            Self::Rid(rid) => (PacketLayerGate::Rid(Rid::from(rid)), None),
+            Self::RidWithPending { effective, pending } => (
+                PacketLayerGate::Rid(Rid::from(effective)),
+                Some(PacketLayerGate::Rid(Rid::from(pending))),
+            ),
+            Self::Block => (PacketLayerGate::Block, None),
+            Self::BlockWithPending(rid) => (
+                PacketLayerGate::Block,
+                Some(PacketLayerGate::Rid(Rid::from(rid))),
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RouteFeedbackExpectation {
+    Drop,
+    SourceWide,
+    Rid(&'static str),
+}
+
+#[derive(Clone, Copy)]
+struct RouteFeedbackCase {
+    id: u64,
+    active: bool,
+    gate: RouteFeedbackGate,
+    feedback_rid: Option<&'static str>,
+    expected: RouteFeedbackExpectation,
+    kind: KeyframeRequestKind,
+}
+
+fn route_feedback_cases() -> [RouteFeedbackCase; 6] {
+    [
+        RouteFeedbackCase {
+            id: 92,
+            active: true,
+            gate: RouteFeedbackGate::Open,
+            feedback_rid: None,
+            expected: RouteFeedbackExpectation::SourceWide,
+            kind: KeyframeRequestKind::Fir,
+        },
+        RouteFeedbackCase {
+            id: 93,
+            active: true,
+            gate: RouteFeedbackGate::Rid("hi"),
+            feedback_rid: None,
+            expected: RouteFeedbackExpectation::Rid("hi"),
+            kind: KeyframeRequestKind::Pli,
+        },
+        RouteFeedbackCase {
+            id: 94,
+            active: true,
+            gate: RouteFeedbackGate::RidWithPending {
+                effective: "lo",
+                pending: "hi",
+            },
+            feedback_rid: None,
+            expected: RouteFeedbackExpectation::Rid("lo"),
+            kind: KeyframeRequestKind::Pli,
+        },
+        RouteFeedbackCase {
+            id: 95,
+            active: true,
+            gate: RouteFeedbackGate::BlockWithPending("hi"),
+            feedback_rid: None,
+            expected: RouteFeedbackExpectation::Rid("hi"),
+            kind: KeyframeRequestKind::Pli,
+        },
+        RouteFeedbackCase {
+            id: 96,
+            active: true,
+            gate: RouteFeedbackGate::Block,
+            feedback_rid: Some("hi"),
+            expected: RouteFeedbackExpectation::Drop,
+            kind: KeyframeRequestKind::Pli,
+        },
+        RouteFeedbackCase {
+            id: 97,
+            active: false,
+            gate: RouteFeedbackGate::Rid("hi"),
+            feedback_rid: None,
+            expected: RouteFeedbackExpectation::Drop,
+            kind: KeyframeRequestKind::Pli,
+        },
+    ]
 }
 
 fn populate_forward_routes(
@@ -1259,18 +1516,19 @@ fn silent_audio_packets_are_dropped_from_routed_fanout_after_transport_activity_
     let packet_sink_registry = RoomPacketSinkRegistry::default();
     let source_transport_media_id =
         register_producer_media(&mut harness.state, &producer_session, "aud-up");
+    let consumer_mid = Mid::from("aud-down");
     let consumer_transport_media_id = register_consumer_media(
         &mut harness.state,
         &consumer_session,
-        "aud-down",
+        consumer_mid,
         source_transport_media_id,
     );
     let mut route_entry = MediaRouteEntry::new(true);
     route_entry.push_destination(MediaRouteDestination {
-        dest_session: consumer_session,
+        dest_session: consumer_session.clone(),
         dest_transport_media_id: consumer_transport_media_id,
         dest_stream: ConsumerStreamHandle::default(),
-        dest_mid: Mid::from("aud-down"),
+        dest_mid: consumer_mid,
         dest_payload_type: None,
         nackable: false,
         active: true,
@@ -1281,6 +1539,13 @@ fn silent_audio_packets_are_dropped_from_routed_fanout_after_transport_activity_
         .state
         .media_route_index
         .insert(source_transport_media_id, route_entry);
+    harness.state.set_consumer_destination_index(
+        &consumer_session,
+        consumer_mid,
+        consumer_transport_media_id,
+        source_transport_media_id,
+        Some(0),
+    );
     harness
         .buffers
         .pending_packets
@@ -1547,95 +1812,77 @@ fn flush_forward_routes_records_relay_overload_drops() {
 }
 
 #[test]
-fn flush_pending_keyframe_requests_marks_local_source_sessions_dirty() {
-    let source_session = test_transport_session_key(61, 0, 62, UserId::Integer(63));
-    let consumer_session = test_transport_session_key(61, 0, 64, UserId::Integer(65));
-    let mut harness = PacketLoopHarness::new();
+fn flush_pending_keyframe_requests_follow_route_scoped_feedback() {
+    for case in route_feedback_cases() {
+        let source_session =
+            test_transport_session_key(case.id, 0, case.id + 100, UserId::Integer(1000));
+        let consumer_session =
+            test_transport_session_key(case.id, 1, case.id + 200, UserId::Integer(2000));
+        let source_transport_media_id = TransportMediaId::new(case.id);
+        let target_id = RelayTargetId::new(case.id);
+        let mut harness = PacketLoopHarness::new();
+        let mut control_rx = remote_keyframe_source(
+            &mut harness.state,
+            source_transport_media_id,
+            &source_session,
+            target_id,
+            1,
+        );
+        let (packet_gate, pending_packet_gate) = case.gate.gates();
+        register_consumer_route_fixture(
+            &mut harness.state,
+            &consumer_session,
+            "cam-down",
+            source_transport_media_id,
+            case.active,
+            packet_gate,
+            pending_packet_gate,
+        );
+        push_keyframe_request_with_rid(
+            &mut harness.buffers,
+            consumer_session,
+            "cam-down",
+            case.feedback_rid.map(Rid::from),
+            case.kind,
+        );
 
-    let source_transport_media_id = local_keyframe_source(
-        &mut harness.state,
-        &source_session,
-        45_050,
-        "cam-up",
-        44_444,
-    );
-    register_consumer_media(
-        &mut harness.state,
-        &consumer_session,
-        "cam-down",
-        source_transport_media_id,
-    );
-    push_keyframe_request(
-        &mut harness.buffers,
-        consumer_session,
-        "cam-down",
-        KeyframeRequestKind::Pli,
-    );
+        flush_pending_keyframe_requests(
+            &mut harness.state,
+            harness.rtc_metrics.as_ref(),
+            &mut harness.buffers,
+        );
 
-    flush_pending_keyframe_requests(
-        &mut harness.state,
-        harness.rtc_metrics.as_ref(),
-        &mut harness.buffers,
-    );
-
-    assert_eq!(
-        drain_ready_sessions(&mut harness.state),
-        vec![source_session.clone()]
-    );
-    let snapshot = harness.metrics.snapshot();
-    assert_eq!(snapshot.rtc_route_control_forwarded(), 1);
-    assert_eq!(snapshot.rtc_route_control_absorbed(), 0);
-}
-
-#[test]
-fn flush_pending_keyframe_requests_forwards_remote_sources_by_transport_media_id() {
-    let source_session = test_transport_session_key(71, 0, 72, UserId::Integer(73));
-    let consumer_session = test_transport_session_key(71, 1, 74, UserId::Integer(75));
-    let source_transport_media_id = TransportMediaId::new(91);
-    let mut harness = PacketLoopHarness::new();
-    let mut control_rx = remote_keyframe_source(
-        &mut harness.state,
-        source_transport_media_id,
-        &source_session,
-        RelayTargetId::new(1),
-        1,
-    );
-
-    register_consumer_media(
-        &mut harness.state,
-        &consumer_session,
-        "cam-down",
-        source_transport_media_id,
-    );
-    push_keyframe_request(
-        &mut harness.buffers,
-        consumer_session,
-        "cam-down",
-        KeyframeRequestKind::Fir,
-    );
-
-    flush_pending_keyframe_requests(
-        &mut harness.state,
-        harness.rtc_metrics.as_ref(),
-        &mut harness.buffers,
-    );
-
-    let command = control_rx.try_recv().ok();
-    assert!(matches!(
-        command,
-        Some(RtcWorkerCommand::MediaControl(RtcMediaControlCommand::Apply {
-            request: RouteControlRequest::RequestRemoteKeyframe {
-                source,
-                target_id,
-                rid: None,
-                kind: KeyframeRequestKind::Fir,
-            },
-            response: None,
-        })) if source.session_key() == &source_session
-            && target_id == RelayTargetId::new(1)
-            && source.transport_media_id() == source_transport_media_id
-    ));
-    assert_eq!(harness.metrics.snapshot().rtc_route_control_forwarded(), 1);
+        match case.expected {
+            RouteFeedbackExpectation::Drop => {
+                assert_no_remote_keyframe_request(&mut control_rx);
+                assert_eq!(harness.metrics.snapshot().rtc_route_control_forwarded(), 0);
+            }
+            RouteFeedbackExpectation::SourceWide => {
+                assert_remote_keyframe_request(
+                    &mut control_rx,
+                    &source_session,
+                    source_transport_media_id,
+                    target_id,
+                    None,
+                    case.kind,
+                );
+                assert_eq!(harness.metrics.snapshot().rtc_route_control_forwarded(), 1);
+            }
+            RouteFeedbackExpectation::Rid(rid) => {
+                assert_remote_keyframe_request(
+                    &mut control_rx,
+                    &source_session,
+                    source_transport_media_id,
+                    target_id,
+                    Some(Rid::from(rid)),
+                    case.kind,
+                );
+                assert_eq!(harness.metrics.snapshot().rtc_route_control_forwarded(), 1);
+            }
+        }
+        assert_eq!(harness.metrics.snapshot().rtc_route_control_absorbed(), 0);
+        assert_no_remote_keyframe_request(&mut control_rx);
+    }
 }
 
 #[test]
@@ -1653,13 +1900,13 @@ fn flush_pending_keyframe_requests_coalesces_duplicate_remote_requests() {
         2,
     );
 
-    register_consumer_media(
+    register_open_consumer_route_fixture(
         &mut harness.state,
         &first_consumer_session,
         "cam-down",
         source_transport_media_id,
     );
-    register_consumer_media(
+    register_open_consumer_route_fixture(
         &mut harness.state,
         &second_consumer_session,
         "cam-down-2",
@@ -1684,25 +1931,85 @@ fn flush_pending_keyframe_requests_coalesces_duplicate_remote_requests() {
         &mut harness.buffers,
     );
 
-    let command = control_rx.try_recv().ok();
-    assert!(matches!(
-        command,
-        Some(RtcWorkerCommand::MediaControl(RtcMediaControlCommand::Apply {
-            request: RouteControlRequest::RequestRemoteKeyframe {
-                source,
-                target_id,
-                rid: None,
-                kind: KeyframeRequestKind::Fir,
-            },
-            response: None,
-        })) if source.session_key() == &source_session
-            && target_id == RelayTargetId::new(4)
-            && source.transport_media_id() == source_transport_media_id
-    ));
-    assert!(control_rx.try_recv().is_err());
+    assert_remote_keyframe_request(
+        &mut control_rx,
+        &source_session,
+        source_transport_media_id,
+        RelayTargetId::new(4),
+        None,
+        KeyframeRequestKind::Fir,
+    );
+    assert_no_remote_keyframe_request(&mut control_rx);
     let snapshot = harness.metrics.snapshot();
     assert_eq!(snapshot.rtc_route_control_forwarded(), 1);
     assert_eq!(snapshot.rtc_route_control_absorbed(), 0);
+}
+
+#[test]
+fn flush_pending_keyframe_requests_keeps_distinct_rids_separate() {
+    let source_session = test_transport_session_key(84, 0, 85, UserId::Integer(86));
+    let first_consumer_session = test_transport_session_key(84, 1, 87, UserId::Integer(88));
+    let second_consumer_session = test_transport_session_key(84, 1, 89, UserId::Integer(90));
+    let source_transport_media_id = TransportMediaId::new(104);
+    let first_rid = Rid::from("lo");
+    let second_rid = Rid::from("hi");
+    let mut harness = PacketLoopHarness::new();
+    let mut control_rx = remote_keyframe_source(
+        &mut harness.state,
+        source_transport_media_id,
+        &source_session,
+        RelayTargetId::new(6),
+        2,
+    );
+    register_consumer_route_fixture(
+        &mut harness.state,
+        &first_consumer_session,
+        "cam-down-1",
+        source_transport_media_id,
+        true,
+        PacketLayerGate::Rid(first_rid),
+        None,
+    );
+    register_consumer_route_fixture(
+        &mut harness.state,
+        &second_consumer_session,
+        "cam-down-2",
+        source_transport_media_id,
+        true,
+        PacketLayerGate::Rid(second_rid),
+        None,
+    );
+    push_keyframe_request(
+        &mut harness.buffers,
+        first_consumer_session,
+        "cam-down-1",
+        KeyframeRequestKind::Pli,
+    );
+    push_keyframe_request(
+        &mut harness.buffers,
+        second_consumer_session,
+        "cam-down-2",
+        KeyframeRequestKind::Fir,
+    );
+
+    flush_pending_keyframe_requests(
+        &mut harness.state,
+        harness.rtc_metrics.as_ref(),
+        &mut harness.buffers,
+    );
+
+    let mut requests = Vec::new();
+    for _ in 0..2 {
+        let (source, target_id, rid, kind) = recv_remote_keyframe_request(&mut control_rx);
+        assert_eq!(source.session_key(), &source_session);
+        assert_eq!(source.transport_media_id(), source_transport_media_id);
+        assert_eq!(target_id, RelayTargetId::new(6));
+        requests.push((rid, kind));
+    }
+    assert!(requests.contains(&(Some(first_rid), KeyframeRequestKind::Pli)));
+    assert!(requests.contains(&(Some(second_rid), KeyframeRequestKind::Fir)));
+    assert_eq!(requests.len(), 2);
+    assert_no_remote_keyframe_request(&mut control_rx);
 }
 
 #[test]
@@ -1719,13 +2026,13 @@ fn flush_pending_keyframe_requests_absorbs_duplicate_local_requests_within_one_f
         "cam-up",
         55_555,
     );
-    register_consumer_media(
+    register_open_consumer_route_fixture(
         &mut harness.state,
         &first_consumer_session,
         "cam-down-1",
         source_transport_media_id,
     );
-    register_consumer_media(
+    register_open_consumer_route_fixture(
         &mut harness.state,
         &second_consumer_session,
         "cam-down-2",

--- a/crates/core/src/engine/media_transport/rtc/route_control/packet_gate.rs
+++ b/crates/core/src/engine/media_transport/rtc/route_control/packet_gate.rs
@@ -71,6 +71,7 @@ impl PacketOperatingPointGate {
     }
 
     /// returns the selected rid restriction when this operating point is rid-bound
+    #[inline]
     pub const fn rid(self) -> Option<Rid> {
         self.rid
     }
@@ -108,6 +109,21 @@ impl PacketOperatingPointGate {
 }
 
 impl PacketLayerGate {
+    /// returns the concrete RID selected by this gate when one exists
+    ///
+    /// open routes, blocked routes and RID-less operating points do not name a
+    /// simulcast layer and therefore return `None`
+    /// feedback routing uses this to map destination policy back to the
+    /// producer layer that can satisfy a keyframe request
+    #[inline]
+    pub const fn selected_rid(&self) -> Option<Rid> {
+        match *self {
+            Self::Rid(rid) => Some(rid),
+            Self::OperatingPoint(operating_point) => operating_point.rid(),
+            Self::Open | Self::Block => None,
+        }
+    }
+
     /// checks whether packet metadata passes this gate without allocating
     ///
     /// the packet loop calls this on the forwarding hot path

--- a/crates/core/src/engine/media_transport/rtc/test_support/route_graph.rs
+++ b/crates/core/src/engine/media_transport/rtc/test_support/route_graph.rs
@@ -102,11 +102,15 @@ impl<'a> MediaWorkerScenario<'a> {
                     mid,
                     source_transport_media_id,
                 });
-        self.state
-            .media_route_index
-            .entry(source_transport_media_id)
-            .or_insert_with(|| MediaRouteEntry::new(true))
-            .push_destination(MediaRouteDestination {
+        let bind_session_key = session_key.clone();
+        let destination_index = {
+            let route_entry = self
+                .state
+                .media_route_index
+                .entry(source_transport_media_id)
+                .or_insert_with(|| MediaRouteEntry::new(true));
+            let destination_index = route_entry.destinations.len();
+            route_entry.push_destination(MediaRouteDestination {
                 dest_session: session_key,
                 dest_transport_media_id: transport_media_id,
                 dest_stream: ConsumerStreamHandle::default(),
@@ -117,6 +121,15 @@ impl<'a> MediaWorkerScenario<'a> {
                 packet_gate,
                 pending_packet_gate,
             });
+            destination_index
+        };
+        self.state.set_consumer_destination_index(
+            &bind_session_key,
+            mid,
+            transport_media_id,
+            source_transport_media_id,
+            Some(destination_index),
+        );
         transport_media_id
     }
 }

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/media/control/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/media/control/mod.rs
@@ -47,8 +47,8 @@ pub(in crate::engine::media_transport::rtc::worker) use responses::{
 pub(in crate::engine::media_transport::rtc) use routes::worker_set_consumer_packet_gates_for_benchmark;
 pub(super) use routes::{
     ConsumerRouteRegistration, consumer_payload_type, ensure_existing_route_source,
-    ensure_route_source_registered, owned_local_producer_mid, packet_gate_rid,
-    register_consumer_route, remove_consumer_route,
+    ensure_route_source_registered, owned_local_producer_mid, register_consumer_route,
+    remove_consumer_route,
 };
 pub(in crate::engine::media_transport::rtc::worker) use routes::{
     refresh_source_packet_gate, remove_source_route,

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/media/control/routes.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/media/control/routes.rs
@@ -29,7 +29,7 @@
 use std::time::Instant;
 
 use o_sfu_router::MediaStream as RouterRtpParameters;
-use str0m::media::{MediaKind, Mid, Pt, Rid};
+use str0m::media::{MediaKind, Mid, Pt};
 
 use super::{super::types::RouteSourceKind, remote_source, selected_rid};
 use crate::engine::media_transport::{
@@ -214,11 +214,13 @@ pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn register
         now,
     );
     let dest_payload_type = consumer_payload_type(consumer_rtp_parameters);
-    state
-        .media_route_index
-        .entry(source_transport_media_id)
-        .or_insert_with(|| MediaRouteEntry::new(true))
-        .push_destination(MediaRouteDestination {
+    let destination_index = {
+        let route_entry = state
+            .media_route_index
+            .entry(source_transport_media_id)
+            .or_insert_with(|| MediaRouteEntry::new(true));
+        let destination_index = route_entry.destinations.len();
+        route_entry.push_destination(MediaRouteDestination {
             dest_session: consumer_session_key.clone(),
             dest_transport_media_id: consumer_transport_media_id,
             dest_stream: consumer_stream,
@@ -229,6 +231,15 @@ pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn register
             packet_gate,
             pending_packet_gate,
         });
+        destination_index
+    };
+    state.set_consumer_destination_index(
+        consumer_session_key,
+        consumer_mid,
+        consumer_transport_media_id,
+        source_transport_media_id,
+        Some(destination_index),
+    );
     refresh_source_packet_gate(state, source_transport_media_id);
 }
 
@@ -268,7 +279,7 @@ pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn remove_c
         state.prune_remote_source_if_unrouted(source_transport_media_id);
         return;
     };
-    let (removed_destination, remove_route_entry) = {
+    let (removed_destination, moved_destination, remove_route_entry) = {
         let Some(position) = route_entry.destinations.iter().position(|destination| {
             destination.dest_session == *consumer_session_key
                 && destination.dest_transport_media_id == consumer_transport_media_id
@@ -276,8 +287,38 @@ pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn remove_c
             return;
         };
         let removed_destination = route_entry.remove_destination(position);
-        (removed_destination, route_entry.destinations.is_empty())
+        let moved_destination = route_entry.destinations.get(position).map(|destination| {
+            (
+                destination.dest_session.clone(),
+                destination.dest_mid,
+                destination.dest_transport_media_id,
+                position,
+            )
+        });
+        (
+            removed_destination,
+            moved_destination,
+            route_entry.destinations.is_empty(),
+        )
     };
+    state.set_consumer_destination_index(
+        &removed_destination.dest_session,
+        removed_destination.dest_mid,
+        removed_destination.dest_transport_media_id,
+        source_transport_media_id,
+        None,
+    );
+    if let Some((session_key, mid, transport_media_id, destination_index)) = moved_destination {
+        // `swap_remove` can move another consumer into `position`
+        // repair that consumer's feedback index before the route is reused
+        state.set_consumer_destination_index(
+            &session_key,
+            mid,
+            transport_media_id,
+            source_transport_media_id,
+            Some(destination_index),
+        );
+    }
     release_destination_stream(state, &removed_destination);
     if remove_route_entry {
         state.media_route_index.remove(&source_transport_media_id);
@@ -299,6 +340,13 @@ pub(in crate::engine::media_transport::rtc::worker) fn remove_source_route(
         return;
     };
     for destination in route_entry.destinations {
+        state.set_consumer_destination_index(
+            &destination.dest_session,
+            destination.dest_mid,
+            destination.dest_transport_media_id,
+            source_transport_media_id,
+            None,
+        );
         release_destination_stream(state, &destination);
     }
     refresh_source_packet_gate(state, source_transport_media_id);
@@ -576,20 +624,6 @@ fn update_consumer_route(
         _ => false,
     })
 }
-/// extracts the rid restriction carried by a packet-layer gate
-///
-/// keyframe routing and selected-rid readiness use this to map destination
-/// policy back to producer-side refresh targets
-pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn packet_gate_rid(
-    packet_gate: &PacketLayerGate,
-) -> Option<Rid> {
-    match packet_gate {
-        PacketLayerGate::Rid(rid) => Some(*rid),
-        PacketLayerGate::OperatingPoint(operating_point) => operating_point.rid(),
-        PacketLayerGate::Open | PacketLayerGate::Block => None,
-    }
-}
-
 /// validates the source side of a route and optionally registers remote state
 ///
 /// local sources are resolved through worker media handles because they must be

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/media/control/selected_rid.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/media/control/selected_rid.rs
@@ -28,7 +28,7 @@ use tracing::{debug, warn};
 
 use super::{
     super::keyframe::request_keyframe_for_source,
-    routes::{owned_local_producer_mid, packet_gate_rid, refresh_source_packet_gate},
+    routes::{owned_local_producer_mid, refresh_source_packet_gate},
 };
 use crate::engine::{
     media_transport::{
@@ -329,7 +329,7 @@ pub(super) fn guarded_packet_gate(
     packet_gate: PacketLayerGate,
     now: Instant,
 ) -> (PacketLayerGate, Option<PacketLayerGate>) {
-    let Some(rid) = packet_gate_rid(&packet_gate) else {
+    let Some(rid) = packet_gate.selected_rid() else {
         return (packet_gate, None);
     };
     if state.producer_rid_is_ready(
@@ -410,7 +410,7 @@ fn update_selected_rid_destinations(
         let Some(selected_rid) = destination
             .pending_packet_gate
             .as_ref()
-            .and_then(packet_gate_rid)
+            .and_then(PacketLayerGate::selected_rid)
         else {
             continue;
         };
@@ -460,7 +460,7 @@ fn suspend_stale_destination_gate(
     if destination.pending_packet_gate.is_some() {
         return;
     }
-    let Some(selected_rid) = packet_gate_rid(&destination.packet_gate) else {
+    let Some(selected_rid) = destination.packet_gate.selected_rid() else {
         return;
     };
     if selected_rid == incoming_rid || ready_rids.contains(&selected_rid) {
@@ -498,7 +498,7 @@ fn activate_bootstrap_fallback_destinations(
         let Some(selected_rid) = destination
             .pending_packet_gate
             .as_ref()
-            .and_then(packet_gate_rid)
+            .and_then(PacketLayerGate::selected_rid)
         else {
             continue;
         };

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/media/keyframe.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/media/keyframe.rs
@@ -11,10 +11,12 @@ use tracing::debug;
 
 use super::{
     super::super::super::{
-        demux::MediaRouteDestination, media_registry::RegisteredMediaHandle,
-        route_control::KeyframeRequestDecision, state::PacketLoopState,
+        demux::MediaRouteDestination,
+        media_registry::RegisteredMediaHandle,
+        route_control::{KeyframeRequestDecision, PacketLayerGate},
+        state::PacketLoopState,
     },
-    control::{ensure_existing_route_source, owned_local_producer_mid, packet_gate_rid},
+    control::{ensure_existing_route_source, owned_local_producer_mid},
     types::RouteSourceKind,
 };
 use crate::engine::{
@@ -162,7 +164,7 @@ pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn worker_r
             );
         }
         RouteSourceKind::Remote => {
-            let Some((source_session_key, source_control)) = state
+            let Some((source, source_control)) = state
                 .remote_source_registration(source_transport_media_id)
                 .map(|registration| {
                     (
@@ -180,7 +182,7 @@ pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn worker_r
             ) {
                 KeyframeRequestDecision::Forward => {
                     source_control.request_keyframe(
-                        &source_session_key,
+                        &source,
                         destination_rid,
                         KeyframeRequestKind::Pli,
                     );
@@ -195,12 +197,16 @@ pub(in crate::engine::media_transport::rtc::worker::handlers::media) fn worker_r
     Ok(())
 }
 
+/// returns the RID that a route-level keyframe command should refresh
+///
+/// route commands can bootstrap a pending selected RID, so they look at
+/// `pending_packet_gate` before the effective fallback gate
 fn keyframe_request_rid(destination: &MediaRouteDestination) -> Option<Rid> {
     destination
         .pending_packet_gate
         .as_ref()
-        .and_then(packet_gate_rid)
-        .or_else(|| packet_gate_rid(&destination.packet_gate))
+        .and_then(PacketLayerGate::selected_rid)
+        .or_else(|| destination.packet_gate.selected_rid())
 }
 
 fn local_keyframe_request_mid(

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/media/tests.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/media/tests.rs
@@ -14,9 +14,8 @@ use std::{
 use fixtures::{
     LocalVideoRoute, PendingSelectedRidRoute, RemoteVideoRoute, assert_consumer_packet_gate,
     assert_remote_keyframe_command, assert_remote_packet_gate_command, drain_ready_sessions,
-    expect_response, install_video_route, prepare_pending_selected_rid_route,
-    prepare_source_session, prepare_source_session_with_rid, register_saturated_remote_source,
-    request_consumer_keyframe,
+    expect_response, prepare_pending_selected_rid_route, prepare_source_session,
+    prepare_source_session_with_rid, register_saturated_remote_source,
 };
 use o_sfu_router::{MediaStream as RouterRtpParameters, StreamBinding};
 use str0m::{
@@ -26,9 +25,10 @@ use str0m::{
 use tokio::sync::{mpsc, oneshot};
 
 use super::{
-    AddSendMediaRequest, apply_route_control_request, drain_due_rid_keyframe_refreshes,
-    observe_source_rid_readiness, refresh_source_packet_gate, request_keyframe_for_source,
-    respond_set_consumer_packet_gates, worker_add_send_media, worker_remove_media,
+    AddSendMediaRequest, apply_route_control_request, control::remove_consumer_route,
+    drain_due_rid_keyframe_refreshes, observe_source_rid_readiness, refresh_source_packet_gate,
+    request_keyframe_for_source, respond_set_consumer_packet_gates, worker_add_send_media,
+    worker_remove_media,
 };
 use crate::{
     Bitrate, MediaCodecFlags,
@@ -41,7 +41,9 @@ use crate::{
                 bitrate::BitrateRegistry,
                 bootstrap,
                 commands::{ConsumerPacketGateCommand, RemoteSourceControl, RouteControlRequest},
-                media_registry::{RegisteredMediaHandle, RemoteSourceRegistration},
+                media_registry::{
+                    ConsumerKeyframeTarget, RegisteredMediaHandle, RemoteSourceRegistration,
+                },
                 relay_registry::{RelayPacketMailbox, RelayTargetId},
                 route_control::{KeyframeRequestDecision, PacketLayerGate},
                 state::PacketLoopState,
@@ -280,6 +282,17 @@ fn set_consumer_packet_gate_updates_one_route_without_rewriting_the_source_gate(
                 && destination.packet_gate == PacketLayerGate::Rid("lo".into())
         })
     ));
+    assert_eq!(
+        state.active_consumer_keyframe_target_for_mid(
+            &first_consumer_session,
+            first_consumer_mid,
+            None,
+        ),
+        Some(ConsumerKeyframeTarget {
+            source_transport_media_id,
+            rid: Some(Rid::from("lo")),
+        })
+    );
     assert!(matches!(
         state.media_route_index.get(&source_transport_media_id),
         Some(route_entry) if route_entry.destinations.iter().any(|destination| {
@@ -292,6 +305,57 @@ fn set_consumer_packet_gate_updates_one_route_without_rewriting_the_source_gate(
             .route_control
             .effective_packet_gate(source_transport_media_id),
         Some(PacketLayerGate::Open)
+    );
+}
+
+#[test]
+fn removing_consumer_route_clears_feedback_index_and_repairs_moved_route() {
+    let first_consumer_session = test_transport_session_key(64, 1, 65, UserId::Integer(66));
+    let second_consumer_session = test_transport_session_key(64, 1, 67, UserId::Integer(68));
+    let first_consumer_mid = Mid::from("cam-down-first");
+    let second_consumer_mid = Mid::from("cam-down-second");
+    let source_transport_media_id = TransportMediaId::new(64_100);
+    let rid = Rid::from("hi");
+    let mut state = PacketLoopState::default();
+    let mut scenario = MediaWorkerScenario::new(&mut state);
+    scenario.existing_source(source_transport_media_id);
+    let first_consumer_transport_media_id = scenario.destination(
+        source_transport_media_id,
+        first_consumer_session.clone(),
+        first_consumer_mid,
+    );
+    scenario.destination_with_gate(
+        source_transport_media_id,
+        second_consumer_session.clone(),
+        second_consumer_mid,
+        PacketLayerGate::Rid(rid),
+    );
+
+    remove_consumer_route(
+        &mut state,
+        &first_consumer_session,
+        first_consumer_transport_media_id,
+        source_transport_media_id,
+    );
+
+    assert_eq!(
+        state.active_consumer_keyframe_target_for_mid(
+            &first_consumer_session,
+            first_consumer_mid,
+            None,
+        ),
+        None
+    );
+    assert_eq!(
+        state.active_consumer_keyframe_target_for_mid(
+            &second_consumer_session,
+            second_consumer_mid,
+            None,
+        ),
+        Some(ConsumerKeyframeTarget {
+            source_transport_media_id,
+            rid: Some(rid),
+        })
     );
 }
 
@@ -609,6 +673,17 @@ fn selected_rid_packet_gate_blocks_when_selected_rid_goes_stale() {
         Some(&PacketLayerGate::Rid(selected_rid)),
     );
     assert_eq!(
+        route.state.active_consumer_keyframe_target_for_mid(
+            &route.consumer_session,
+            Mid::from("cam-down"),
+            None,
+        ),
+        Some(ConsumerKeyframeTarget {
+            source_transport_media_id: route.source_transport_media_id,
+            rid: Some(selected_rid),
+        })
+    );
+    assert_eq!(
         route
             .state
             .route_control
@@ -848,43 +923,6 @@ fn remote_source_teardown_drops_pending_packet_gate_state() {
             .is_none()
     );
     assert_eq!(metrics.snapshot().rtc_remote_control_packet_gate_drops(), 1);
-}
-
-#[test]
-fn remote_keyframe_command_drops_are_counted_under_mailbox_pressure() {
-    let source_session = test_transport_session_key(141, 0, 172, UserId::Integer(173));
-    let consumer_session = test_transport_session_key(141, 1, 174, UserId::Integer(175));
-    let consumer_mid = Mid::from("cam-down");
-    let mut state = PacketLoopState::default();
-    let metrics = RuntimeMetrics::default();
-    let rtc_metrics = metrics.register_rtc_worker();
-    let source_transport_media_id = TransportMediaId::new(65);
-    let _command_rx = register_saturated_remote_source(
-        &mut state,
-        source_transport_media_id,
-        &source_session,
-        RelayTargetId::new(22),
-        Arc::clone(&rtc_metrics),
-    );
-    let consumer_transport_media_id = install_video_route(
-        &mut state,
-        source_transport_media_id,
-        &consumer_session,
-        consumer_mid,
-    );
-
-    request_consumer_keyframe(
-        &mut state,
-        &metrics,
-        &consumer_session,
-        consumer_transport_media_id,
-        &source_session,
-        source_transport_media_id,
-    );
-
-    let snapshot = metrics.snapshot();
-    assert_eq!(snapshot.rtc_remote_control_keyframe_drops(), 1);
-    assert_eq!(snapshot.rtc_route_control_forwarded(), 1);
 }
 
 #[test]

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/media/tests/fixtures.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/media/tests/fixtures.rs
@@ -131,21 +131,6 @@ pub(super) fn assert_consumer_packet_gate(
     );
 }
 
-pub(super) fn install_video_route(
-    state: &mut PacketLoopState,
-    source_transport_media_id: TransportMediaId,
-    consumer_session: &TransportSessionKey,
-    consumer_mid: Mid,
-) -> TransportMediaId {
-    install_video_route_with_gate(
-        state,
-        source_transport_media_id,
-        consumer_session,
-        consumer_mid,
-        PacketLayerGate::Open,
-    )
-}
-
 pub(super) fn install_video_route_with_gate(
     state: &mut PacketLoopState,
     source_transport_media_id: TransportMediaId,

--- a/tests/benchmarks/packet_loop_callgrind.rs
+++ b/tests/benchmarks/packet_loop_callgrind.rs
@@ -227,9 +227,9 @@ fn active_speaker_policy(mut fixture: ActiveSpeakerBenchFixture) -> usize {
 //
 // coalescing keeps route-control feedback storms from turning into one remote
 // source command per consumer
-// this benchmark checks the sorted flush path that collapses many requests into
-// the single producer-side signal the packet loop should emit
-#[library_benchmark(config = callgrind_config(0.5))]
+// this benchmark checks the route-scoped flush path that resolves current route
+// state before collapsing many requests into one producer-side signal
+#[library_benchmark(config = callgrind_config(5.0))]
 #[bench::remote_source(KeyframeCoalescingBenchFixture::remote_source_requests())]
 fn keyframe_coalesce_512(mut fixture: KeyframeCoalescingBenchFixture) -> usize {
     black_box(fixture.flush_requests())


### PR DESCRIPTION
consumer pli and fir feedback from simulcast routes was coalesced by source only
when browser feedback arrived without a rid, a rid-selected downstream route could still turn into a source-wide producer refresh that could request every simulcast layer at once and make unrelated viewers wait behind the same recovery burst

this changes packet-loop feedback resolution to map a consumer session plus mid through the current route destination before producer control sees the request
rid-selected destinations now request the selected producer rid
blocked destinations use the pending selected rid only while there is no effective fallback gate
open or rid-less destinations keep the previous source-wide behavior
stale, removed or inactive destinations drop feedback

keyframe request coalescing now keys duplicate suppression by source media id plus rid
that keeps duplicate requests for one routed layer coalesced while preserving separate upstream requests for different selected layers
