### PR TITLE
[REF] core: unify room commit effect execution

### DIFF
--- a/crates/core/src/engine/room/effects/batch.rs
+++ b/crates/core/src/engine/room/effects/batch.rs
@@ -1,22 +1,7 @@
-//! shared post-lock room effect execution
-//!
-//! room transitions keep the `RoomState` lock only long enough to validate
-//! intent, mutate authoritative state and capture the facts needed by external
-//! systems
-//!
-//! [`RoomEffectBatch`] is the cold-path boundary that consumes those captured
-//! facts after unlock
-//! it gives membership, publish, unpublish and subscription
-//! workflows one ordering point for metrics, transport cleanup, relay updates,
-//! source policy events, lifecycle fan-out, diagnostics and outbound room
-//! requests
-//!
-//! callers should build a batch only from committed state results that have already
-//! committed
-//! the executor must not rediscover ownership from live room state
-//! after async work starts, because a replacement session may have claimed the
-//! same user-facing identity by then
+//! shared post-lock room commit execution
 
+use o_sfu_router::MediaKind;
+use o_sfu_telemetry::schema::event as telemetry_event;
 use tracing::warn;
 
 use crate::{
@@ -25,35 +10,32 @@ use crate::{
         ConnectionId, UserId,
         diagnostics::DiagnosticsEventData,
         media_transport::{
-            MediaTransport, TransportRelayRouteAction, TransportRelayRouteEffect,
-            TransportSourceKey,
+            ConsumerActivity, MediaTransport, ProducerActivity, TransportMediaId,
+            TransportRelayRouteAction, TransportRelayRouteEffect, TransportSourceKey,
         },
         room::{
-            Room, RoomEventRequest, RoomMediaCounts, SourcePolicyEvent, UserOutbound,
+            RemoteTrackBootstrap, Room, RoomMediaCounts, SourcePolicyEvent, TrackBindingUpdate,
+            UserOutbound,
             cleanup::TransportCleanupOperation,
-            media_graph::{RelayRouteEffect, TransportMediaRemoval},
+            media_graph::{
+                ConsumerBootstrapOrigin, ConsumerRouteTransportRef, ConsumerRouteUpdate,
+                PendingConsumerBootstrapTarget, PlannedConsumerBootstrap,
+                PreparedConsumerBootstrap, RelayRouteEffect, TransportMediaRemoval,
+            },
             outbound::OutboundSender,
             state::LifecycleEffects,
         },
+        source_model::UserStreamId,
     },
 };
 
 #[derive(Debug, Clone, Copy)]
 pub struct RoomEffectContext<'a> {
-    /// transport handle available for post-lock observations and policy work
-    ///
-    /// state-only tests may provide this while still disabling cleanup mutation
-    /// so source policy can observe transport state without removing media
     media: Option<&'a MediaTransport>,
-    /// transport handle available for adapter mutation after room ownership ends
-    ///
-    /// relay updates, media removals and transport user closes use this handle
-    /// only when the caller authorizes cleanup side effects
     cleanup: Option<&'a MediaTransport>,
 }
 
 impl<'a> RoomEffectContext<'a> {
-    /// build the production context for normal runtime room work
     pub const fn runtime(media_transport: &'a MediaTransport) -> Self {
         Self {
             media: Some(media_transport),
@@ -61,7 +43,6 @@ impl<'a> RoomEffectContext<'a> {
         }
     }
 
-    /// build a context that preserves room state effects without mutating transport cleanup state
     #[cfg(any(test, feature = "testing-transport"))]
     pub const fn state_only(media_transport: Option<&'a MediaTransport>) -> Self {
         Self {
@@ -71,12 +52,8 @@ impl<'a> RoomEffectContext<'a> {
     }
 }
 
-/// media gauge delta captured while room state was authoritative
-///
-/// callers pass snapshots instead of recomputing counts after unlock, so metric
-/// updates describe the committed transition that produced the batch
 #[derive(Debug, Clone, Copy)]
-pub struct MediaCountDelta {
+struct MediaCountDelta {
     before: RoomMediaCounts,
     after: RoomMediaCounts,
 }
@@ -99,28 +76,19 @@ impl MediaCountDelta {
     }
 }
 
-/// ordered side effects for one committed room transition
-///
-/// this type is private to `engine::room` because it encodes room-local
-/// lifecycle rules, transport cleanup policy and diagnostics ordering
-/// each builder method records a fact that was already decided by room state or
-/// by a transport boundary that just completed
-///
-/// execution is cold-path room work
-/// the batch may allocate and move effect vectors by value, but it must not be
-/// called from packet forwarding paths
 #[derive(Debug, Default)]
-pub struct RoomEffectBatch {
-    /// facts captured while room state was authoritative
-    mutation: CommittedRoomMutation,
-    /// relay route mutations derived from room topology before unlock
+pub struct RoomCommit {
+    users: Option<UserCountDelta>,
+    media: Vec<MediaCountDelta>,
     relays: Vec<RelayRouteEffect>,
-    /// detached media ids that cleanup.rs may retry if the adapter is unavailable
-    removals: Vec<TransportMediaRemoval>,
-    /// detached transport users that no longer have an owning room session
-    closes: Vec<TransportUserCleanup>,
-    /// best-effort close requests and room fan-out captured by state
+    cleanup: RoomCleanup,
+    producers: Vec<ProducerActivityEffect>,
+    source_policy: Option<SourcePolicyEvent>,
     lifecycle: Vec<LifecycleEffects>,
+    routes: Vec<ConsumerRouteActivity>,
+    bootstraps: Vec<ConsumerBootstrapLease>,
+    track_bindings: Vec<TrackBindingFanout>,
+    diagnostics: Vec<DiagnosticsEffect>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -129,44 +97,41 @@ struct UserCountDelta {
     after: usize,
 }
 
-/// committed room-state facts consumed by the post-lock executor
+#[derive(Debug)]
+struct ConsumerRouteActivity {
+    route: ConsumerRouteTransportRef,
+    stream: UserStreamId,
+    kind: MediaKind,
+    active: bool,
+    diagnostics: DiagnosticsEventData,
+}
+
+#[derive(Debug)]
+struct ConsumerBootstrapLease {
+    bootstrap: PlannedConsumerBootstrap,
+    origin: ConsumerBootstrapOrigin,
+}
+
 #[derive(Debug, Default)]
-struct CommittedRoomMutation {
-    /// active-user gauge delta from a committed membership transition
-    user_count_delta: Option<UserCountDelta>,
-    /// media gauge deltas from committed publish, unpublish or subscribe work
-    media_deltas: Vec<MediaCountDelta>,
-    /// source policy event requested after committed room work
-    source_policy: Option<SourcePolicyEvent>,
-    /// diagnostics store mutations that must preserve caller order
-    diagnostics: Vec<DiagnosticsEffect>,
-    /// room event requests enqueued only after state and transport effects run
-    outbound: Vec<OutboundRequestEffect>,
+struct RoomCleanup {
+    before_close: Vec<TransportCleanupOperation>,
+    close_users: Vec<TransportCleanupOperation>,
 }
 
-/// detached transport user that should be closed after room state moves on
-///
-/// the identity is captured before async cleanup starts, so replacement joins
-/// cannot make cleanup target the new transport user by accident
-#[derive(Debug, Clone)]
-pub struct TransportUserCleanup {
-    user_id: UserId,
-    connection_id: ConnectionId,
+#[derive(Debug)]
+struct ProducerActivityEffect {
+    source: TransportSourceKey,
+    active: bool,
+    stream: UserStreamId,
+    diagnostics: DiagnosticsEventData,
 }
 
-impl TransportUserCleanup {
-    pub fn new(user_id: UserId, connection_id: ConnectionId) -> Self {
-        Self {
-            user_id,
-            connection_id,
-        }
-    }
+#[derive(Debug)]
+struct TrackBindingFanout {
+    recipients: Vec<OutboundSender>,
+    update: TrackBindingUpdate,
 }
 
-/// diagnostics mutations captured as ordered effects
-///
-/// register, record and forget operations stay in the batch so membership
-/// finalization cannot drift into a different diagnostics order per path
 #[derive(Debug)]
 enum DiagnosticsEffect {
     RegisterUser(UserId),
@@ -174,69 +139,41 @@ enum DiagnosticsEffect {
     ForgetUser(UserId),
 }
 
-/// outbound request emitted after the room transition and transport work finish
-///
-/// this keeps request enqueueing behind the same post-lock ordering as the rest
-/// of the transition, while send failure remains best-effort like room fan-out
-#[derive(Debug)]
-struct OutboundRequestEffect {
-    sender: OutboundSender,
-    request: RoomEventRequest,
-}
-
-/// result surface for follow-up decisions after batch execution
-///
-/// cleanup reports only retry-backed media removal outcome
-/// relay success stays separate because consumer bootstrap must release pending
-/// state when relay setup fails before the consumer can be created
 #[derive(Debug, Clone, Copy)]
-pub struct RoomEffectExecution {
+pub struct RoomCommitExecution {
     cleanup: TransportEffectOutcome,
-    relays_applied: bool,
+    producer_activity: TransportEffectOutcome,
 }
 
-impl RoomEffectExecution {
+impl RoomCommitExecution {
     pub const fn cleanup(self) -> TransportEffectOutcome {
         self.cleanup
     }
 
-    pub const fn relay_effects_applied(self) -> bool {
-        self.relays_applied
+    pub const fn producer_activity(self) -> TransportEffectOutcome {
+        self.producer_activity
     }
 }
 
-impl RoomEffectBatch {
-    /// start an empty batch for one committed transition
+impl RoomCommit {
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// record the active-user gauge delta that belongs to this transition
     pub fn with_user_count_delta(mut self, before: usize, after: usize) -> Self {
-        self.mutation.user_count_delta = Some(UserCountDelta { before, after });
+        self.users = Some(UserCountDelta { before, after });
         self
     }
 
-    /// record a media-count gauge delta from state snapshots
-    pub fn with_media_count_delta(self, before: RoomMediaCounts, after: RoomMediaCounts) -> Self {
-        self.with_media_count_delta_value(MediaCountDelta::new(before, after))
-    }
-
-    /// record a media-count delta only when the caller planned one
-    pub fn with_optional_media_count_delta(mut self, delta: Option<MediaCountDelta>) -> Self {
-        if let Some(delta) = delta {
-            self.mutation.media_deltas.push(delta);
-        }
+    pub fn with_media_count_delta(
+        mut self,
+        before: RoomMediaCounts,
+        after: RoomMediaCounts,
+    ) -> Self {
+        self.media.push(MediaCountDelta::new(before, after));
         self
     }
 
-    /// record a prebuilt media-count delta
-    pub fn with_media_count_delta_value(mut self, delta: MediaCountDelta) -> Self {
-        self.mutation.media_deltas.push(delta);
-        self
-    }
-
-    /// queue relay route effects captured from room topology
     pub fn with_relay_effects(
         mut self,
         effects: impl IntoIterator<Item = RelayRouteEffect>,
@@ -245,112 +182,168 @@ impl RoomEffectBatch {
         self
     }
 
-    /// queue detached media removals under cleanup retry ownership
     pub fn with_transport_removals(
         mut self,
+        room: &Room,
         removals: impl IntoIterator<Item = TransportMediaRemoval>,
     ) -> Self {
-        self.removals.extend(removals);
+        self.cleanup
+            .before_close
+            .extend(removals.into_iter().map(|removal| {
+                let connection_id = removal.connection();
+                TransportCleanupOperation::RemoveMedia {
+                    session_key: room.transport_user_key(removal.user(), connection_id),
+                    connection_id,
+                    transport_media_id: removal.transport_media(),
+                }
+            }));
         self
     }
 
-    /// queue a transport user close after room state released ownership
-    pub fn with_transport_user_close(mut self, cleanup: TransportUserCleanup) -> Self {
-        self.closes.push(cleanup);
+    pub fn with_transport_user_close(
+        mut self,
+        room: &Room,
+        user_id: &UserId,
+        connection_id: ConnectionId,
+    ) -> Self {
+        self.cleanup
+            .close_users
+            .push(TransportCleanupOperation::CloseUser {
+                session_key: room.transport_user_key(user_id, connection_id),
+                connection_id,
+            });
         self
     }
 
-    /// record the source-policy consequence of the committed transition
+    pub fn with_producer_activity(
+        mut self,
+        source: TransportSourceKey,
+        active: bool,
+        stream: UserStreamId,
+        diagnostics: DiagnosticsEventData,
+    ) -> Self {
+        self.producers.push(ProducerActivityEffect {
+            source,
+            active,
+            stream,
+            diagnostics,
+        });
+        self
+    }
+
+    pub fn with_track_binding_update(
+        mut self,
+        recipients: Vec<OutboundSender>,
+        update: TrackBindingUpdate,
+    ) -> Self {
+        self.track_bindings
+            .push(TrackBindingFanout { recipients, update });
+        self
+    }
+
     pub fn with_source_policy_event(mut self, event: SourcePolicyEvent) -> Self {
-        self.mutation.source_policy = Some(event);
+        self.source_policy = Some(event);
         self
     }
 
-    /// queue lifecycle notifications captured by room state
     pub fn with_lifecycle_effects(mut self, effects: LifecycleEffects) -> Self {
         self.lifecycle.push(effects);
         self
     }
 
-    /// register a user in diagnostics after the join transition commits
+    pub fn with_route_updates(
+        mut self,
+        room: &Room,
+        user_id: &UserId,
+        connection_id: ConnectionId,
+        updates: Vec<ConsumerRouteUpdate>,
+    ) -> Self {
+        let media_worker_id = room
+            .transport_user_key(user_id, connection_id)
+            .media_worker_id();
+        self.routes.extend(updates.into_iter().map(|update| {
+            let ConsumerRouteUpdate {
+                route,
+                stream,
+                kind,
+                active,
+            } = update;
+            let diagnostics = DiagnosticsEventData::for_user(
+                room.uuid(),
+                user_id,
+                telemetry_event::SUBSCRIPTION_ACTIVITY_CHANGED,
+            )
+            .with_connection_id(connection_id.as_u64())
+            .with_media_worker_id(media_worker_id.as_usize())
+            .with_transport_media_id(route.consumer_media().as_u64())
+            .insert_field("active", active)
+            .insert_field(
+                "producer_user_id",
+                serde_json::to_value(route.source_user_id()).unwrap_or(serde_json::Value::Null),
+            )
+            .insert_field("source_transport_media_id", route.source_media().as_u64())
+            .insert_field("stream_id", stream.to_string());
+            ConsumerRouteActivity {
+                route,
+                stream,
+                kind,
+                active,
+                diagnostics,
+            }
+        }));
+        self
+    }
+
+    pub fn with_bootstraps(
+        mut self,
+        bootstraps: Vec<PlannedConsumerBootstrap>,
+        origin: ConsumerBootstrapOrigin,
+    ) -> Self {
+        self.bootstraps.extend(
+            bootstraps
+                .into_iter()
+                .map(|bootstrap| ConsumerBootstrapLease { bootstrap, origin }),
+        );
+        self
+    }
+
     pub fn register_diagnostics_user(mut self, user_id: UserId) -> Self {
-        self.mutation
-            .diagnostics
+        self.diagnostics
             .push(DiagnosticsEffect::RegisterUser(user_id));
         self
     }
 
-    /// record a diagnostics event in the caller-selected position
     pub fn record_diagnostics(mut self, diagnostics: DiagnosticsEventData) -> Self {
-        self.mutation
-            .diagnostics
+        self.diagnostics
             .push(DiagnosticsEffect::Record(diagnostics));
         self
     }
 
-    /// forget a user in diagnostics after the room session is gone
     pub fn forget_diagnostics_user(mut self, user_id: UserId) -> Self {
-        self.mutation
-            .diagnostics
+        self.diagnostics
             .push(DiagnosticsEffect::ForgetUser(user_id));
         self
     }
 
-    /// enqueue a room event request after transport-facing effects have run
-    pub fn send_outbound_request(
-        mut self,
-        sender: OutboundSender,
-        request: RoomEventRequest,
-    ) -> Self {
-        self.mutation
-            .outbound
-            .push(OutboundRequestEffect { sender, request });
-        self
-    }
-
-    /// execute one committed post-lock batch in the room-wide effect order
-    ///
-    /// the order is fixed so future room workflows do not interleave async
-    /// cleanup and outward notifications differently
-    ///
-    /// 1. record room gauges from state-owned snapshots
-    /// 2. apply relay route effects that were captured before unlock
-    /// 3. run retry-backed transport media cleanup
-    /// 4. close detached transport users
-    /// 5. handle the source-policy event from transport observations
-    /// 6. emit lifecycle fan-out and user close messages
-    /// 7. write diagnostics effects in captured order
-    /// 8. enqueue outbound room-event requests
-    ///
-    /// relay failures are reported through [`RoomEffectExecution`] because
-    /// bootstrap callers may still need to release pending consumer state
-    /// cleanup failures stay owned by cleanup.rs retry state and are surfaced
-    /// through the returned cleanup outcome
-    pub async fn execute(self, room: &Room, context: RoomEffectContext<'_>) -> RoomEffectExecution {
-        let Self {
-            mutation,
-            relays,
-            removals,
-            closes,
-            lifecycle,
-        } = self;
-        let CommittedRoomMutation {
-            user_count_delta,
-            media_deltas,
-            source_policy,
-            diagnostics,
-            outbound,
-        } = mutation;
-        Self::record_gauge_deltas(room, user_count_delta, &media_deltas);
-        let relays_applied = Self::execute_relay_effects(room, context, &relays).await;
-        let cleanup = Self::execute_transport_cleanup(room, context, &removals, &closes).await;
-        Self::execute_source_policy_event(room, context, source_policy).await;
-        Self::emit_lifecycle_effects(lifecycle);
-        Self::record_diagnostics_effects(room, diagnostics);
-        Self::send_outbound_requests(outbound);
-        RoomEffectExecution {
+    pub async fn execute(self, room: &Room, context: RoomEffectContext<'_>) -> RoomCommitExecution {
+        Self::record_gauge_deltas(room, self.users, &self.media);
+        if let Some(media_transport) = context.cleanup {
+            execute_relay_route_effects(room, media_transport, &self.relays).await;
+        }
+        let cleanup = self.cleanup.execute(room, context).await;
+        let producer_activity =
+            Self::execute_producer_activity(room, context, self.producers).await;
+        Self::execute_route_activity(room, context, self.routes).await;
+        Self::execute_bootstraps(room, context, self.bootstraps).await;
+        Self::emit_track_binding_updates(self.track_bindings);
+        if let Some(event) = self.source_policy {
+            room.handle_source_policy_event(event, context.media).await;
+        }
+        Self::emit_lifecycle_effects(self.lifecycle);
+        Self::record_diagnostics_effects(room, self.diagnostics);
+        RoomCommitExecution {
             cleanup,
-            relays_applied,
+            producer_activity,
         }
     }
 
@@ -369,62 +362,81 @@ impl RoomEffectBatch {
         }
     }
 
-    async fn execute_relay_effects(
+    async fn execute_route_activity(
         room: &Room,
         context: RoomEffectContext<'_>,
-        relays: &[RelayRouteEffect],
-    ) -> bool {
-        let Some(media_transport) = context.cleanup else {
-            return true;
-        };
-        execute_relay_route_effects(room, media_transport, relays).await
-    }
-
-    async fn execute_transport_cleanup(
-        room: &Room,
-        context: RoomEffectContext<'_>,
-        removals: &[TransportMediaRemoval],
-        closes: &[TransportUserCleanup],
-    ) -> TransportEffectOutcome {
-        let Some(media_transport) = context.cleanup else {
-            return TransportEffectOutcome::Applied;
-        };
-        let removals = removals
-            .iter()
-            .map(|removal| {
-                let connection_id = removal.connection();
-                TransportCleanupOperation::RemoveMedia {
-                    session_key: room.transport_user_key(removal.user(), connection_id),
-                    connection_id,
-                    transport_media_id: removal.transport_media(),
-                }
-            })
-            .collect::<Vec<_>>();
-        let cleanup = room
-            .execute_transport_cleanup_operations(media_transport, &removals)
-            .await;
-        if !closes.is_empty() {
-            let closes = closes
-                .iter()
-                .map(|cleanup| TransportCleanupOperation::CloseUser {
-                    session_key: room.transport_user_key(&cleanup.user_id, cleanup.connection_id),
-                    connection_id: cleanup.connection_id,
-                })
-                .collect::<Vec<_>>();
-            let _ = room
-                .execute_transport_cleanup_operations(media_transport, &closes)
-                .await;
-        }
-        cleanup
-    }
-
-    async fn execute_source_policy_event(
-        room: &Room,
-        context: RoomEffectContext<'_>,
-        source_policy: Option<SourcePolicyEvent>,
+        routes: Vec<ConsumerRouteActivity>,
     ) {
-        if let Some(event) = source_policy {
-            room.handle_source_policy_event(event, context.media).await;
+        let Some(media_transport) = context.cleanup else {
+            return;
+        };
+        for op in routes {
+            let route = &op.route;
+            let transport_route = room.transport_consumer_route(route);
+            if media_transport
+                .set_consumer_active(&transport_route, ConsumerActivity::from_active(op.active))
+                .await
+                .is_err()
+            {
+                warn!(
+                    ?route,
+                    stream_id = %op.stream,
+                    active = op.active,
+                    "media transport failed to update consumer route activity"
+                );
+            } else if op.active
+                && op.kind == MediaKind::Video
+                && media_transport
+                    .request_consumer_keyframe(&transport_route)
+                    .await
+                    .is_err()
+            {
+                warn!(
+                    ?route,
+                    stream_id = %op.stream,
+                    "media transport failed to request a consumer keyframe refresh"
+                );
+            }
+            room.diagnostics.record(op.diagnostics);
+        }
+    }
+
+    async fn execute_producer_activity(
+        room: &Room,
+        context: RoomEffectContext<'_>,
+        producers: Vec<ProducerActivityEffect>,
+    ) -> TransportEffectOutcome {
+        let mut outcome = TransportEffectOutcome::Applied;
+        for op in producers {
+            if let Some(media_transport) = context.media
+                && media_transport
+                    .set_producer_active(&op.source, ProducerActivity::from_active(op.active))
+                    .await
+                    .is_err()
+            {
+                outcome = TransportEffectOutcome::Failed;
+                warn!(
+                    source = ?op.source,
+                    stream_id = %op.stream,
+                    active = op.active,
+                    "media transport failed to update producer route activity"
+                );
+            }
+            room.diagnostics.record(op.diagnostics);
+        }
+        outcome
+    }
+
+    async fn execute_bootstraps(
+        room: &Room,
+        context: RoomEffectContext<'_>,
+        bootstraps: Vec<ConsumerBootstrapLease>,
+    ) {
+        let Some(media_transport) = context.cleanup else {
+            return;
+        };
+        for lease in bootstraps {
+            lease.execute(room, media_transport).await;
         }
     }
 
@@ -437,6 +449,14 @@ impl RoomEffectBatch {
             }
             for fanout in effects.fanouts {
                 fanout.emit();
+            }
+        }
+    }
+
+    fn emit_track_binding_updates(fanouts: Vec<TrackBindingFanout>) {
+        for fanout in fanouts {
+            for recipient in fanout.recipients {
+                let _ = recipient.send(UserOutbound::TrackBindingUpdate(fanout.update.clone()));
             }
         }
     }
@@ -456,19 +476,204 @@ impl RoomEffectBatch {
             }
         }
     }
+}
 
-    fn send_outbound_requests(outbound: Vec<OutboundRequestEffect>) {
-        for request in outbound {
-            let _ = request
-                .sender
-                .send(UserOutbound::Request(Box::new(request.request)));
+impl RoomCleanup {
+    async fn execute(self, room: &Room, context: RoomEffectContext<'_>) -> TransportEffectOutcome {
+        let Some(media_transport) = context.cleanup else {
+            return TransportEffectOutcome::Applied;
+        };
+        let before_close =
+            Self::execute_operations(room, media_transport, &self.before_close).await;
+        let close_users = Self::execute_operations(room, media_transport, &self.close_users).await;
+        if before_close == TransportEffectOutcome::Failed
+            || close_users == TransportEffectOutcome::Failed
+        {
+            TransportEffectOutcome::Failed
+        } else {
+            TransportEffectOutcome::Applied
         }
     }
+
+    async fn execute_operations(
+        room: &Room,
+        media_transport: &MediaTransport,
+        operations: &[TransportCleanupOperation],
+    ) -> TransportEffectOutcome {
+        if operations.is_empty() {
+            return TransportEffectOutcome::Applied;
+        }
+        room.execute_transport_cleanup_operations(media_transport, operations)
+            .await
+    }
+}
+
+impl ConsumerBootstrapLease {
+    async fn execute(self, room: &Room, media_transport: &MediaTransport) {
+        let (target, prepared, pending, relays) = self.bootstrap.into_parts();
+        let origin = self.origin;
+        if !execute_relay_route_effects(room, media_transport, &relays).await {
+            release_consumer_bootstrap(room, &target, media_transport).await;
+            return;
+        }
+        let activity = ConsumerActivity::from_active(pending.consumer_active());
+        let Some((consumer_media, mid)) = Self::declare_transport_media(
+            &target,
+            &prepared,
+            activity,
+            origin,
+            room,
+            media_transport,
+        )
+        .await
+        else {
+            return;
+        };
+        let (before, outbound, after) = {
+            let mut state = room.state.write().await;
+            let before = state.media_counts();
+            let outbound = state.commit_bootstrap(&target, pending, consumer_media, mid);
+            let after = state.media_counts();
+            drop(state);
+            (before, outbound, after)
+        };
+        Self::finish(
+            room,
+            media_transport,
+            &target,
+            origin,
+            consumer_media,
+            MediaCountDelta::new(before, after),
+            outbound,
+        )
+        .await;
+    }
+
+    async fn declare_transport_media(
+        target: &PendingConsumerBootstrapTarget,
+        prepared: &PreparedConsumerBootstrap,
+        activity: ConsumerActivity,
+        origin: ConsumerBootstrapOrigin,
+        room: &Room,
+        media_transport: &MediaTransport,
+    ) -> Option<(TransportMediaId, Option<String>)> {
+        let consumer_session =
+            room.transport_user_key(target.consumer_user_id(), target.consumer_connection_id());
+        let producer_session =
+            room.transport_user_key(target.producer_user_id(), target.producer_connection_id());
+        match media_transport
+            .consume_media(
+                &consumer_session,
+                target.media_kind(),
+                &producer_session,
+                target.transport_media_id(),
+                &prepared.rtp,
+                activity,
+            )
+            .await
+        {
+            Ok(consumer_media) => {
+                let mid = media_transport
+                    .transport_media_mid(&consumer_session, consumer_media)
+                    .await;
+                Some((consumer_media, mid))
+            }
+            Err(error) => {
+                release_consumer_bootstrap(room, target, media_transport).await;
+                warn!(
+                    consumer_user_id = ?target.consumer_user_id(),
+                    consumer_connection_id = ?target.consumer_connection_id(),
+                    producer_user_id = ?target.producer_user_id(),
+                    producer_connection_id = ?target.producer_connection_id(),
+                    source_transport_media_id = ?target.transport_media_id(),
+                    error = ?error,
+                    consumer_mid = prepared.rtp.mid(),
+                    ?origin,
+                    "media transport rejected consume media declaration"
+                );
+                None
+            }
+        }
+    }
+
+    async fn finish(
+        room: &Room,
+        media_transport: &MediaTransport,
+        target: &PendingConsumerBootstrapTarget,
+        origin: ConsumerBootstrapOrigin,
+        consumer_media: TransportMediaId,
+        delta: MediaCountDelta,
+        outbound: Option<(OutboundSender, RemoteTrackBootstrap)>,
+    ) {
+        let Some((sender, bootstrap)) = outbound else {
+            delta.record(room);
+            release_consumer_bootstrap(room, target, media_transport).await;
+            let cleanup = [TransportCleanupOperation::RemoveMedia {
+                session_key: room
+                    .transport_user_key(target.consumer_user_id(), target.consumer_connection_id()),
+                connection_id: target.consumer_connection_id(),
+                transport_media_id: consumer_media,
+            }];
+            room.execute_transport_cleanup_operations(media_transport, &cleanup)
+                .await;
+            return;
+        };
+        delta.record(room);
+        room.diagnostics.record(
+            DiagnosticsEventData::for_user(
+                room.uuid(),
+                target.consumer_user_id(),
+                telemetry_event::SUBSCRIBE_SUCCEEDED,
+            )
+            .with_connection_id(target.consumer_connection_id().as_u64())
+            .with_media_worker_id(
+                room.transport_user_key(target.consumer_user_id(), target.consumer_connection_id())
+                    .media_worker_id()
+                    .as_usize(),
+            )
+            .with_transport_media_id(consumer_media.as_u64())
+            .insert_field(
+                "producer_user_id",
+                serde_json::to_value(target.producer_user_id()).unwrap_or(serde_json::Value::Null),
+            )
+            .insert_field(
+                "source_transport_media_id",
+                target.transport_media_id().as_u64(),
+            )
+            .insert_field("stream_id", target.stream_id().to_string())
+            .insert_field("origin", origin.as_diagnostic_str()),
+        );
+        let _ = sender.send(UserOutbound::Request(Box::new(
+            bootstrap.into_room_event_request(),
+        )));
+    }
+}
+
+async fn release_consumer_bootstrap(
+    room: &Room,
+    target: &PendingConsumerBootstrapTarget,
+    media_transport: &MediaTransport,
+) {
+    let (before, after, relays) = {
+        let mut state = room.state.write().await;
+        let before = state.media_counts();
+        let relays = state.release_bootstrap(target);
+        let after = state.media_counts();
+        drop(state);
+        (before, after, relays)
+    };
+    MediaCountDelta::new(before, after).record(room);
+    execute_relay_route_effects(room, media_transport, &relays).await;
+    room.handle_source_policy_event(
+        SourcePolicyEvent::FanoutPressureChanged,
+        Some(media_transport),
+    )
+    .await;
 }
 
 async fn execute_relay_route_effects(
     room: &Room,
-    media_port: &MediaTransport,
+    media_transport: &MediaTransport,
     effects: &[RelayRouteEffect],
 ) -> bool {
     let mut applied = true;
@@ -480,7 +685,7 @@ async fn execute_relay_route_effects(
                 route: effect.route.clone(),
             }];
             if room
-                .execute_transport_cleanup_operations(media_port, &operation)
+                .execute_transport_cleanup_operations(media_transport, &operation)
                 .await
                 == TransportEffectOutcome::Failed
             {
@@ -496,8 +701,10 @@ async fn execute_relay_route_effects(
             target_media_worker_id: effect.route.target_worker,
             action: effect.action,
         };
-        let result = media_port.apply_relay_route_effect(&transport_effect).await;
-        if let Err(error) = result {
+        if let Err(error) = media_transport
+            .apply_relay_route_effect(&transport_effect)
+            .await
+        {
             applied = false;
             warn!(
                 ?effect,

--- a/crates/core/src/engine/room/effects/mod.rs
+++ b/crates/core/src/engine/room/effects/mod.rs
@@ -1,8 +1,4 @@
-//! Shared post-lock effect executor for room transitions.
-//!
-//! Transition modules own their choreography. This module keeps only the common
-//! batching primitive used to apply transport cleanup, relay changes,
-//! diagnostics and outbound sends after room-state locks have been released.
+//! Shared post-lock commit executor for room transitions.
 
 mod batch;
-pub(super) use batch::{MediaCountDelta, RoomEffectBatch, RoomEffectContext, TransportUserCleanup};
+pub(super) use batch::{RoomCommit, RoomEffectContext};

--- a/crates/core/src/engine/room/media_graph/mod.rs
+++ b/crates/core/src/engine/room/media_graph/mod.rs
@@ -47,9 +47,8 @@ pub(super) use self::{
     producer::ValidatedPublishDescriptor,
     route_graph::{RelayRouteEffect, RelayRouteKey},
     subscription::{
-        ConsumerBootstrapOrigin, ConsumerRouteUpdate, PendingConsumerBootstrap,
-        PendingConsumerBootstrapTarget, PlannedConsumerBootstrap, PlannedSubscriptionChange,
-        PreparedConsumerBootstrap,
+        ConsumerBootstrapOrigin, ConsumerRouteUpdate, PendingConsumerBootstrapTarget,
+        PlannedConsumerBootstrap, PreparedConsumerBootstrap,
     },
 };
 

--- a/crates/core/src/engine/room/media_graph/producer.rs
+++ b/crates/core/src/engine/room/media_graph/producer.rs
@@ -18,8 +18,7 @@ use tracing::{error, warn};
 
 use super::{
     super::{
-        TrackBindingUpdate, UserOutbound, outbound::OutboundSender, state::RoomState,
-        topology::RoutedProducerId,
+        TrackBindingUpdate, outbound::OutboundSender, state::RoomState, topology::RoutedProducerId,
     },
     ConsumerKey, ProducerRouteTarget, ProducerRuntimeId, PublishedProducer, PublishedSourceInstall,
     SourceTransportMediaIndexEntry, TransportMediaRemoval,
@@ -62,8 +61,6 @@ pub(in crate::engine::room) struct PreparedPublishedTrack {
 
 #[derive(Debug)]
 pub(in crate::engine::room) struct ProducerActivityOutcome {
-    pub transport_media_id: TransportMediaId,
-    pub active: bool,
     recipients: Vec<OutboundSender>,
     update: TrackBindingUpdate,
 }
@@ -71,6 +68,7 @@ pub(in crate::engine::room) struct ProducerActivityOutcome {
 #[derive(Debug)]
 pub(in crate::engine::room) struct UnpublishTrackOutcome {
     recipients: Vec<OutboundSender>,
+    update: TrackBindingUpdate,
     relay_effects: Vec<RelayRouteEffect>,
     transport_removals: Vec<TransportMediaRemoval>,
 }
@@ -380,6 +378,11 @@ impl RoomState {
                 .values()
                 .map(|user| user.sender.clone())
                 .collect(),
+            update: TrackBindingUpdate {
+                user_id: user_id.clone(),
+                stream_id: stream_id.clone(),
+                active: None,
+            },
             relay_effects,
             transport_removals,
         })
@@ -418,8 +421,6 @@ impl RoomState {
         }
         self.media.set_producer_active(producer_target, active);
         Some(ProducerActivityOutcome {
-            transport_media_id: producer_target.transport_media_id(),
-            active,
             recipients: self
                 .users
                 .values()
@@ -476,31 +477,26 @@ impl ValidatedPublishDescriptor {
 }
 
 impl ProducerActivityOutcome {
-    pub fn emit(self) {
-        for recipient in self.recipients {
-            let _ = recipient.send(UserOutbound::TrackBindingUpdate(self.update.clone()));
-        }
+    pub fn into_track_binding_update(self) -> (Vec<OutboundSender>, TrackBindingUpdate) {
+        (self.recipients, self.update)
     }
 }
 
 impl UnpublishTrackOutcome {
-    pub fn relay_effects(&self) -> &[RelayRouteEffect] {
-        &self.relay_effects
-    }
-
-    pub fn transport_removals(&self) -> &[TransportMediaRemoval] {
-        &self.transport_removals
-    }
-
-    pub fn emit(self, user_id: &UserId, stream_id: &UserStreamId) {
-        let track_update = UserOutbound::TrackBindingUpdate(TrackBindingUpdate {
-            user_id: user_id.clone(),
-            stream_id: stream_id.clone(),
-            active: None,
-        });
-        for recipient in self.recipients {
-            let _ = recipient.send(track_update.clone());
-        }
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<OutboundSender>,
+        TrackBindingUpdate,
+        Vec<RelayRouteEffect>,
+        Vec<TransportMediaRemoval>,
+    ) {
+        (
+            self.recipients,
+            self.update,
+            self.relay_effects,
+            self.transport_removals,
+        )
     }
 }
 

--- a/crates/core/src/engine/room/media_graph/subscription.rs
+++ b/crates/core/src/engine/room/media_graph/subscription.rs
@@ -38,11 +38,11 @@ use crate::engine::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConsumerRouteUpdate {
-    pub route: ConsumerRouteTransportRef,
-    pub stream: UserStreamId,
-    pub kind: RouterMediaKind,
-    pub active: bool,
+pub(in crate::engine::room) struct ConsumerRouteUpdate {
+    pub(in crate::engine::room) route: ConsumerRouteTransportRef,
+    pub(in crate::engine::room) stream: UserStreamId,
+    pub(in crate::engine::room) kind: RouterMediaKind,
+    pub(in crate::engine::room) active: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,6 +127,16 @@ pub enum ConsumerBootstrapOrigin {
     LateJoin,
     Publish,
     Subscribe,
+}
+
+impl ConsumerBootstrapOrigin {
+    pub(in crate::engine::room) const fn as_diagnostic_str(self) -> &'static str {
+        match self {
+            Self::LateJoin => "latejoin",
+            Self::Publish => "publish",
+            Self::Subscribe => "subscribe",
+        }
+    }
 }
 
 impl RoomState {
@@ -285,12 +295,12 @@ impl RoomState {
                 );
                 continue;
             }
-            updates.push(ConsumerRouteUpdate::new(
-                route_ref,
-                stream_id.clone(),
+            updates.push(ConsumerRouteUpdate {
+                route: route_ref,
+                stream: stream_id.clone(),
                 kind,
                 active,
-            ));
+            });
             relays.extend(self.media.set_relay_consumer_active(
                 user_id,
                 connection_id,
@@ -713,22 +723,6 @@ impl PlannedSubscriptionChange {
         Vec<RelayRouteEffect>,
     ) {
         (self.updates, self.bootstraps, self.relays)
-    }
-}
-
-impl ConsumerRouteUpdate {
-    pub const fn new(
-        route: ConsumerRouteTransportRef,
-        stream: UserStreamId,
-        kind: RouterMediaKind,
-        active: bool,
-    ) -> Self {
-        Self {
-            route,
-            stream,
-            kind,
-            active,
-        }
     }
 }
 

--- a/crates/core/src/engine/room/membership.rs
+++ b/crates/core/src/engine/room/membership.rs
@@ -33,7 +33,7 @@ use {
 use super::{
     BroadcastPayloadError, Room, RoomJoinError, RoomMediaCounts, SourcePolicyEvent,
     UserOutboundSender,
-    effects::{RoomEffectBatch, RoomEffectContext, TransportUserCleanup},
+    effects::{RoomCommit, RoomEffectContext},
     placement::{CommittedPlacementReceipt, JoinPlacementPlan},
     state::{DisconnectUsersOutcome, JoinUserOutcome, LeaveUserOutcome, RoomState},
 };
@@ -508,11 +508,11 @@ impl Room {
             transport_session_key.media_worker_id(),
             placement_receipt.media_worker_id()
         );
-        RoomEffectBatch::new()
+        RoomCommit::new()
             .with_user_count_delta(count_delta.users_before, count_delta.users_after)
             .with_media_count_delta(count_delta.media_before, count_delta.media_after)
             .with_relay_effects(relay_effects)
-            .with_transport_removals(transport_removals)
+            .with_transport_removals(self, transport_removals)
             .with_source_policy_event(SourcePolicyEvent::RouteGraphChanged)
             .with_lifecycle_effects(effects)
             .register_diagnostics_user(user_id.clone())
@@ -544,14 +544,14 @@ impl Room {
         let media_worker_id = self
             .placement_state
             .media_worker_id_for_connection(connection_id);
-        let mut batch = RoomEffectBatch::new()
+        let mut commit = RoomCommit::new()
             .with_user_count_delta(count_delta.users_before, count_delta.users_after)
             .with_media_count_delta(count_delta.media_before, count_delta.media_after)
-            .with_transport_user_close(TransportUserCleanup::new(user_id.clone(), connection_id));
+            .with_transport_user_close(self, &user_id, connection_id);
         if let Some(outcome) = outcome {
-            batch = batch
+            commit = commit
                 .with_relay_effects(outcome.relay_effects)
-                .with_transport_removals(outcome.transport_removals)
+                .with_transport_removals(self, outcome.transport_removals)
                 .with_lifecycle_effects(outcome.effects)
                 .record_diagnostics(
                     DiagnosticsEventData::for_user(
@@ -565,7 +565,7 @@ impl Room {
                 .forget_diagnostics_user(user_id.clone())
                 .with_source_policy_event(SourcePolicyEvent::RouteGraphChanged);
         }
-        batch.execute(self, context).await;
+        commit.execute(self, context).await;
         self.placement_state
             .unregister_committed_placement(connection_id);
         if had_state {
@@ -586,20 +586,21 @@ impl Room {
         count_delta: MembershipCountDelta,
         context: RoomEffectContext<'_>,
     ) -> UserTransitionResult {
-        let mut batch = RoomEffectBatch::new()
+        let mut commit = RoomCommit::new()
             .with_user_count_delta(count_delta.users_before, count_delta.users_after)
             .with_media_count_delta(count_delta.media_before, count_delta.media_after)
             .with_relay_effects(outcome.relay_effects)
-            .with_transport_removals(outcome.transport_removals)
+            .with_transport_removals(self, outcome.transport_removals)
             .with_source_policy_event(SourcePolicyEvent::RouteGraphChanged)
             .with_lifecycle_effects(outcome.effects);
         let mut disconnected_sessions = Vec::with_capacity(outcome.disconnected_users.len());
         for disconnected_session in outcome.disconnected_users {
-            batch = batch
-                .with_transport_user_close(TransportUserCleanup::new(
-                    disconnected_session.user_id.clone(),
+            commit = commit
+                .with_transport_user_close(
+                    self,
+                    &disconnected_session.user_id,
                     disconnected_session.connection_id,
-                ))
+                )
                 .record_diagnostics(
                     DiagnosticsEventData::for_user(
                         self.uuid(),
@@ -615,7 +616,7 @@ impl Room {
                 .forget_diagnostics_user(disconnected_session.user_id.clone());
             disconnected_sessions.push(disconnected_session);
         }
-        batch.execute(self, context).await;
+        commit.execute(self, context).await;
         for disconnected_session in disconnected_sessions {
             self.placement_state
                 .unregister_committed_placement(disconnected_session.connection_id);

--- a/crates/core/src/engine/room/tests/manager_tests.rs
+++ b/crates/core/src/engine/room/tests/manager_tests.rs
@@ -6,9 +6,9 @@ use tokio::{sync::Notify, task::yield_now, time::timeout};
 use super::{
     super::{
         TestPlacementReason,
+        effects::{RoomCommit, RoomEffectContext},
         manager::JoinPlacementTestGate,
         media_graph::{ConsumerRouteTransportRef, ConsumerRouteUpdate},
-        transition::SubscriptionEffectPlan,
         user_negotiation::UserTransportReady,
     },
     api::NegotiatedPublish,
@@ -463,16 +463,21 @@ async fn spillover_media_diagnostics_use_connection_worker() {
         user_connection_id(&room, &UserId::Integer(1)).await,
         TransportMediaId::new(11),
     );
-    let subscription_update =
-        ConsumerRouteUpdate::new(route, stream_id.clone(), MediaKind::Audio, false);
-    SubscriptionEffectPlan::from_route_updates(
-        &room,
-        &publisher_id,
-        publisher_connection_id,
-        vec![subscription_update],
-    )
-    .execute(&room, &media_transport)
-    .await;
+    let subscription_update = ConsumerRouteUpdate {
+        route,
+        stream: stream_id.clone(),
+        kind: MediaKind::Audio,
+        active: false,
+    };
+    RoomCommit::new()
+        .with_route_updates(
+            &room,
+            &publisher_id,
+            publisher_connection_id,
+            vec![subscription_update],
+        )
+        .execute(&room, RoomEffectContext::runtime(&media_transport))
+        .await;
     assert_event_worker(
         &room,
         &publisher_id,

--- a/crates/core/src/engine/room/tests/membership_tests.rs
+++ b/crates/core/src/engine/room/tests/membership_tests.rs
@@ -175,4 +175,5 @@ async fn removing_publisher_clears_media_state_and_transport_routes() {
             .await
             .is_none()
     );
+    assert_eq!(room.test_api().lifecycle().pending_cleanup_retry_count(), 0);
 }

--- a/crates/core/src/engine/room/tests/producer_tests/bootstrap.rs
+++ b/crates/core/src/engine/room/tests/producer_tests/bootstrap.rs
@@ -79,7 +79,7 @@ async fn transport_connect_bootstrap_late_join_when_capabilities_arrive_first() 
 
 #[tokio::test]
 async fn refresh_retry_bootstraps_only_missing_consumers_on_real_rtc() {
-    let mut scenario = setup_real_rtc_refresh_scenario().await;
+    let mut scenario = Box::pin(setup_real_rtc_refresh_scenario()).await;
 
     assert!(
         scenario
@@ -162,7 +162,7 @@ async fn refresh_retry_bootstraps_only_missing_consumers_on_real_rtc() {
 
 #[tokio::test]
 async fn negotiated_publish_commit_bootstraps_consumers_on_real_rtc() {
-    let mut scenario = setup_real_rtc_refresh_scenario().await;
+    let mut scenario = Box::pin(setup_real_rtc_refresh_scenario()).await;
     let Some(publisher_connection_id) = scenario
         .room
         .test_api()

--- a/crates/core/src/engine/room/tests/producer_tests/cleanup.rs
+++ b/crates/core/src/engine/room/tests/producer_tests/cleanup.rs
@@ -53,7 +53,7 @@ async fn explicit_unpublish_removes_state_and_transport_media() {
 
 #[tokio::test]
 async fn explicit_unpublish_queues_cleanup_when_real_transport_owner_is_gone() {
-    let mut scenario = setup_real_rtc_refresh_scenario().await;
+    let mut scenario = Box::pin(setup_real_rtc_refresh_scenario()).await;
 
     publish_track(
         &scenario.room,

--- a/crates/core/src/engine/room/transition/mod.rs
+++ b/crates/core/src/engine/room/transition/mod.rs
@@ -9,5 +9,3 @@ mod subscription;
 pub(super) use publication::PendingPublishTransactions;
 #[cfg(any(test, feature = "testing-transport"))]
 pub(super) use publication::ReservedPublish;
-#[cfg(test)]
-pub(super) use subscription::SubscriptionEffectPlan;

--- a/crates/core/src/engine/room/transition/publication.rs
+++ b/crates/core/src/engine/room/transition/publication.rs
@@ -1,27 +1,4 @@
-//! Publication transitions for room media state.
-//!
-//! # Role
-//!
-//! This module owns the time-ordered publication workflows that cross room
-//! state and transport state. `RoomState` stays authoritative for committed
-//! producers. The media transport stays authoritative for allocated media
-//! lines. Publication transitions keep the short-lived ownership bridge between
-//! those layers so callers do not have to remember rollback details.
-//!
-//! # Staged publish lifecycle
-//!
-//! A publish is staged only after room state validates the current user and
-//! the media transport reserves a media line. While the browser answers
-//! renegotiation, that reservation lives in `PendingPublishTransactions`.
-//! Answer handling later drains the transaction and either commits it into
-//! room state or consumes it through transport cleanup.
-//!
-//! # Concurrency
-//!
-//! This is cold-path room work. Transport calls happen after room state
-//! locks are released. The pending-publish registry has its own mutex, but that
-//! lock is held only for lookup, insertion and draining. Commit and cleanup run
-//! after the registry lock is released.
+//! publication transitions for staged and committed room media
 
 use std::{
     collections::{BTreeMap, btree_map::Entry},
@@ -35,7 +12,7 @@ use tracing::warn;
 use super::super::{
     Room, RoomMediaCounts, RoomUserOperation, SourcePolicyEvent,
     cleanup::TransportCleanupOperation,
-    effects::{RoomEffectBatch, RoomEffectContext},
+    effects::{RoomCommit, RoomEffectContext},
     media_graph::{
         ConsumerBootstrapOrigin, PendingConsumerBootstrapTarget, ValidatedPublishDescriptor,
     },
@@ -47,8 +24,8 @@ use crate::{
         ConnectionId, UserId,
         diagnostics::DiagnosticsEventData,
         media_transport::{
-            AppliedSessionAnswer, ProducerActivity, SessionUploadEncoding, TransportAdapterError,
-            TransportMediaId, TransportSourceKey,
+            AppliedSessionAnswer, SessionUploadEncoding, TransportAdapterError, TransportMediaId,
+            TransportSourceKey,
         },
         source_model::{SourcePublishIntent, UserStreamId},
         sync::lock_unpoisoned,
@@ -69,20 +46,12 @@ mod test_support;
 /// facing user id.
 ///
 /// This registry owns only in-flight reservations. Once a publish commits, the
-/// producer and its transport media belong to room state. Once a publish is
-/// rolled back, the transaction must be consumed through reservation cleanup.
+/// producer and its transport media belong to room state.
 #[derive(Debug, Default)]
 pub struct PendingPublishTransactions {
-    /// In-flight publish ownership keyed by the exact websocket connection that
-    /// reserved the transport media.
     staged: BTreeMap<PendingPublishKey, ReservedPublish>,
 }
 
-/// Stable key for one staged publish slot
-///
-/// This uses the protocol user identity for room ownership, the runtime
-/// connection id for stale-socket rejection and the user stream id
-/// for the per-user media slot.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct PendingPublishKey {
     user: UserId,
@@ -100,40 +69,18 @@ struct PendingPublishKey {
 /// cleaning transport media while leaving a descriptor that can still commit.
 #[derive(Debug)]
 pub struct ReservedPublish {
-    /// Stage-time room validation. Commit must re-check it because
-    /// replacement or disconnect can make the descriptor stale while transport
-    /// work is in flight.
     descriptor: ValidatedPublishDescriptor,
-    /// Transport media ownership while the publish is not yet a live producer.
     reservation: StagedMediaReservation,
 }
 
-/// Legal states for one staged transport-media reservation.
-///
-/// These states stay local to the transaction boundary. The
-/// websocket layer sees publish intent and answer handling. `RoomState` sees
-/// only committed producers. The media transport sees media add or remove
-/// calls. This enum records which layer is responsible for the reserved media
-/// right now.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StagedMediaReservationState {
-    /// The media line exists in the media transport but is not committed in
-    /// room state.
     Reserved,
-    /// The room committed the producer, so normal unpublish or leave cleanup
-    /// handles the transport media from this point onward.
     Committed,
-    /// The transaction made an explicit cleanup decision.
-    ///
-    /// This does not prove the media transport removed the handle
-    /// successfully. Cleanup is best-effort at this boundary and failures are
-    /// reported through logs.
     Released,
 }
 
 /// Guard for transport media reserved by a staged publish.
-///
-/// # note
 ///
 /// Transport cleanup is async, so this guard must not try to clean up in
 /// `Drop`. Instead the guard is consumed by either `cleanup` or `commit`
@@ -143,16 +90,9 @@ enum StagedMediaReservationState {
 #[derive(Debug)]
 #[must_use = "staged media reservations must be committed or cleaned up explicitly"]
 struct StagedMediaReservation {
-    /// Protocol-facing user identity used to rebuild the transport user
-    /// key for cleanup.
     user: UserId,
-    /// Runtime-local connection identity that prevents a replacement socket
-    /// from inheriting stale transport media.
     connection: ConnectionId,
-    /// Transport media handle that must be removed unless the publish
-    /// becomes a live producer.
     media: TransportMediaId,
-    /// Current state for the reserved media.
     state: StagedMediaReservationState,
 }
 
@@ -165,10 +105,6 @@ struct AnsweredPublish {
     encodings: Vec<SessionUploadEncoding>,
 }
 
-/// Post-commit work for a publish that already became live in room state.
-///
-/// This exists so the lock-protected state mutation stays small while the
-/// follow-up effects still run in the right order after unlock
 #[derive(Debug)]
 struct CommittedPublish {
     before: RoomMediaCounts,
@@ -520,20 +456,19 @@ impl CommittedPublish {
     /// - diagnostics happen last
     async fn finish(self, operation: RoomUserOperation<'_>) {
         let room = operation.room();
-        RoomEffectBatch::new()
-            .with_media_count_delta(self.before, self.after)
-            .execute(
-                room,
-                RoomEffectContext::runtime(operation.media_transport()),
-            )
-            .await;
-        room.bootstrap_consumers(
-            operation.media_transport(),
-            ConsumerBootstrapOrigin::Publish,
-            self.consumers,
-        )
-        .await;
-        RoomEffectBatch::new()
+        let commit = {
+            let worker_lookup = room.placement_state.worker_lookup();
+            let mut state = room.state.write().await;
+            let before = state.media_counts();
+            let bootstraps = state.plan_consumers(self.consumers, worker_lookup);
+            let after = state.media_counts();
+            drop(state);
+            RoomCommit::new()
+                .with_media_count_delta(self.before, self.after)
+                .with_media_count_delta(before, after)
+                .with_bootstraps(bootstraps, ConsumerBootstrapOrigin::Publish)
+        };
+        commit
             .with_source_policy_event(SourcePolicyEvent::RouteGraphChanged)
             .record_diagnostics(self.diagnostics)
             .execute(
@@ -583,7 +518,7 @@ impl RoomUserOperation<'_> {
             return Ok(PublishStageOutcome::Duplicate);
         }
         let session_key = self.transport_user_key();
-        let rtp_parameters = answer_derived_publish_parameters();
+        let rtp_parameters = RouterRtpParameters::default();
         let media = match self
             .media_transport()
             .publish_media(&session_key, intent.media_kind(), &rtp_parameters)
@@ -690,10 +625,6 @@ impl RoomUserOperation<'_> {
         committed_stream_ids
     }
 
-    #[allow(
-        clippy::cognitive_complexity,
-        reason = "the production-change transition intentionally keeps router updates, user-info sync, broadcast and transport activity in one explicit sequence"
-    )]
     pub(crate) async fn set_publication_activity(
         self,
         stream_id: &UserStreamId,
@@ -716,42 +647,28 @@ impl RoomUserOperation<'_> {
         }) else {
             return PublicationActivityOutcome::StalePublication;
         };
-        let source = TransportSourceKey::new(transport_user_key, outcome.transport_media_id);
-        let transport_update = if self
-            .media_transport()
-            .set_producer_active(&source, ProducerActivity::from_active(outcome.active))
-            .await
-            .is_err()
-        {
-            warn!(
-                user_id = ?self.user_id(),
-                stream_id = %stream_id,
-                active = outcome.active,
-                "media transport failed to update producer route activity"
-            );
-            TransportEffectOutcome::Failed
-        } else {
-            TransportEffectOutcome::Applied
-        };
-        room.diagnostics.record(
-            DiagnosticsEventData::for_user(
-                room.uuid(),
-                self.user_id(),
-                telemetry_event::PUBLICATION_ACTIVITY_CHANGED,
-            )
-            .with_connection_id(self.connection_id().as_u64())
-            .with_media_worker_id(media_worker_id.as_usize())
-            .with_transport_media_id(outcome.transport_media_id.as_u64())
-            .insert_field("active", outcome.active)
-            .insert_field("stream_id", stream_id.to_string()),
-        );
-        outcome.emit();
-        room.handle_source_policy_event(
-            SourcePolicyEvent::FanoutPressureChanged,
-            Some(self.media_transport()),
+        let transport_media_id = producer_target.transport_media_id();
+        let source = TransportSourceKey::new(transport_user_key, transport_media_id);
+        let diagnostics = DiagnosticsEventData::for_user(
+            room.uuid(),
+            self.user_id(),
+            telemetry_event::PUBLICATION_ACTIVITY_CHANGED,
         )
-        .await;
-        PublicationActivityOutcome::Applied { transport_update }
+        .with_connection_id(self.connection_id().as_u64())
+        .with_media_worker_id(media_worker_id.as_usize())
+        .with_transport_media_id(transport_media_id.as_u64())
+        .insert_field("active", active)
+        .insert_field("stream_id", stream_id.to_string());
+        let (recipients, track_update) = outcome.into_track_binding_update();
+        let execution = RoomCommit::new()
+            .with_producer_activity(source, active, stream_id.clone(), diagnostics)
+            .with_track_binding_update(recipients, track_update)
+            .with_source_policy_event(SourcePolicyEvent::FanoutPressureChanged)
+            .execute(room, RoomEffectContext::runtime(self.media_transport()))
+            .await;
+        PublicationActivityOutcome::Applied {
+            transport_update: execution.producer_activity(),
+        }
     }
 
     pub(crate) async fn unpublish(self, stream_id: &UserStreamId) -> UnpublishOutcome {
@@ -770,26 +687,20 @@ impl RoomUserOperation<'_> {
         let Some(outcome) = outcome else {
             return UnpublishOutcome::MissingPublication;
         };
-        let execution = RoomEffectBatch::new()
+        let (recipients, track_update, relays, removals) = outcome.into_parts();
+        let execution = RoomCommit::new()
             .with_media_count_delta(before, after)
-            .with_relay_effects(outcome.relay_effects().iter().cloned())
-            .with_transport_removals(outcome.transport_removals().iter().cloned())
+            .with_relay_effects(relays)
+            .with_transport_removals(room, removals)
+            .with_track_binding_update(recipients, track_update)
+            .with_source_policy_event(SourcePolicyEvent::RouteGraphChanged)
             .execute(room, RoomEffectContext::runtime(media_port))
-            .await;
-        outcome.emit(user_id, stream_id);
-        room.handle_source_policy_event(SourcePolicyEvent::RouteGraphChanged, Some(media_port))
             .await;
         room.reconcile_spillover_routers().await;
         UnpublishOutcome::Unpublished {
             cleanup: execution.cleanup(),
         }
     }
-}
-
-/// Marker parameters for a protocol publish whose concrete SSRC and RID
-/// bindings are projected from the accepted SDP answer.
-fn answer_derived_publish_parameters() -> RouterRtpParameters {
-    RouterRtpParameters::default()
 }
 
 impl Room {

--- a/crates/core/src/engine/room/transition/subscription.rs
+++ b/crates/core/src/engine/room/transition/subscription.rs
@@ -1,119 +1,19 @@
-//! subscription transition choreography
-//!
-//! this module turns committed room-state decisions into transport and outbound
-//! work for receiver intent and consumer bootstrap flows
-//!
-//! room graph and topology commits stay synchronous room-state work
-//! relay changes, transport consume calls and outbound requests run only after
-//! the room-state lock is released
-
 use std::collections::BTreeMap;
 
-use o_sfu_telemetry::schema::event as telemetry_event;
-use tracing::warn;
-
 use super::super::{
-    RemoteTrackBootstrap, Room, RoomMediaCounts, RoomUserOperation, SourcePolicyEvent,
-    cleanup::TransportCleanupOperation,
-    effects::{MediaCountDelta, RoomEffectBatch, RoomEffectContext},
-    media_graph::{
-        ConsumerBootstrapOrigin, ConsumerRouteTransportRef, ConsumerRouteUpdate,
-        PendingConsumerBootstrap, PendingConsumerBootstrapTarget, PlannedConsumerBootstrap,
-        PlannedSubscriptionChange, PreparedConsumerBootstrap, RelayRouteEffect,
-    },
-    outbound::OutboundSender,
+    RoomUserOperation, SourcePolicyEvent,
+    effects::{RoomCommit, RoomEffectContext},
+    media_graph::ConsumerBootstrapOrigin,
 };
 use crate::{
     SubscriptionUpdateOutcome,
     engine::{
-        ConnectionId, UserId,
-        diagnostics::DiagnosticsEventData,
-        media_transport::{ConsumerActivity, MediaTransport, TransportMediaId},
+        UserId,
         source_model::{SourceSubscriptionIntent, UserStreamId},
     },
 };
 
-#[derive(Debug)]
-/// pending transport activity change for one committed consumer route
-///
-/// this carries the route identity plus the diagnostics payload captured while
-/// room state still knew which subscription update accepted the change
-struct SubscriptionRouteActivityOp {
-    /// transport-facing route that should be paused or resumed
-    route: ConsumerRouteTransportRef,
-    /// source stream used in diagnostics and keyframe refresh logs
-    stream: UserStreamId,
-    /// media kind used to request a keyframe after video resume
-    kind: o_sfu_router::MediaKind,
-    /// receiver-local route activity accepted by room state
-    active: bool,
-    /// diagnostics record emitted after the transport update attempt
-    diagnostics: DiagnosticsEventData,
-}
-
-#[derive(Debug, Clone, Copy)]
-/// state snapshots and receiver identity needed to build one effect plan
-///
-/// the context is captured before unlock so later async work never reads live
-/// room state to rediscover which transition produced the effects
-struct SubscriptionEffectContext<'a> {
-    /// receiver whose intent or bootstrap created the work
-    user: &'a UserId,
-    /// connection that was current while room state accepted the plan
-    connection: ConnectionId,
-    /// media counts before the accepted room-state mutation
-    before: RoomMediaCounts,
-    /// media counts after the accepted room-state mutation
-    after: RoomMediaCounts,
-    /// user-visible cause recorded on successful consumer bootstrap
-    origin: ConsumerBootstrapOrigin,
-}
-
-#[derive(Debug, Default)]
-/// post-lock work produced by one subscription state transition
-///
-/// every field is a fact captured before transport awaits start
-/// transport and relay failures are handled after the original state
-/// transaction ends, with cleanup when a bootstrap lease cannot be committed
-pub struct SubscriptionEffectPlan {
-    /// media gauge delta for the committed room-state mutation
-    media_delta: Option<MediaCountDelta>,
-    /// relay route mutations accepted by room state
-    relay_ops: Vec<RelayRouteEffect>,
-    /// transport route activity updates plus matching diagnostics
-    route_ops: Vec<SubscriptionRouteActivityOp>,
-    /// pending consumer bootstraps that still need transport media
-    bootstraps: Vec<PendingConsumerLease>,
-}
-
-#[derive(Debug)]
-/// single-use lease for a pending consumer bootstrap
-///
-/// the lease carries the pending graph reservation plus the prepared transport
-/// input that must be consumed exactly once by the async effect path
-/// if relay setup or transport consume fails, releasing this lease removes
-/// pending graph and relay state so the next bootstrap attempt starts cleanly
-struct PendingConsumerLease {
-    /// immutable identity of the producer and receiver route being bootstrapped
-    target: PendingConsumerBootstrapTarget,
-    /// transport parameters negotiated from the producer snapshot
-    prepared: PreparedConsumerBootstrap,
-    /// graph reservation to consume during final room-state commit
-    pending: PendingConsumerBootstrap,
-    /// relay routes that must exist before the transport consumer is declared
-    relays: Vec<RelayRouteEffect>,
-    /// bootstrap cause carried into diagnostics after commit
-    origin: ConsumerBootstrapOrigin,
-}
-
 impl RoomUserOperation<'_> {
-    /// boots missing consumer routes for the current connection after negotiation
-    ///
-    /// callers use this when a receiver has become able to consume after earlier
-    /// room state already planned or published sources
-    /// returns `false` when the connection is stale or no bootstrap work exists
-    ///
-    /// the method holds the room-state lock only while building the plan
     pub(crate) async fn bootstrap_consumers(self) -> bool {
         let room = self.room();
         let worker_lookup = room.placement_state.worker_lookup();
@@ -126,35 +26,22 @@ impl RoomUserOperation<'_> {
         };
         let after = state.media_counts();
         drop(state);
-        let effects = SubscriptionEffectPlan::from_bootstraps(
-            before,
-            after,
-            bootstraps,
-            ConsumerBootstrapOrigin::LateJoin,
-        );
-        effects.execute(room, self.media_transport()).await;
-        room.handle_source_policy_event(
-            SourcePolicyEvent::RouteGraphChanged,
-            Some(self.media_transport()),
-        )
-        .await;
+        RoomCommit::new()
+            .with_media_count_delta(before, after)
+            .with_bootstraps(bootstraps, ConsumerBootstrapOrigin::LateJoin)
+            .with_source_policy_event(SourcePolicyEvent::RouteGraphChanged)
+            .execute(room, RoomEffectContext::runtime(self.media_transport()))
+            .await;
         true
     }
 
-    /// stores receiver intent and applies the resulting route work
-    ///
-    /// the caller must pass the current connection id for the receiver
-    /// stale connections are rejected before intent is persisted
-    ///
-    /// route activity, relay changes and missing consumer bootstrap work are
-    /// executed after the state lock is released
     pub(crate) async fn update_subscription(
         self,
         target_user_id: &UserId,
         intents: &BTreeMap<UserStreamId, SourceSubscriptionIntent>,
     ) -> SubscriptionUpdateOutcome {
         let room = self.room();
-        let (effects, source_policy_event) = {
+        let effects = {
             let worker_lookup = room.placement_state.worker_lookup();
             let mut state = room.state.write().await;
             if state
@@ -178,404 +65,18 @@ impl RoomUserOperation<'_> {
             };
             let after = state.media_counts();
             drop(state);
-            (
-                SubscriptionEffectPlan::from_change(
-                    room,
-                    SubscriptionEffectContext {
-                        user: self.user_id(),
-                        connection: self.connection_id(),
-                        before,
-                        after,
-                        origin: ConsumerBootstrapOrigin::Subscribe,
-                    },
-                    change,
-                ),
-                source_policy_event,
-            )
+            let (updates, bootstraps, relays) = change.into_parts();
+            RoomCommit::new()
+                .with_media_count_delta(before, after)
+                .with_relay_effects(relays)
+                .with_route_updates(room, self.user_id(), self.connection_id(), updates)
+                .with_bootstraps(bootstraps, ConsumerBootstrapOrigin::Subscribe)
+                .with_source_policy_event(source_policy_event)
         };
-        effects.execute(room, self.media_transport()).await;
-        room.handle_source_policy_event(source_policy_event, Some(self.media_transport()))
+        effects
+            .execute(room, RoomEffectContext::runtime(self.media_transport()))
             .await;
         SubscriptionUpdateOutcome::Applied
-    }
-}
-
-impl Room {
-    /// bootstraps concrete consumer targets captured by another room transition
-    ///
-    /// publish commit uses this when a new producer should reach existing receivers
-    /// the target list is validated again under room state before any transport
-    /// work starts, so stale targets become no-ops
-    pub(super) async fn bootstrap_consumers(
-        &self,
-        media_port: &MediaTransport,
-        origin: ConsumerBootstrapOrigin,
-        targets: Vec<PendingConsumerBootstrapTarget>,
-    ) {
-        let effects = {
-            let worker_lookup = self.placement_state.worker_lookup();
-            let mut state = self.state.write().await;
-            let before = state.media_counts();
-            let bootstraps = state.plan_consumers(targets, worker_lookup);
-            let after = state.media_counts();
-            drop(state);
-            SubscriptionEffectPlan::from_bootstraps(before, after, bootstraps, origin)
-        };
-        effects.execute(self, media_port).await;
-    }
-
-    /// releases a pending consumer-bootstrap reservation after its lease ends
-    ///
-    /// this mirrors staged-publish ownership on the subscriber side
-    /// room state owns the reservation while metrics and relay cleanup happen
-    /// after unlock
-    async fn release_bootstrap(
-        &self,
-        target: &PendingConsumerBootstrapTarget,
-        media_port: &MediaTransport,
-    ) {
-        let (before, after, relays) = {
-            let mut state = self.state.write().await;
-            let before = state.media_counts();
-            let relays = state.release_bootstrap(target);
-            let after = state.media_counts();
-            drop(state);
-            (before, after, relays)
-        };
-        RoomEffectBatch::new()
-            .with_media_count_delta(before, after)
-            .with_relay_effects(relays)
-            .execute(self, RoomEffectContext::runtime(media_port))
-            .await;
-        self.handle_source_policy_event(SourcePolicyEvent::FanoutPressureChanged, Some(media_port))
-            .await;
-    }
-}
-
-impl SubscriptionEffectPlan {
-    /// builds route activity effects from route updates accepted by room state
-    ///
-    /// diagnostics are shaped here so callers can finish all subscription-side
-    /// side effects from one post-lock executor
-    pub fn from_route_updates(
-        room: &Room,
-        user_id: &UserId,
-        connection_id: ConnectionId,
-        updates: Vec<ConsumerRouteUpdate>,
-    ) -> Self {
-        let media_worker_id = room
-            .transport_user_key(user_id, connection_id)
-            .media_worker_id();
-        let route_ops = updates
-            .into_iter()
-            .map(|route_update| {
-                let ConsumerRouteUpdate {
-                    route,
-                    stream,
-                    kind,
-                    active,
-                } = route_update;
-                let diagnostics = DiagnosticsEventData::for_user(
-                    room.uuid(),
-                    user_id,
-                    telemetry_event::SUBSCRIPTION_ACTIVITY_CHANGED,
-                )
-                .with_connection_id(connection_id.as_u64())
-                .with_media_worker_id(media_worker_id.as_usize())
-                .with_transport_media_id(route.consumer_media().as_u64())
-                .insert_field("active", active)
-                .insert_field(
-                    "producer_user_id",
-                    serde_json::to_value(route.source_user_id()).unwrap_or(serde_json::Value::Null),
-                )
-                .insert_field("source_transport_media_id", route.source_media().as_u64())
-                .insert_field("stream_id", stream.to_string());
-                SubscriptionRouteActivityOp {
-                    route,
-                    stream,
-                    kind,
-                    active,
-                    diagnostics,
-                }
-            })
-            .collect();
-        Self {
-            media_delta: None,
-            relay_ops: Vec::new(),
-            route_ops,
-            bootstraps: Vec::new(),
-        }
-    }
-
-    /// builds the full post-lock plan for a receiver intent change
-    ///
-    /// the plan may contain route toggles, relay changes and new consumer
-    /// bootstraps because changing receiver intent can affect existing and
-    /// missing routes at the same time
-    fn from_change(
-        room: &Room,
-        context: SubscriptionEffectContext<'_>,
-        change: PlannedSubscriptionChange,
-    ) -> Self {
-        let (updates, bootstraps, relays) = change.into_parts();
-        let mut effect_plan =
-            Self::from_route_updates(room, context.user, context.connection, updates);
-        effect_plan.media_delta = Some(MediaCountDelta::new(context.before, context.after));
-        effect_plan.relay_ops = relays;
-        effect_plan.bootstraps = bootstraps
-            .into_iter()
-            .map(|bootstrap| PendingConsumerLease::new(bootstrap, context.origin))
-            .collect();
-        effect_plan
-    }
-
-    /// builds the post-lock plan for bootstrap work without route toggles
-    ///
-    /// late-join and publish paths use this when room state has already chosen
-    /// concrete consumer targets and only needs transport-side setup
-    fn from_bootstraps(
-        before: RoomMediaCounts,
-        after: RoomMediaCounts,
-        bootstraps: Vec<PlannedConsumerBootstrap>,
-        origin: ConsumerBootstrapOrigin,
-    ) -> Self {
-        Self {
-            media_delta: Some(MediaCountDelta::new(before, after)),
-            relay_ops: Vec::new(),
-            route_ops: Vec::new(),
-            bootstraps: bootstraps
-                .into_iter()
-                .map(|it| PendingConsumerLease::new(it, origin))
-                .collect(),
-        }
-    }
-
-    /// executes captured subscription effects after the room lock is gone
-    ///
-    /// resumed video routes request a keyframe after the activity update because
-    /// the receiver may need a fresh decodable frame after a long pause
-    /// pending consumer leases are consumed after shared batch effects so relay
-    /// routes exist before transport media is declared
-    pub async fn execute(self, room: &Room, media_port: &MediaTransport) {
-        RoomEffectBatch::new()
-            .with_optional_media_count_delta(self.media_delta)
-            .with_relay_effects(self.relay_ops)
-            .execute(room, RoomEffectContext::runtime(media_port))
-            .await;
-        for op in self.route_ops {
-            let route = &op.route;
-            let transport_route = room.transport_consumer_route(route);
-            if media_port
-                .set_consumer_active(&transport_route, ConsumerActivity::from_active(op.active))
-                .await
-                .is_err()
-            {
-                warn!(
-                    ?route,
-                    stream_id = %op.stream,
-                    active = op.active,
-                    "media transport failed to update consumer route activity"
-                );
-            } else if op.active
-                && op.kind == o_sfu_router::MediaKind::Video
-                && media_port
-                    .request_consumer_keyframe(&transport_route)
-                    .await
-                    .is_err()
-            {
-                warn!(
-                    ?route,
-                    stream_id = %op.stream,
-                    "media transport failed to request a consumer keyframe refresh"
-                );
-            }
-            room.diagnostics.record(op.diagnostics);
-        }
-        for lease in self.bootstraps {
-            lease.execute(room, media_port).await;
-        }
-    }
-}
-
-impl PendingConsumerLease {
-    fn new(bootstrap: PlannedConsumerBootstrap, origin: ConsumerBootstrapOrigin) -> Self {
-        let (target, prepared, pending, relays) = bootstrap.into_parts();
-        Self {
-            target,
-            prepared,
-            pending,
-            relays,
-            origin,
-        }
-    }
-
-    /// runs relay setup, transport consume and final room commit for one lease
-    ///
-    /// the room-state reservation is consumed only after relay and transport work
-    /// succeeds
-    /// every failure path releases pending graph and relay state so retry sees
-    /// the source through normal planning
-    async fn execute(self, room: &Room, media_port: &MediaTransport) {
-        let Self {
-            target,
-            prepared,
-            pending,
-            relays,
-            origin,
-        } = self;
-        let execution = RoomEffectBatch::new()
-            .with_relay_effects(relays)
-            .execute(room, RoomEffectContext::runtime(media_port))
-            .await;
-        if !execution.relay_effects_applied() {
-            room.release_bootstrap(&target, media_port).await;
-            return;
-        }
-        let activity = ConsumerActivity::from_active(pending.consumer_active());
-        let Some((consumer_media, mid)) =
-            Self::declare_transport_media(&target, &prepared, activity, origin, room, media_port)
-                .await
-        else {
-            return;
-        };
-        let (before, outbound, after) = {
-            let mut state = room.state.write().await;
-            let before = state.media_counts();
-            let outbound = state.commit_bootstrap(&target, pending, consumer_media, mid);
-            let after = state.media_counts();
-            drop(state);
-            (before, outbound, after)
-        };
-        let delta = MediaCountDelta::new(before, after);
-        Self::finish(
-            room,
-            media_port,
-            &target,
-            origin,
-            consumer_media,
-            delta,
-            outbound,
-        )
-        .await;
-    }
-
-    /// declares transport media for a pending consumer before graph commit
-    ///
-    /// transport rejection releases pending bootstrap because no committed graph
-    /// route may point at missing adapter media
-    async fn declare_transport_media(
-        target: &PendingConsumerBootstrapTarget,
-        prepared: &PreparedConsumerBootstrap,
-        activity: ConsumerActivity,
-        origin: ConsumerBootstrapOrigin,
-        room: &Room,
-        media_port: &MediaTransport,
-    ) -> Option<(TransportMediaId, Option<String>)> {
-        let consumer_session =
-            room.transport_user_key(target.consumer_user_id(), target.consumer_connection_id());
-        let producer_session =
-            room.transport_user_key(target.producer_user_id(), target.producer_connection_id());
-        match media_port
-            .consume_media(
-                &consumer_session,
-                target.media_kind(),
-                &producer_session,
-                target.transport_media_id(),
-                &prepared.rtp,
-                activity,
-            )
-            .await
-        {
-            Ok(consumer_media) => {
-                let mid = media_port
-                    .transport_media_mid(&consumer_session, consumer_media)
-                    .await;
-                Some((consumer_media, mid))
-            }
-            Err(error) => {
-                room.release_bootstrap(target, media_port).await;
-                warn!(
-                    consumer_user_id = ?target.consumer_user_id(),
-                    consumer_connection_id = ?target.consumer_connection_id(),
-                    producer_user_id = ?target.producer_user_id(),
-                    producer_connection_id = ?target.producer_connection_id(),
-                    source_transport_media_id = ?target.transport_media_id(),
-                    error = ?error,
-                    consumer_mid = prepared.rtp.mid(),
-                    ?origin,
-                    "media transport rejected consume media declaration"
-                );
-                None
-            }
-        }
-    }
-
-    /// emits a committed consumer bootstrap or cleans up rejected transport media
-    ///
-    /// the caller passes the graph commit outcome rather than letting this method
-    /// query room state again
-    /// rejection means the transport media has no graph owner, so cleanup removes it
-    ///
-    /// fresh subscribers get keyframe refresh through later negotiation callbacks
-    /// after the receiver applies the relevant SDP answer
-    async fn finish(
-        room: &Room,
-        media_port: &MediaTransport,
-        target: &PendingConsumerBootstrapTarget,
-        origin: ConsumerBootstrapOrigin,
-        consumer_media: TransportMediaId,
-        delta: MediaCountDelta,
-        outbound: Option<(OutboundSender, RemoteTrackBootstrap)>,
-    ) {
-        let Some((sender, bootstrap)) = outbound else {
-            RoomEffectBatch::new()
-                .with_media_count_delta_value(delta)
-                .execute(room, RoomEffectContext::runtime(media_port))
-                .await;
-            room.release_bootstrap(target, media_port).await;
-            let cleanup = [TransportCleanupOperation::RemoveMedia {
-                session_key: room
-                    .transport_user_key(target.consumer_user_id(), target.consumer_connection_id()),
-                connection_id: target.consumer_connection_id(),
-                transport_media_id: consumer_media,
-            }];
-            room.execute_transport_cleanup_operations(media_port, &cleanup)
-                .await;
-            return;
-        };
-        RoomEffectBatch::new()
-            .with_media_count_delta_value(delta)
-            .record_diagnostics(
-                DiagnosticsEventData::for_user(
-                    room.uuid(),
-                    target.consumer_user_id(),
-                    telemetry_event::SUBSCRIBE_SUCCEEDED,
-                )
-                .with_connection_id(target.consumer_connection_id().as_u64())
-                .with_media_worker_id(
-                    room.transport_user_key(
-                        target.consumer_user_id(),
-                        target.consumer_connection_id(),
-                    )
-                    .media_worker_id()
-                    .as_usize(),
-                )
-                .with_transport_media_id(consumer_media.as_u64())
-                .insert_field(
-                    "producer_user_id",
-                    serde_json::to_value(target.producer_user_id())
-                        .unwrap_or(serde_json::Value::Null),
-                )
-                .insert_field(
-                    "source_transport_media_id",
-                    target.transport_media_id().as_u64(),
-                )
-                .insert_field("stream_id", target.stream_id().to_string())
-                .insert_field("origin", format!("{origin:?}").to_lowercase()),
-            )
-            .send_outbound_request(sender, bootstrap.into_room_event_request())
-            .execute(room, RoomEffectContext::runtime(media_port))
-            .await;
     }
 }
 
@@ -627,6 +128,13 @@ mod tests {
         BTreeMap::from([(
             stream_id_for_source(TestSourceKind::ScalableVideo),
             SourceSubscriptionIntent::new(Some(false), None),
+        )])
+    }
+
+    fn active_scalable_video_intents() -> BTreeMap<UserStreamId, SourceSubscriptionIntent> {
+        BTreeMap::from([(
+            stream_id_for_source(TestSourceKind::ScalableVideo),
+            SourceSubscriptionIntent::new(Some(true), None),
         )])
     }
 
@@ -745,6 +253,21 @@ mod tests {
         transport_media_id
     }
 
+    async fn destination_active(
+        media_transport: &MediaTransport,
+        source_media_id: TransportMediaId,
+        user_id: &UserId,
+    ) -> Option<bool> {
+        media_transport
+            .test_api()
+            .route_entry_by_media_id(source_media_id)
+            .await?
+            .destinations
+            .into_iter()
+            .find(|destination| destination.dest_session.user_id() == user_id)
+            .map(|destination| destination.active)
+    }
+
     #[tokio::test]
     async fn stored_receiver_intent_applies_to_future_consumer_bootstrap() {
         let (
@@ -778,6 +301,66 @@ mod tests {
                 .await
                 .consumer_route_state(&subscriber_id, &publisher_id, &stream_id),
             Some(ConsumerRouteState::Inactive)
+        );
+    }
+
+    #[tokio::test]
+    async fn receiver_intent_updates_transport_route_activity() {
+        let (
+            room,
+            media_transport,
+            publisher_id,
+            publisher_connection_id,
+            subscriber_id,
+            subscriber_connection_id,
+        ) = setup_subscription_room(true).await;
+        let stream_id = stream_id_for_source(TestSourceKind::ScalableVideo);
+        let source_media_id = publish_scalable_video(
+            &room,
+            &media_transport,
+            &publisher_id,
+            publisher_connection_id,
+        )
+        .await;
+
+        assert_eq!(
+            destination_active(&media_transport, source_media_id, &subscriber_id).await,
+            Some(true)
+        );
+        assert_eq!(
+            room.user_operation(&subscriber_id, subscriber_connection_id, &media_transport)
+                .update_subscription(&publisher_id, &pause_scalable_video_intents())
+                .await,
+            SubscriptionUpdateOutcome::Applied
+        );
+        assert_eq!(
+            room.state
+                .read()
+                .await
+                .consumer_route_state(&subscriber_id, &publisher_id, &stream_id,),
+            Some(ConsumerRouteState::Inactive)
+        );
+        assert_eq!(
+            destination_active(&media_transport, source_media_id, &subscriber_id).await,
+            Some(false)
+        );
+
+        assert_eq!(
+            room.user_operation(&subscriber_id, subscriber_connection_id, &media_transport)
+                .update_subscription(&publisher_id, &active_scalable_video_intents())
+                .await,
+            SubscriptionUpdateOutcome::Applied
+        );
+        assert_eq!(
+            room.state
+                .read()
+                .await
+                .consumer_route_state(&subscriber_id, &publisher_id, &stream_id,),
+            Some(ConsumerRouteState::Active)
+        );
+        assert_eq!(
+            destination_active(&media_transport, source_media_id, &subscriber_id).await,
+            Some(true)
         );
     }
 


### PR DESCRIPTION
Room transitions currently build post-lock effects through multiple local plans, which makes publication and subscription cleanup harder to follow and keeps duplicate execution paths alive.

This refactor replaces the scattered transition effect plans with one RoomCommit executor input for membership, publication and subscription work. The room transition code now captures committed facts once, then executes transport cleanup, relay effects, route activity, consumer bootstrap, diagnostics and outbound requests through the same room effect boundary.