### PR TITLE
[FIX] core: target BWE from routed video demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ you can read the one at [odoo/sfu](https://github.com/odoo/sfu), it's roughly th
 | `CODEC_AUDIO_PREFERENCE`                     | `opus,PCMU,PCMA`           | Optional comma-separated audio codec preference order. Missing codecs keep their default relative order.                                                          |
 | `CODEC_VIDEO_PREFERENCE`                     | `VP8,H264,H265,VP9,AV1`    | Optional comma-separated video codec preference order. Missing codecs keep their default relative order.                                                          |
 | `MAX_BITRATE_IN`                             | `8000000`                  | Maximum incoming bitrate in bps per user (upload).                                                                                                                |
-| `MAX_BITRATE_OUT`                            | `10000000`                 | WebRTC desired-send-bitrate and BWE ceiling in bps per user (download). It is not a strict packet-forwarding cap.                                                 |
+| `MAX_BITRATE_OUT`                            | `10000000`                 | Receiver-side BWE ceiling in bps per user (download). Desired send bitrate is derived from selected receiver video demand and capped by this value. It is not a strict packet-forwarding cap. |
 | `MAX_VIDEO_BITRATE`                          | `4000000`                  | Maximum bitrate in bps for the highest default simulcast video layer metadata.                                                                                    |
 
 

--- a/crates/core/src/engine/media_transport/mod.rs
+++ b/crates/core/src/engine/media_transport/mod.rs
@@ -54,8 +54,8 @@ use tracing::warn;
 pub use types::{
     ActiveSpeakerActivityReason, ActiveSpeakerActivityState, ActiveSpeakerSource,
     ActiveSpeakerSourceDiagnostic, AppliedProducer, AppliedSessionAnswer, ConsumerActivity,
-    ConsumerPacketGateUpdate, ProducerActivity, ReceiverBandwidthSnapshot, RelayRouteActivity,
-    SessionOffer, SessionUploadEncoding, SessionUploadSlot, SourcePacketGate,
+    ConsumerPacketGateUpdate, ProducerActivity, ReceiverBandwidthSnapshot, ReceiverBweTargetUpdate,
+    RelayRouteActivity, SessionOffer, SessionUploadEncoding, SessionUploadSlot, SourcePacketGate,
     SourcePacketOperatingPoint, TransportAdapterError, TransportBitrateSnapshot,
     TransportConsumerRoute, TransportMediaId, TransportPlacementPressureSnapshot,
     TransportQualitySample, TransportQualitySnapshot, TransportRelayRouteAction,
@@ -487,6 +487,26 @@ impl MediaTransport {
                     route = ?update.route(),
                     packet_gate = ?update.packet_gate(),
                     "media transport failed to update a batched consumer packet gate"
+                );
+            }
+        }
+        results
+    }
+
+    /// Applies receiver-side desired BWE targets and preserves input order in
+    /// the returned results.
+    pub async fn set_receiver_bwe_targets(
+        &self,
+        updates: &[ReceiverBweTargetUpdate],
+    ) -> Vec<Result<(), TransportAdapterError>> {
+        let results = self.execute_receiver_bwe_target_batch(updates).await;
+        for (update, result) in updates.iter().zip(results.iter()) {
+            if let Err(error) = result {
+                warn!(
+                    ?error,
+                    session_key = ?update.session_key(),
+                    target = update.target().as_bps(),
+                    "media transport failed to update a receiver BWE target"
                 );
             }
         }

--- a/crates/core/src/engine/media_transport/rtc/bootstrap.rs
+++ b/crates/core/src/engine/media_transport/rtc/bootstrap.rs
@@ -150,8 +150,6 @@ pub(super) fn ensure_session_rtc_state_with_stats_interval(
         .enable_bwe(Some(Str0mBitrate::bps(max_bitrate_out.as_bps())))
         .set_ice_lite(true)
         .build(started_at);
-    rtc.bwe()
-        .set_desired_bitrate(Str0mBitrate::bps(max_bitrate_out.as_bps()));
     let candidate = Candidate::host(candidate_addr, webrtc::IceTransport::Udp.as_str())
         .map_err(|_error| TransportAdapterError::TransportUnavailable)?;
     if rtc.add_local_candidate(candidate).is_none() {
@@ -168,6 +166,9 @@ pub(super) fn ensure_session_rtc_state_with_stats_interval(
             max_bitrate_in: None,
             #[cfg(test)]
             max_bitrate_out: Some(max_bitrate_out),
+            receiver_bwe_target: None,
+            #[cfg(test)]
+            receiver_bwe_str0m_update_count: 0,
             dtls_started: false,
             packet_loop_dirty: false,
             sdp_negotiation: SessionSdpNegotiationState::default(),

--- a/crates/core/src/engine/media_transport/rtc/commands.rs
+++ b/crates/core/src/engine/media_transport/rtc/commands.rs
@@ -19,9 +19,9 @@ use super::{
 use crate::engine::{
     RoomInstanceId,
     media_transport::{
-        ActiveSpeakerSource, ActiveSpeakerSourceDiagnostic, AppliedSessionAnswer, SessionOffer,
-        TransportConsumerRoute, TransportMediaId, TransportResult, TransportSessionKey,
-        TransportSourceKey,
+        ActiveSpeakerSource, ActiveSpeakerSourceDiagnostic, AppliedSessionAnswer,
+        ReceiverBweTargetUpdate, SessionOffer, TransportConsumerRoute, TransportMediaId,
+        TransportResult, TransportSessionKey, TransportSourceKey,
     },
     metrics::{RtcMetricsRecorder, RtcRemoteControlDropKind, RtcRemotePacketGateConvergence},
 };
@@ -297,6 +297,14 @@ pub(super) enum RtcWorkerCommand {
     ExpiredActiveSpeakerRoomInstanceIds {
         now: Instant,
         response: RtcWorkerResponse<BTreeSet<RoomInstanceId>>,
+    },
+    /// update receiver-side desired send bitrate for BWE probing
+    ///
+    /// the worker caps every target at its outgoing bitrate ceiling and dedupes
+    /// unchanged values before touching str0m
+    SetReceiverBweTargetBatch {
+        updates: Vec<ReceiverBweTargetUpdate>,
+        response: RtcWorkerResponse<Vec<TransportResult<()>>>,
     },
     /// accept the answer for the current pending local offer
     ///

--- a/crates/core/src/engine/media_transport/rtc/state/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/state/mod.rs
@@ -94,6 +94,11 @@ pub(super) struct RtcSessionState {
     #[cfg(test)]
     /// outbound bitrate cap used to build the session in deterministic tests
     pub(super) max_bitrate_out: Option<Bitrate>,
+    /// last desired receiver-side send bitrate applied to str0m BWE
+    pub(super) receiver_bwe_target: Option<Bitrate>,
+    #[cfg(test)]
+    /// number of non-deduped desired-bitrate writes issued to str0m BWE
+    pub(super) receiver_bwe_str0m_update_count: u64,
     /// whether a remote answer has committed DTLS and media packet routing can start
     pub(super) dtls_started: bool,
     /// scheduler bit that prevents duplicate dirty-session wakeups

--- a/crates/core/src/engine/media_transport/rtc/test_support.rs
+++ b/crates/core/src/engine/media_transport/rtc/test_support.rs
@@ -15,9 +15,9 @@ use std::time::Instant;
 pub use probe::{DebugPacketGate, DebugRouteDestination, DebugRouteEntry};
 #[cfg(any(test, feature = "testing-transport"))]
 pub(super) use probe::{
-    DebugProbe, DebugProbeRequest, ObserveAudioActivityProbe, RouteEntryByConsumerMidProbe,
-    RouteEntryByMediaIdProbe, RouteEntryProbe, RtcWorkerDebugChannels, RtcWorkerDebugHandle,
-    handle_debug_probe,
+    DebugProbe, DebugProbeRequest, ObserveAudioActivityProbe, ReceiverBweTargetProbe,
+    RouteEntryByConsumerMidProbe, RouteEntryByMediaIdProbe, RouteEntryProbe,
+    RtcWorkerDebugChannels, RtcWorkerDebugHandle, handle_debug_probe,
 };
 #[cfg(test)]
 pub(super) use probe::{

--- a/crates/core/src/engine/media_transport/rtc/test_support/probe.rs
+++ b/crates/core/src/engine/media_transport/rtc/test_support/probe.rs
@@ -33,11 +33,14 @@ use std::{net::SocketAddr, time::Instant};
 use str0m::media::Mid;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::engine::media_transport::{
-    TransportMediaId, TransportSessionKey,
-    rtc::{
-        packet_loop::PacketLoopInputReceivers, route_control::PacketLayerGate,
-        state::PacketLoopState, worker::WorkerCommandContext,
+use crate::{
+    Bitrate,
+    engine::media_transport::{
+        TransportMediaId, TransportSessionKey,
+        rtc::{
+            packet_loop::PacketLoopInputReceivers, route_control::PacketLayerGate,
+            state::PacketLoopState, worker::WorkerCommandContext,
+        },
     },
 };
 
@@ -345,6 +348,27 @@ impl DebugProbe for RouteEntryByMediaIdProbe {
         _context: &WorkerCommandContext<'_>,
     ) -> Self::Output {
         debug_route_entry(state, self.source_transport_media_id)
+    }
+}
+
+#[cfg(any(test, feature = "testing-transport"))]
+pub(in crate::engine::media_transport::rtc) struct ReceiverBweTargetProbe {
+    pub session_key: TransportSessionKey,
+}
+
+#[cfg(any(test, feature = "testing-transport"))]
+impl DebugProbe for ReceiverBweTargetProbe {
+    type Output = Option<Bitrate>;
+
+    fn inspect(
+        self,
+        state: &mut PacketLoopState,
+        _context: &WorkerCommandContext<'_>,
+    ) -> Self::Output {
+        state
+            .users
+            .get(&self.session_key)
+            .and_then(|session_state| session_state.receiver_bwe_target)
     }
 }
 

--- a/crates/core/src/engine/media_transport/rtc/tests/fixtures.rs
+++ b/crates/core/src/engine/media_transport/rtc/tests/fixtures.rs
@@ -27,8 +27,8 @@ pub(super) use crate::{
     engine::{
         UserId,
         media_transport::{
-            ActiveSpeakerSource, SessionOffer, TransportAdapterError, TransportConsumerRoute,
-            TransportMediaId, TransportSessionKey, TransportSourceKey,
+            ActiveSpeakerSource, ReceiverBweTargetUpdate, SessionOffer, TransportAdapterError,
+            TransportConsumerRoute, TransportMediaId, TransportSessionKey, TransportSourceKey,
         },
         metrics::test_support::RuntimeMetricsSnapshotTestExt,
     },

--- a/crates/core/src/engine/media_transport/rtc/tests/media_flow_tests.rs
+++ b/crates/core/src/engine/media_transport/rtc/tests/media_flow_tests.rs
@@ -86,6 +86,122 @@ async fn rtc_session_bootstrap_applies_configured_outgoing_bitrate_cap() {
 }
 
 #[tokio::test]
+async fn rtc_receiver_bwe_target_update_writes_session_state() {
+    let adapter = RtcWorker::default();
+    let session_key = transport_key(1, 183, UserId::Integer(183));
+    expect_initial_offer(&adapter, &session_key).await;
+    let update = ReceiverBweTargetUpdate::new(session_key.clone(), Bitrate::from_kbps(850));
+
+    let results = adapter
+        .set_receiver_bwe_targets(slice::from_ref(&update))
+        .await
+        .expect("receiver BWE target command should reach the worker");
+
+    assert_eq!(results, vec![Ok(())]);
+    assert_eq!(
+        adapter
+            .debug_session_receiver_bwe_target(&session_key)
+            .await,
+        Some(Bitrate::from_kbps(850))
+    );
+}
+
+#[tokio::test]
+async fn rtc_receiver_bwe_target_update_dedupes_identical_targets() {
+    let adapter = RtcWorker::default();
+    let session_key = transport_key(1, 184, UserId::Integer(184));
+    expect_initial_offer(&adapter, &session_key).await;
+    let update = ReceiverBweTargetUpdate::new(session_key.clone(), Bitrate::from_kbps(640));
+
+    let first_results = adapter
+        .set_receiver_bwe_targets(slice::from_ref(&update))
+        .await
+        .expect("first receiver BWE target command should reach the worker");
+    let second_results = adapter
+        .set_receiver_bwe_targets(slice::from_ref(&update))
+        .await
+        .expect("second receiver BWE target command should reach the worker");
+
+    assert_eq!(first_results, vec![Ok(())]);
+    assert_eq!(second_results, vec![Ok(())]);
+    assert_eq!(
+        adapter
+            .debug_session_receiver_bwe_str0m_update_count(&session_key)
+            .await,
+        Some(1)
+    );
+}
+
+#[tokio::test]
+async fn rtc_receiver_bwe_target_update_caps_at_max_bitrate_out() {
+    let adapter = rtc_with_bitrate_limits(Bitrate::from_mbps(8), Bitrate::from_kbps(500));
+    let session_key = transport_key(1, 185, UserId::Integer(185));
+    expect_initial_offer(&adapter, &session_key).await;
+    let update = ReceiverBweTargetUpdate::new(session_key.clone(), Bitrate::from_kbps(900));
+
+    let results = adapter
+        .set_receiver_bwe_targets(slice::from_ref(&update))
+        .await
+        .expect("receiver BWE target command should reach the worker");
+
+    assert_eq!(results, vec![Ok(())]);
+    assert_eq!(
+        adapter
+            .debug_session_receiver_bwe_target(&session_key)
+            .await,
+        Some(Bitrate::from_kbps(500))
+    );
+}
+
+#[tokio::test]
+async fn rtc_receiver_bwe_target_update_missing_session_returns_error() {
+    let adapter = RtcWorker::default();
+    let session_key = transport_key(1, 186, UserId::Integer(186));
+    let update = ReceiverBweTargetUpdate::new(session_key, Bitrate::from_kbps(400));
+
+    let results = adapter
+        .set_receiver_bwe_targets(slice::from_ref(&update))
+        .await
+        .expect("missing session result should still return through the worker");
+
+    assert!(matches!(
+        results.as_slice(),
+        [Err(TransportAdapterError::InvalidInput)]
+    ));
+}
+
+#[tokio::test]
+async fn rtc_receiver_bwe_zero_target_clears_previous_target() {
+    let adapter = RtcWorker::default();
+    let session_key = transport_key(1, 187, UserId::Integer(187));
+    expect_initial_offer(&adapter, &session_key).await;
+    let non_zero = ReceiverBweTargetUpdate::new(session_key.clone(), Bitrate::from_kbps(700));
+    let zero = ReceiverBweTargetUpdate::new(session_key.clone(), Bitrate::zero());
+
+    assert!(
+        adapter
+            .set_receiver_bwe_targets(slice::from_ref(&non_zero))
+            .await
+            .expect("non-zero target command should reach the worker")[0]
+            .is_ok()
+    );
+    assert!(
+        adapter
+            .set_receiver_bwe_targets(slice::from_ref(&zero))
+            .await
+            .expect("zero target command should reach the worker")[0]
+            .is_ok()
+    );
+
+    assert_eq!(
+        adapter
+            .debug_session_receiver_bwe_target(&session_key)
+            .await,
+        Some(Bitrate::zero())
+    );
+}
+
+#[tokio::test]
 async fn rtc_recv_media_applies_configured_incoming_bitrate_cap() {
     let adapter =
         rtc_with_bitrate_limits(Bitrate::from_bps(1_234_567), Bitrate::from_bps(7_654_321));

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/bwe.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/bwe.rs
@@ -1,0 +1,52 @@
+//! receiver-side bandwidth-estimation target updates.
+//!
+//! Room policy owns selected receiver video demand. The RTC worker only applies
+//! that demand to the session-local str0m BWE controller after capping it to the
+//! configured outgoing ceiling.
+
+use str0m::bwe::Bitrate as Str0mBitrate;
+
+use super::super::super::state::PacketLoopState;
+use crate::{
+    Bitrate,
+    engine::media_transport::{ReceiverBweTargetUpdate, TransportAdapterError, TransportResult},
+};
+
+pub(super) fn worker_set_receiver_bwe_targets(
+    state: &mut PacketLoopState,
+    max_bitrate_out: Bitrate,
+    updates: &[ReceiverBweTargetUpdate],
+) -> Vec<TransportResult<()>> {
+    updates
+        .iter()
+        .map(|update| apply_receiver_bwe_target(state, max_bitrate_out, update))
+        .collect()
+}
+
+fn apply_receiver_bwe_target(
+    state: &mut PacketLoopState,
+    max_bitrate_out: Bitrate,
+    update: &ReceiverBweTargetUpdate,
+) -> TransportResult<()> {
+    let target = update.target().min(max_bitrate_out);
+    let Some(session_state) = state.users.get_mut(update.session_key()) else {
+        return Err(TransportAdapterError::InvalidInput);
+    };
+    if session_state.receiver_bwe_target == Some(target) {
+        return Ok(());
+    }
+    let previous = session_state.receiver_bwe_target;
+    session_state.receiver_bwe_target = Some(target);
+    if target == Bitrate::zero() && previous.is_none() {
+        return Ok(());
+    }
+    #[cfg(test)]
+    {
+        session_state.receiver_bwe_str0m_update_count += 1;
+    }
+    session_state
+        .rtc
+        .bwe()
+        .set_desired_bitrate(Str0mBitrate::bps(target.as_bps()));
+    Ok(())
+}

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/dispatcher.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/dispatcher.rs
@@ -21,7 +21,7 @@ use super::{
         commands::{CloseSessionState, RtcMediaControlCommand, RtcWorkerCommand},
         state::{PacketLoopState, RtcSnapshotState},
     },
-    media,
+    bwe, media,
     negotiation::{self, OfferBootstrapConfig},
     session,
 };
@@ -95,18 +95,14 @@ pub fn handle_worker_command(
                 &session_key,
             ),
         ),
-        RtcWorkerCommand::ActiveSpeakerSourceSnapshot { response } => {
-            respond(
-                response,
-                Ok(state.active_speaker_source_snapshot(context.now)),
-            );
-        }
-        RtcWorkerCommand::ActiveSpeakerDiagnosticSnapshot { response } => {
-            respond(
-                response,
-                Ok(state.active_speaker_diagnostic_snapshot(context.now)),
-            );
-        }
+        RtcWorkerCommand::ActiveSpeakerSourceSnapshot { response } => respond(
+            response,
+            Ok(state.active_speaker_source_snapshot(context.now)),
+        ),
+        RtcWorkerCommand::ActiveSpeakerDiagnosticSnapshot { response } => respond(
+            response,
+            Ok(state.active_speaker_diagnostic_snapshot(context.now)),
+        ),
         RtcWorkerCommand::NextActiveSpeakerDeadline { response } => {
             respond(
                 response,
@@ -115,12 +111,18 @@ pub fn handle_worker_command(
                     .next_active_speaker_deadline(context.now)),
             );
         }
-        RtcWorkerCommand::ExpiredActiveSpeakerRoomInstanceIds { now, response } => {
-            respond(
-                response,
-                Ok(state.expired_active_speaker_room_instance_ids(now)),
-            );
-        }
+        RtcWorkerCommand::ExpiredActiveSpeakerRoomInstanceIds { now, response } => respond(
+            response,
+            Ok(state.expired_active_speaker_room_instance_ids(now)),
+        ),
+        RtcWorkerCommand::SetReceiverBweTargetBatch { updates, response } => respond(
+            response,
+            Ok(bwe::worker_set_receiver_bwe_targets(
+                state,
+                context.max_bitrate_out,
+                &updates,
+            )),
+        ),
         RtcWorkerCommand::CreateSessionRenegotiationOffer {
             session_key,
             response,

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/mod.rs
@@ -13,6 +13,7 @@
 //! - expose the small helpers that packet-loop code reuses directly, such as
 //!   keyframe requests for already-resolved sources
 
+mod bwe;
 mod dispatcher;
 mod media;
 mod negotiation;

--- a/crates/core/src/engine/media_transport/rtc/worker/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/mod.rs
@@ -76,9 +76,9 @@ use crate::{
         diagnostics::DiagnosticsStore,
         media_transport::{
             AppliedSessionAnswer, ConsumerPacketGateUpdate, MediaTransportConfig,
-            MediaTransportDeps, SessionOffer, SourcePacketGate, SourcePolicySignal,
-            TransportAdapterError, TransportConsumerRoute, TransportMediaId, TransportResult,
-            TransportSessionKey, TransportSourceKey,
+            MediaTransportDeps, ReceiverBweTargetUpdate, SessionOffer, SourcePacketGate,
+            SourcePolicySignal, TransportAdapterError, TransportConsumerRoute, TransportMediaId,
+            TransportResult, TransportSessionKey, TransportSourceKey,
         },
         metrics::{RtcMetricsRecorder, RtpMetricsRecorder, RuntimeMetrics},
         packet_sink_registry::RoomPacketSinkRegistry,
@@ -624,6 +624,24 @@ impl RtcWorker {
                 updates,
                 response,
             })
+        })
+        .await
+    }
+
+    /// updates receiver-side desired bitrate targets for BWE probing
+    ///
+    /// # Errors
+    ///
+    /// returns [`TransportAdapterError`] when the worker cannot receive or
+    /// answer the batch command
+    pub async fn set_receiver_bwe_targets<'a>(
+        &self,
+        updates: impl IntoIterator<Item = &'a ReceiverBweTargetUpdate>,
+    ) -> Result<Vec<TransportResult<()>>, TransportAdapterError> {
+        let updates = updates.into_iter().cloned().collect();
+        self.request_worker(|response| RtcWorkerCommand::SetReceiverBweTargetBatch {
+            updates,
+            response,
         })
         .await
     }

--- a/crates/core/src/engine/media_transport/rtc/worker/test_support.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/test_support.rs
@@ -14,8 +14,7 @@ use {
         WorkerCommandContext,
     },
     crate::{
-        Bitrate, CodecPreferences, MediaCodecFlags, MediaWorkerId, RtcPortRange,
-        SessionBitrateLimits,
+        CodecPreferences, MediaCodecFlags, MediaWorkerId, RtcPortRange, SessionBitrateLimits,
         engine::{
             diagnostics::DiagnosticsStore,
             media_transport::{
@@ -36,12 +35,13 @@ use super::{
     super::{
         state::TransportSessionHealth,
         test_support::{
-            DebugProbe, DebugRouteEntry, ObserveAudioActivityProbe, RouteEntryByConsumerMidProbe,
-            RouteEntryByMediaIdProbe, RouteEntryProbe,
+            DebugProbe, DebugRouteEntry, ObserveAudioActivityProbe, ReceiverBweTargetProbe,
+            RouteEntryByConsumerMidProbe, RouteEntryByMediaIdProbe, RouteEntryProbe,
         },
     },
     RtcWorker,
 };
+use crate::Bitrate;
 
 #[cfg(test)]
 #[allow(
@@ -203,6 +203,34 @@ impl RtcWorker {
                 .users
                 .get(&session_key)
                 .and_then(|session_state| session_state.max_bitrate_out)
+        })
+        .await
+        .flatten()
+    }
+
+    #[cfg(any(test, feature = "testing-transport"))]
+    pub async fn debug_session_receiver_bwe_target(
+        &self,
+        session_key: &TransportSessionKey,
+    ) -> Option<Bitrate> {
+        self.probe_debug_worker(ReceiverBweTargetProbe {
+            session_key: session_key.clone(),
+        })
+        .await
+        .flatten()
+    }
+
+    #[cfg(test)]
+    pub async fn debug_session_receiver_bwe_str0m_update_count(
+        &self,
+        session_key: &TransportSessionKey,
+    ) -> Option<u64> {
+        let session_key = session_key.clone();
+        self.read_debug_worker(move |state, _context| {
+            state
+                .users
+                .get(&session_key)
+                .map(|session_state| session_state.receiver_bwe_str0m_update_count)
         })
         .await
         .flatten()

--- a/crates/core/src/engine/media_transport/test_support/mod.rs
+++ b/crates/core/src/engine/media_transport/test_support/mod.rs
@@ -142,6 +142,16 @@ impl MediaTransportTestApi<'_> {
         None
     }
 
+    pub async fn session_receiver_bwe_target(
+        self,
+        session_key: &TransportSessionKey,
+    ) -> Option<crate::Bitrate> {
+        self.transport
+            .worker_for_user(session_key)?
+            .debug_session_receiver_bwe_target(session_key)
+            .await
+    }
+
     pub async fn observe_audio_activity(self, transport_media_id: TransportMediaId, now: Instant) {
         self.observe_audio_activity_with_level(transport_media_id, -20, now)
             .await;

--- a/crates/core/src/engine/media_transport/types.rs
+++ b/crates/core/src/engine/media_transport/types.rs
@@ -614,6 +614,32 @@ impl ConsumerPacketGateUpdate {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceiverBweTargetUpdate {
+    session_key: TransportSessionKey,
+    target: Bitrate,
+}
+
+impl ReceiverBweTargetUpdate {
+    #[must_use]
+    pub fn new(session_key: TransportSessionKey, target: Bitrate) -> Self {
+        Self {
+            session_key,
+            target,
+        }
+    }
+
+    #[must_use]
+    pub fn session_key(&self) -> &TransportSessionKey {
+        &self.session_key
+    }
+
+    #[must_use]
+    pub const fn target(&self) -> Bitrate {
+        self.target
+    }
+}
+
 /// Packet-facing layered operating point selected for one source route.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourcePacketOperatingPoint {

--- a/crates/core/src/engine/media_transport/workers.rs
+++ b/crates/core/src/engine/media_transport/workers.rs
@@ -21,8 +21,8 @@ use crate::engine::{
     media_transport::{
         ActiveSpeakerSource, ActiveSpeakerSourceDiagnostic, ConsumerPacketGateUpdate,
         MediaTransport, MediaTransportConfig, MediaTransportDeps, ReceiverBandwidthSnapshot,
-        SourcePolicySignal, SourcePolicyUpdateSubscription, TransportAdapterError,
-        TransportBitrateSnapshot, TransportConsumerRoute, TransportMediaId,
+        ReceiverBweTargetUpdate, SourcePolicySignal, SourcePolicyUpdateSubscription,
+        TransportAdapterError, TransportBitrateSnapshot, TransportConsumerRoute, TransportMediaId,
         TransportPlacementPressureSnapshot, TransportQualitySnapshot, TransportRelayRouteAction,
         TransportRelayRouteEffect, TransportSessionHealth, TransportSessionKey, TransportSourceKey,
         TransportWorkerPressureSnapshot,
@@ -216,6 +216,37 @@ impl MediaTransport {
                     &key.source,
                     batch.iter().filter_map(|index| updates.get(*index)),
                 )
+                .await
+                .unwrap_or_else(|error| vec![Err(error); update_count]);
+            for (index, result) in batch.into_iter().zip(batch_results) {
+                if let Some(stored_result) = results.get_mut(index) {
+                    *stored_result = result;
+                }
+            }
+        }
+        results
+    }
+
+    /// Applies receiver BWE targets in worker-local batches.
+    pub(super) async fn execute_receiver_bwe_target_batch(
+        &self,
+        updates: &[ReceiverBweTargetUpdate],
+    ) -> Vec<Result<(), TransportAdapterError>> {
+        let mut results = vec![Err(TransportAdapterError::TransportUnavailable); updates.len()];
+        let mut batches = BTreeMap::<usize, Vec<usize>>::new();
+        for (index, update) in updates.iter().enumerate() {
+            let Some(worker_index) = self.worker_index_for_user(update.session_key()) else {
+                continue;
+            };
+            batches.entry(worker_index).or_default().push(index);
+        }
+        for (worker_index, batch) in batches {
+            let Some(worker) = self.worker_for_index(worker_index) else {
+                continue;
+            };
+            let update_count = batch.len();
+            let batch_results = worker
+                .set_receiver_bwe_targets(batch.iter().filter_map(|index| updates.get(*index)))
                 .await
                 .unwrap_or_else(|error| vec![Err(error); update_count]);
             for (index, result) in batch.into_iter().zip(batch_results) {

--- a/crates/core/src/engine/room/source_policy/action.rs
+++ b/crates/core/src/engine/room/source_policy/action.rs
@@ -5,14 +5,56 @@
 //! policy executor.
 
 use super::super::media_graph::ConsumerRouteTransportRef;
-use crate::engine::{
-    UserId,
-    media_transport::SourcePacketGate,
-    source_model::{
-        ConsumerSourceSelection, PolicyPauseReason, PublishedSourceId,
-        ReceiverVideoBudgetDiagnostics, SourceSelector,
+use crate::{
+    Bitrate,
+    engine::{
+        ConnectionId, UserId,
+        media_transport::SourcePacketGate,
+        source_model::{
+            ConsumerSourceSelection, PolicyPauseReason, PublishedSourceId,
+            ReceiverVideoBudgetDiagnostics, SourceSelector,
+        },
     },
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::engine::room) struct ReceiverBweTargetPlan {
+    user_id: UserId,
+    connection_id: ConnectionId,
+    target: Bitrate,
+}
+
+impl ReceiverBweTargetPlan {
+    pub fn new(user_id: UserId, connection_id: ConnectionId, target: Bitrate) -> Self {
+        Self {
+            user_id,
+            connection_id,
+            target,
+        }
+    }
+
+    pub fn user_id(&self) -> &UserId {
+        &self.user_id
+    }
+
+    pub const fn connection_id(&self) -> ConnectionId {
+        self.connection_id
+    }
+
+    pub const fn target(&self) -> Bitrate {
+        self.target
+    }
+
+    pub const fn set_target(&mut self, target: Bitrate) {
+        self.target = target;
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::engine::room) struct ReceiverVideoPolicyPlan {
+    pub consumer_packet_updates: Vec<ConsumerPacketSelectionUpdate>,
+    pub receiver_bwe_targets: Vec<ReceiverBweTargetPlan>,
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(in crate::engine::room) struct BudgetSolverOutcomes {

--- a/crates/core/src/engine/room/source_policy/effects.rs
+++ b/crates/core/src/engine/room/source_policy/effects.rs
@@ -10,12 +10,13 @@ use tracing::{debug, warn};
 
 use super::{
     super::{Room, state::RoomState},
-    ConsumerPacketSelectionUpdate, FeaturedUserUpdate, rank_active_speaker_sources,
+    ConsumerPacketSelectionUpdate, FeaturedUserUpdate, ReceiverBweTargetPlan,
+    rank_active_speaker_sources,
 };
 use crate::engine::{
     media_transport::{
         ActiveSpeakerSource, ConsumerActivity, ConsumerPacketGateUpdate, MediaTransport,
-        ReceiverBandwidthSnapshot,
+        ReceiverBandwidthSnapshot, ReceiverBweTargetUpdate,
     },
     metrics::{self, BudgetSolverOutcome},
 };
@@ -33,6 +34,7 @@ mod test_support;
 #[derive(Debug, Default)]
 pub(in crate::engine::room) struct SourcePolicyEffectPlan {
     consumer_packet_updates: Vec<ConsumerPacketSelectionUpdate>,
+    receiver_bwe_targets: Vec<ReceiverBweTargetPlan>,
     featured_users: Vec<FeaturedUserUpdate>,
 }
 
@@ -49,19 +51,23 @@ impl SourcePolicyEffectPlan {
         let ranked_active_speaker_sources = rank_active_speaker_sources(active_speaker_sources);
         let mut consumer_packet_updates =
             state.audio_route_activity_updates(&ranked_active_speaker_sources);
-        consumer_packet_updates.extend(state.consumer_packet_selection_updates(
+        let video_plan = state.receiver_video_policy_plan(
             &ranked_active_speaker_sources,
             receiver_bandwidth_snapshot,
-        ));
+        );
+        consumer_packet_updates.extend(video_plan.consumer_packet_updates);
         let featured_users = state.featured_user_updates(&ranked_active_speaker_sources);
         Self {
             consumer_packet_updates,
+            receiver_bwe_targets: video_plan.receiver_bwe_targets,
             featured_users,
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.consumer_packet_updates.is_empty() && self.featured_users.is_empty()
+        self.consumer_packet_updates.is_empty()
+            && self.receiver_bwe_targets.is_empty()
+            && self.featured_users.is_empty()
     }
 
     /// Applies transport-visible gates before committing selector state.
@@ -71,6 +77,7 @@ impl SourcePolicyEffectPlan {
     /// `RoomState`; rejected or stale updates are left for the next policy
     /// refresh.
     pub async fn execute(self, room: &Room, media_port: &MediaTransport) {
+        Self::apply_receiver_bwe_targets(room, media_port, &self.receiver_bwe_targets).await;
         let applied_consumer_packet_updates =
             Self::apply_consumer_packet_updates(room, media_port, self.consumer_packet_updates)
                 .await;
@@ -86,6 +93,23 @@ impl SourcePolicyEffectPlan {
         if let Some(info_fanout) = info_fanout {
             info_fanout.emit();
         }
+    }
+
+    async fn apply_receiver_bwe_targets(
+        room: &Room,
+        media_port: &MediaTransport,
+        targets: &[ReceiverBweTargetPlan],
+    ) {
+        let updates = targets
+            .iter()
+            .map(|target| {
+                ReceiverBweTargetUpdate::new(
+                    room.transport_user_key(target.user_id(), target.connection_id()),
+                    target.target(),
+                )
+            })
+            .collect::<Vec<_>>();
+        media_port.set_receiver_bwe_targets(&updates).await;
     }
 
     fn record_source_selection_metrics(room: &Room, updates: &[ConsumerPacketSelectionUpdate]) {

--- a/crates/core/src/engine/room/source_policy/mod.rs
+++ b/crates/core/src/engine/room/source_policy/mod.rs
@@ -17,7 +17,7 @@ mod sync;
 mod video;
 
 pub(in crate::engine::room) use self::{
-    action::{ConsumerPacketSelectionUpdate, FeaturedUserUpdate},
+    action::{ConsumerPacketSelectionUpdate, FeaturedUserUpdate, ReceiverBweTargetPlan},
     active_speaker::rank_active_speaker_sources,
     effects::SourcePolicyEffectPlan,
     sync::SourcePolicyEvent,

--- a/crates/core/src/engine/room/source_policy/video/budget.rs
+++ b/crates/core/src/engine/room/source_policy/video/budget.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeSet;
 use super::{
     super::{
         VideoAdmissionRank,
-        action::{BudgetSolverOutcomes, ConsumerPacketSelectionUpdate},
+        action::{BudgetSolverOutcomes, ConsumerPacketSelectionUpdate, ReceiverVideoPolicyPlan},
     },
     input::{ReceiverVideoPolicyInput, ReceiverVideoRouteInput, SelectableRouteEncodings},
     projection::source_packet_gate_for_selector,
@@ -187,49 +187,58 @@ impl super::super::super::state::RoomState {
     /// change room authority on their own. This method combines them with
     /// committed source descriptors, subscription state and active-speaker
     /// layout state to build staged updates for the effect executor.
-    pub fn consumer_packet_selection_updates(
+    pub fn receiver_video_policy_plan(
         &self,
         ranked_active_speaker_sources: &[ActiveSpeakerSource],
         receiver_bandwidth_snapshot: &ReceiverBandwidthSnapshot,
-    ) -> Vec<ConsumerPacketSelectionUpdate> {
+    ) -> ReceiverVideoPolicyPlan {
         let input = ReceiverVideoPolicyInput::from_state(
             self,
             ranked_active_speaker_sources,
             receiver_bandwidth_snapshot,
         );
-        receiver_video_selection_updates(&input)
+        receiver_video_selection_plan(input)
     }
 }
 
-fn receiver_video_selection_updates(
-    input: &ReceiverVideoPolicyInput<'_>,
-) -> Vec<ConsumerPacketSelectionUpdate> {
-    let routes = input.routes.as_slice();
+fn receiver_video_selection_plan(input: ReceiverVideoPolicyInput<'_>) -> ReceiverVideoPolicyPlan {
+    let ReceiverVideoPolicyInput {
+        routes,
+        mut receiver_bwe_targets,
+        max_video_downloads_per_receiver,
+    } = input;
     let mut selection_updates = Vec::with_capacity(routes.len());
-    let mut remaining_routes = routes;
+    let mut remaining_routes = routes.as_slice();
     while let Some((first_route, rest)) = remaining_routes.split_first() {
         let consumer_user_id = first_route.consumer_user_id();
         let group_len = 1 + rest
             .iter()
             .take_while(|route| route.consumer_user_id() == consumer_user_id)
             .count();
-        let Some((receiver_routes, next_routes)) = remaining_routes.split_at_checked(group_len)
-        else {
-            break;
-        };
-        selection_updates.extend(plan_receiver_routes(
-            receiver_routes,
-            input.max_video_downloads_per_receiver,
-        ));
+        let (receiver_routes, next_routes) = remaining_routes.split_at(group_len);
+        let receiver_plan = plan_receiver_routes(receiver_routes, max_video_downloads_per_receiver);
+        if let Some(target) = receiver_bwe_targets.get_mut(consumer_user_id) {
+            target.set_target(receiver_plan.receiver_bwe_target);
+        }
+        selection_updates.extend(receiver_plan.selection_updates);
         remaining_routes = next_routes;
     }
-    selection_updates
+    ReceiverVideoPolicyPlan {
+        consumer_packet_updates: selection_updates,
+        receiver_bwe_targets: receiver_bwe_targets.into_values().collect(),
+    }
+}
+
+#[derive(Debug)]
+struct PlannedReceiverRoutes {
+    selection_updates: Vec<ConsumerPacketSelectionUpdate>,
+    receiver_bwe_target: Bitrate,
 }
 
 fn plan_receiver_routes<'a>(
     routes: &'a [ReceiverVideoRouteInput<'a>],
     max_video_downloads_per_receiver: usize,
-) -> Vec<ConsumerPacketSelectionUpdate> {
+) -> PlannedReceiverRoutes {
     let receiver_bandwidth = routes.iter().find_map(|route| route.receiver_bandwidth);
     let mut planned_routes = routes
         .iter()
@@ -240,10 +249,15 @@ fn plan_receiver_routes<'a>(
         apply_receiver_overload_policy(&mut planned_routes, receiver_bandwidth);
     }
     let budget = receiver_budget_diagnostics(&planned_routes, receiver_bandwidth);
-    planned_routes
+    let receiver_bwe_target = budget.selected_video_bitrate();
+    let selection_updates = planned_routes
         .into_iter()
         .filter_map(|route| planned_route_update(route, budget))
-        .collect()
+        .collect();
+    PlannedReceiverRoutes {
+        selection_updates,
+        receiver_bwe_target,
+    }
 }
 
 fn planned_receiver_route<'a>(
@@ -785,7 +799,7 @@ mod tests {
         media_transport::{SourcePacketGate, TransportMediaId},
         room::{
             media_graph::ConsumerRouteTransportRef,
-            source_policy::video::layout::ReceiverVideoLayoutIntent,
+            source_policy::{ReceiverBweTargetPlan, video::layout::ReceiverVideoLayoutIntent},
         },
         source_model::{
             PublishedSourceDescriptor, PublishedSourceDescriptorParts, PublishedSourceId,
@@ -808,6 +822,28 @@ mod tests {
             primary_ssrc: None,
             repair_ssrc: None,
             max_bitrate: None,
+            resolution_scale: None,
+            max_framerate: None,
+            policy_role: Some(role),
+            max_temporal_layer_id: None,
+            negotiated_format: None,
+        })
+    }
+
+    fn bitrate_encoding(
+        source_id: PublishedSourceId,
+        encoding_id: SourceEncodingId,
+        rid: &str,
+        max_bitrate: Bitrate,
+        role: UploadLayerPolicyRole,
+    ) -> SourceEncodingDescriptor {
+        SourceEncodingDescriptor::new(SourceEncodingDescriptorParts {
+            encoding_id,
+            source_id,
+            rid: Some(Rid::new(rid)),
+            primary_ssrc: None,
+            repair_ssrc: None,
+            max_bitrate: Some(max_bitrate),
             resolution_scale: None,
             max_framerate: None,
             policy_role: Some(role),
@@ -930,7 +966,8 @@ mod tests {
         selection.set_adaptation_observations(1, 0);
         let route = route(&source, selection);
 
-        let updates = plan_receiver_routes(&[route], usize::MAX);
+        let plan = plan_receiver_routes(&[route], usize::MAX);
+        let updates = plan.selection_updates;
 
         assert_eq!(updates.len(), 1);
         let update = updates
@@ -980,7 +1017,8 @@ mod tests {
             ),
         ];
 
-        let updates = plan_receiver_routes(&routes, 1);
+        let plan = plan_receiver_routes(&routes, 1);
+        let updates = plan.selection_updates;
         let hidden_update = updates
             .iter()
             .find(|update| update.source_id == hidden_source_id)
@@ -993,6 +1031,127 @@ mod tests {
         assert!(hidden_update.route_activity_update);
         assert!(hidden_update.outcomes.is_paused());
         assert_eq!(hidden_update.budget.active_video_route_count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn two_party_receiver_bwe_target_uses_high_layer() -> Result<(), SourceModelError> {
+        let source_id = PublishedSourceId::from_raw(7);
+        let low_encoding_id = SourceEncodingId::from_raw(1);
+        let high_encoding_id = SourceEncodingId::from_raw(2);
+        let source = scalable_source(vec![
+            bitrate_encoding(
+                source_id,
+                low_encoding_id,
+                "lo",
+                Bitrate::from_kbps(150),
+                UploadLayerPolicyRole::Thumbnail,
+            ),
+            bitrate_encoding(
+                source_id,
+                high_encoding_id,
+                "hi",
+                Bitrate::from_kbps(900),
+                UploadLayerPolicyRole::Featured,
+            ),
+        ])?;
+        let mut route = route(&source, ConsumerSourceSelection::open(true));
+        route.user_count = 2;
+        route.receiver_bandwidth = None;
+
+        let plan = plan_receiver_routes(&[route], usize::MAX);
+
+        assert_eq!(plan.receiver_bwe_target, Bitrate::from_kbps(900));
+        Ok(())
+    }
+
+    #[test]
+    fn multiparty_receiver_bwe_target_uses_thumbnail_layer() -> Result<(), SourceModelError> {
+        let source_id = PublishedSourceId::from_raw(7);
+        let low_encoding_id = SourceEncodingId::from_raw(1);
+        let high_encoding_id = SourceEncodingId::from_raw(2);
+        let source = scalable_source(vec![
+            bitrate_encoding(
+                source_id,
+                low_encoding_id,
+                "lo",
+                Bitrate::from_kbps(150),
+                UploadLayerPolicyRole::Thumbnail,
+            ),
+            bitrate_encoding(
+                source_id,
+                high_encoding_id,
+                "hi",
+                Bitrate::from_kbps(900),
+                UploadLayerPolicyRole::Featured,
+            ),
+        ])?;
+        let mut route = route(&source, ConsumerSourceSelection::open(true));
+        route.receiver_bandwidth = None;
+
+        let plan = plan_receiver_routes(&[route], usize::MAX);
+
+        assert_eq!(plan.receiver_bwe_target, Bitrate::from_kbps(150));
+        Ok(())
+    }
+
+    #[test]
+    fn receiver_without_video_routes_gets_zero_bwe_target() {
+        let input = ReceiverVideoPolicyInput {
+            routes: Vec::new(),
+            receiver_bwe_targets: [(
+                UserId::Integer(42),
+                ReceiverBweTargetPlan::new(
+                    UserId::Integer(42),
+                    ConnectionId::from_raw(10),
+                    Bitrate::zero(),
+                ),
+            )]
+            .into(),
+            max_video_downloads_per_receiver: usize::MAX,
+        };
+
+        let plan = receiver_video_selection_plan(input);
+
+        assert_eq!(plan.receiver_bwe_targets.len(), 1);
+        let target = plan
+            .receiver_bwe_targets
+            .first()
+            .expect("plan should keep the seeded receiver BWE target");
+        assert_eq!(target.target(), Bitrate::zero());
+    }
+
+    #[test]
+    fn protected_over_budget_route_keeps_selected_bwe_target() -> Result<(), SourceModelError> {
+        let source_id = PublishedSourceId::from_raw(7);
+        let low_encoding_id = SourceEncodingId::from_raw(1);
+        let high_encoding_id = SourceEncodingId::from_raw(2);
+        let source = scalable_source(vec![
+            bitrate_encoding(
+                source_id,
+                low_encoding_id,
+                "lo",
+                Bitrate::from_kbps(150),
+                UploadLayerPolicyRole::Thumbnail,
+            ),
+            bitrate_encoding(
+                source_id,
+                high_encoding_id,
+                "hi",
+                Bitrate::from_kbps(900),
+                UploadLayerPolicyRole::Featured,
+            ),
+        ])?;
+        let mut route = route_with_layout(
+            &source,
+            ConsumerSourceSelection::open(true),
+            SourceRoomPolicySelector::Pinned,
+        );
+        route.receiver_bandwidth = Some(Bitrate::from_kbps(100));
+
+        let plan = plan_receiver_routes(&[route], usize::MAX);
+
+        assert_eq!(plan.receiver_bwe_target, Bitrate::from_kbps(900));
         Ok(())
     }
 }

--- a/crates/core/src/engine/room/source_policy/video/input.rs
+++ b/crates/core/src/engine/room/source_policy/video/input.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use o_sfu_router::MediaKind;
 
 use super::{
-    super::super::{media_graph::ConsumerRouteTransportRef, state::RoomState},
+    super::{super::media_graph::ConsumerRouteTransportRef, action::ReceiverBweTargetPlan},
     layout::{ReceiverVideoLayoutIntent, featured_source_user_ids_for_active_speakers},
 };
 use crate::{
@@ -16,6 +16,7 @@ use crate::{
     engine::{
         UserId,
         media_transport::{ActiveSpeakerSource, ReceiverBandwidthSnapshot, TransportMediaId},
+        room::state::RoomState,
         source_model::{
             ActiveSpeakerSourceRole, ConsumerSourceSelection, PublishedSourceDescriptor,
             PublishedSourceId, SourceAdaptationPolicy, SourceEncodingDescriptor,
@@ -26,6 +27,7 @@ use crate::{
 #[derive(Debug)]
 pub(in crate::engine::room) struct ReceiverVideoPolicyInput<'a> {
     pub routes: Vec<ReceiverVideoRouteInput<'a>>,
+    pub receiver_bwe_targets: BTreeMap<UserId, ReceiverBweTargetPlan>,
     pub max_video_downloads_per_receiver: usize,
 }
 
@@ -43,6 +45,16 @@ impl<'a> ReceiverVideoPolicyInput<'a> {
         let receiver_bandwidth_by_user = receiver_bandwidth_by_user(receiver_bandwidth_snapshot);
         let visible_scalable_route_counts =
             visible_scalable_route_counts_by_consumer(state, &featured_source_user_ids);
+        let receiver_bwe_targets = state
+            .transport_user_entries()
+            .into_iter()
+            .map(|(user_id, connection_id)| {
+                (
+                    user_id.clone(),
+                    ReceiverBweTargetPlan::new(user_id, connection_id, Bitrate::zero()),
+                )
+            })
+            .collect();
         let routes = state
             .source_policy_live_consumer_routes()
             .filter_map(|route| {
@@ -85,6 +97,7 @@ impl<'a> ReceiverVideoPolicyInput<'a> {
             .collect();
         Self {
             routes,
+            receiver_bwe_targets,
             max_video_downloads_per_receiver: state
                 .source_policy_media_limits()
                 .max_video_downloads_per_receiver(),

--- a/crates/core/src/engine/room/tests/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/tests/producer_tests/source_policy.rs
@@ -21,6 +21,13 @@ async fn two_party_camera_publish_selects_the_highest_consumer_layer() {
         "hi",
     )
     .await;
+    assert_receiver_bwe_target(
+        &room,
+        &adapter,
+        &UserId::Integer(2),
+        Bitrate::from_kbps(900),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -40,6 +47,32 @@ async fn multiparty_camera_publish_marks_thumbnail_routes_in_diagnostics() {
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn source_policy_resets_receiver_bwe_target_after_last_video_route_removal() {
+    let (room, adapter, _publisher_rx, _subscriber_rx) = setup_two_ready_users().await;
+    publish_simulcast_camera(&room, &UserId::Integer(1), &adapter).await;
+    assert_receiver_bwe_target(
+        &room,
+        &adapter,
+        &UserId::Integer(2),
+        Bitrate::from_kbps(900),
+    )
+    .await;
+
+    let publisher_connection_id = user_connection_id(&room, &UserId::Integer(1)).await;
+    assert_eq!(
+        room.user_operation(&UserId::Integer(1), publisher_connection_id, &adapter)
+            .unpublish(&stream_id_for_source(TestSourceKind::ScalableVideo))
+            .await,
+        UnpublishOutcome::Unpublished {
+            cleanup: crate::TransportEffectOutcome::Applied
+        }
+    );
+    room.sync_source_packet_selection_policy(&adapter).await;
+
+    assert_receiver_bwe_target(&room, &adapter, &UserId::Integer(2), Bitrate::zero()).await;
 }
 
 #[tokio::test]

--- a/crates/core/src/engine/room/tests/producer_tests/support.rs
+++ b/crates/core/src/engine/room/tests/producer_tests/support.rs
@@ -8,7 +8,7 @@ pub(super) use str0m::{Candidate, Rtc, change::SdpOffer};
 
 pub(super) use super::super::{api::NegotiatedPublish, fixtures::*};
 pub(super) use crate::{
-    RoomMediaLimits, RtcPortRange,
+    Bitrate, RoomMediaLimits, RtcPortRange,
     engine::{
         diagnostics::{
             DiagnosticsPolicyPauseReason, DiagnosticsRouteState, DiagnosticsSourceSelector,
@@ -193,6 +193,23 @@ pub(super) async fn active_destination_count_for_receiver(
             .count();
     }
     count
+}
+
+pub(super) async fn assert_receiver_bwe_target(
+    room: &Arc<Room>,
+    adapter: &MediaTransport,
+    receiver_user_id: &UserId,
+    expected_target: Bitrate,
+) {
+    let connection_id = user_connection_id(room, receiver_user_id).await;
+    let session_key = room.transport_user_key(receiver_user_id, connection_id);
+    assert_eq!(
+        adapter
+            .test_api()
+            .session_receiver_bwe_target(&session_key)
+            .await,
+        Some(expected_target)
+    );
 }
 
 pub(super) struct RealRtcRefreshScenario {


### PR DESCRIPTION
The RTC bootstrap was using the per-user outgoing bitrate cap as the str0m desired bitrate. That made every receiver advertise demand up to MAX_BITRATE_OUT even when room policy had selected a much smaller video set.

This change keeps MAX_BITRATE_OUT as the transport BWE ceiling and moves the desired bitrate to source policy. Each receiver now gets a BWE target derived from the selected video bitrate of its active routed sources. Receivers with no active selected video are reset to zero so stale demand does not survive route removal.

The RTC worker stores the last applied target and only updates str0m when the capped target changes. This keeps repeated policy refreshes cheap and avoids unnecessary probe resets.