### PR TITLE
[REF] core: store committed routing sessions together

### DIFF
--- a/crates/core/src/engine/room/manager/mod.rs
+++ b/crates/core/src/engine/room/manager/mod.rs
@@ -409,8 +409,8 @@ impl RoomManager {
         })?;
         Ok(RoomUserAdmission {
             room,
-            connection_id: routing_receipt.connection_id(),
-            transport_session_key: routing_receipt.transport_session_key().clone(),
+            connection_id: routing_receipt.connection_id,
+            transport_session_key: routing_receipt.transport_session_key,
         })
     }
 

--- a/crates/core/src/engine/room/media_graph/mod.rs
+++ b/crates/core/src/engine/room/media_graph/mod.rs
@@ -24,6 +24,8 @@ mod route_graph_tests;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+pub(super) use self::subscription::ConsumerSetupProducerSnapshot;
 pub use self::subscription::{ConsumerRouteState, RemoteTrackSetup};
 pub(super) use self::{
     ids::{ConsumerRuntimeId, ProducerRuntimeId},

--- a/crates/core/src/engine/room/membership.rs
+++ b/crates/core/src/engine/room/membership.rs
@@ -348,7 +348,9 @@ impl Room {
                         });
                     let state_outcome = state.apply_leave(user_id, connection_id);
                     if state_outcome.is_none() {
-                        state.routing.unregister_committed_placement(connection_id);
+                        state
+                            .routing
+                            .unregister_committed_placement(user_id, connection_id);
                     }
                     UserTransitionOutcome::Close {
                         state_outcome,
@@ -469,8 +471,8 @@ impl Room {
             transport_cleanup,
             relay_effects,
         } = outcome;
-        let connection_id = routing_receipt.connection_id();
-        let media_worker_id = routing_receipt.transport_session_key().media_worker_id();
+        let connection_id = routing_receipt.connection_id;
+        let media_worker_id = routing_receipt.transport_session_key.media_worker_id();
         RoomCommit::new()
             .with_user_count_delta(count_delta.users_before, count_delta.users_after)
             .with_media_count_delta(count_delta.media_before, count_delta.media_after)

--- a/crates/core/src/engine/room/placement.rs
+++ b/crates/core/src/engine/room/placement.rs
@@ -251,10 +251,6 @@ impl ResolvedPlacement {
         Self(placement)
     }
 
-    pub const fn router(self) -> RouterId {
-        self.0.router
-    }
-
     pub const fn into_context(self) -> LocalRouterRuntimeContext {
         self.0
     }

--- a/crates/core/src/engine/room/routing/mod.rs
+++ b/crates/core/src/engine/room/routing/mod.rs
@@ -128,25 +128,41 @@ impl RoutedConsumerId {
     }
 }
 
-/// committed room-local routing over one or more pure router instances
 #[derive(Debug, Clone)]
 pub(super) struct RoomRoutingState {
     instance_id: RoomInstanceId,
     primary_router: RouterId,
     local_routers: Option<LocalRoomRouterPlacements>,
-    placement_by_connection: BTreeMap<ConnectionId, LocalRouterRuntimeContext>,
     router_state_factory: RoomRouterStateFactory,
     routers: BTreeMap<RouterId, RoomRouterState>,
-    session_home_router: BTreeMap<UserId, RouterId>,
-    session_seed_by_user: BTreeMap<UserId, u64>,
+    sessions: CommittedSessionPlacements,
     shadow_sessions: ShadowSessionTracker,
 }
 
-/// placement data returned by a committed join transition
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct CommittedRoutingReceipt {
+    pub(super) connection_id: ConnectionId,
+    pub(super) transport_session_key: TransportSessionKey,
+}
+
+#[derive(Debug)]
+pub(super) struct DisplacedRoutingSession {
+    pub(super) connection_id: ConnectionId,
+    pub(super) transport_session_key: TransportSessionKey,
+}
+
+#[derive(Debug, Clone)]
+struct CommittedSessionPlacement {
     connection_id: ConnectionId,
+    router_session_seed: u64,
+    runtime: LocalRouterRuntimeContext,
     transport_session_key: TransportSessionKey,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CommittedSessionPlacements {
+    by_connection: BTreeMap<ConnectionId, CommittedSessionPlacement>,
+    active_connection_by_user: BTreeMap<UserId, ConnectionId>,
 }
 
 #[derive(Clone)]
@@ -181,13 +197,26 @@ impl RoomRouterStateFactory {
     }
 }
 
-impl CommittedRoutingReceipt {
-    pub(super) const fn connection_id(&self) -> ConnectionId {
-        self.connection_id
+impl CommittedSessionPlacements {
+    fn active(&self, user_id: &UserId) -> Option<&CommittedSessionPlacement> {
+        let connection_id = self.active_connection_by_user.get(user_id)?;
+        self.by_connection.get(connection_id)
     }
 
-    pub(super) const fn transport_session_key(&self) -> &TransportSessionKey {
-        &self.transport_session_key
+    fn insert(&mut self, user_id: UserId, session: CommittedSessionPlacement) {
+        let connection_id = session.connection_id;
+        if let Some(previous) = self
+            .active_connection_by_user
+            .insert(user_id, connection_id)
+        {
+            self.by_connection.remove(&previous);
+        }
+        self.by_connection.insert(connection_id, session);
+    }
+
+    fn remove(&mut self, user_id: &UserId) -> Option<CommittedSessionPlacement> {
+        let connection_id = self.active_connection_by_user.remove(user_id)?;
+        self.by_connection.remove(&connection_id)
     }
 }
 
@@ -208,11 +237,9 @@ impl RoomRoutingState {
             instance_id,
             primary_router: primary_router_id,
             local_routers,
-            placement_by_connection: BTreeMap::new(),
             router_state_factory: router_state_factory.clone(),
             routers,
-            session_home_router: BTreeMap::new(),
-            session_seed_by_user: BTreeMap::new(),
+            sessions: CommittedSessionPlacements::default(),
             shadow_sessions: ShadowSessionTracker::default(),
         }
     }
@@ -230,13 +257,8 @@ impl RoomRoutingState {
         user_id: &UserId,
         connection_id: ConnectionId,
     ) -> Option<TransportSessionKey> {
-        let placement = self.placement_for_connection(connection_id)?;
-        Some(TransportSessionKey::new(
-            self.instance_id,
-            placement.media_worker,
-            connection_id,
-            user_id.clone(),
-        ))
+        let session = self.sessions.active(user_id)?;
+        (session.connection_id == connection_id).then(|| session.transport_session_key.clone())
     }
 
     #[must_use]
@@ -255,42 +277,57 @@ impl RoomRoutingState {
         session_key
     }
 
-    pub(super) fn register_committed_placement(
+    pub(super) fn commit_session_placement(
         &mut self,
         user_id: &UserId,
         connection_id: ConnectionId,
         placement: ResolvedPlacement,
-    ) -> CommittedRoutingReceipt {
+        affected_consumers: impl IntoIterator<Item = RoutedConsumerId>,
+    ) -> Result<(CommittedRoutingReceipt, Option<DisplacedRoutingSession>), RoomRoutingError> {
         let placement = placement.into_context();
-        match &mut self.local_routers {
-            Some(local_routers) => local_routers.upsert(placement),
-            None => {
-                self.local_routers = Some(LocalRoomRouterPlacements::new(placement, Vec::new()));
-            }
+        let displaced_session =
+            self.sessions
+                .active(user_id)
+                .map(|session| DisplacedRoutingSession {
+                    connection_id: session.connection_id,
+                    transport_session_key: session.transport_session_key.clone(),
+                });
+        if displaced_session.is_some() {
+            self.remove_session(user_id, affected_consumers)?;
         }
-        self.placement_by_connection
-            .insert(connection_id, placement);
+        self.attach_placement(placement);
+        let router_session_seed = connection_id.as_u64();
+        let router = self.router_mut_for_user(user_id, placement.router)?;
+        router.ensure_session(user_id, router_session_seed)?;
+        router.ensure_session_transports(user_id)?;
         let transport_session_key = TransportSessionKey::new(
             self.instance_id,
             placement.media_worker,
             connection_id,
             user_id.clone(),
         );
-        CommittedRoutingReceipt {
+        let session = CommittedSessionPlacement {
+            connection_id,
+            router_session_seed,
+            runtime: placement,
+            transport_session_key: transport_session_key.clone(),
+        };
+        let receipt = CommittedRoutingReceipt {
             connection_id,
             transport_session_key,
-        }
+        };
+        self.sessions.insert(user_id.clone(), session);
+        Ok((receipt, displaced_session))
     }
 
-    pub(super) fn unregister_committed_placement(&mut self, connection_id: ConnectionId) {
-        self.placement_by_connection.remove(&connection_id);
-    }
-
-    fn placement_for_connection(
-        &self,
+    pub(super) fn unregister_committed_placement(
+        &mut self,
+        user_id: &UserId,
         connection_id: ConnectionId,
-    ) -> Option<LocalRouterRuntimeContext> {
-        self.placement_by_connection.get(&connection_id).copied()
+    ) {
+        if self.sessions.active_connection_by_user.get(user_id) == Some(&connection_id) {
+            self.sessions.remove(user_id);
+        }
     }
 
     #[expect(
@@ -301,10 +338,10 @@ impl RoomRoutingState {
         &self,
         connection_id: ConnectionId,
     ) -> MediaWorkerId {
-        let Some(placement) = self.placement_for_connection(connection_id) else {
+        let Some(session) = self.sessions.by_connection.get(&connection_id) else {
             unreachable!("media worker lookup requires committed connection placement");
         };
-        placement.media_worker
+        session.runtime.media_worker
     }
 
     pub(super) fn assigned_primary_media_worker_id(&self) -> Option<MediaWorkerId> {
@@ -319,9 +356,10 @@ impl RoomRoutingState {
     )]
     pub(super) fn worker_lookup(&self) -> impl Fn(ConnectionId) -> MediaWorkerId + use<> {
         let media_worker_by_connection = self
-            .placement_by_connection
+            .sessions
+            .by_connection
             .iter()
-            .map(|(connection_id, placement)| (*connection_id, placement.media_worker))
+            .map(|(connection_id, session)| (*connection_id, session.runtime.media_worker))
             .collect::<BTreeMap<_, _>>();
         move |connection_id| {
             let Some(media_worker) = media_worker_by_connection.get(&connection_id).copied() else {
@@ -345,45 +383,19 @@ impl RoomRoutingState {
         )
     }
 
-    pub(super) fn ensure_session_transports(
-        &mut self,
-        user_id: &UserId,
-    ) -> Result<(), RoomRoutingError> {
-        let router_id = self.require_home_router_id(user_id)?;
-        self.router_mut_for_user(user_id, router_id)?
-            .ensure_session_transports(user_id)?;
-        Ok(())
-    }
-
-    pub(super) fn apply_client_join_on_placement(
-        &mut self,
-        user_id: &UserId,
-        router_session_seed: u64,
-        placement: ResolvedPlacement,
-    ) -> Result<(), RoomRoutingError> {
-        self.ensure_session_on_placement(user_id, router_session_seed, placement)?;
-        self.ensure_session_transports(user_id)?;
-        Ok(())
-    }
-
-    pub(super) fn replace_client_session_on_placement(
-        &mut self,
-        user_id: &UserId,
-        router_session_seed: u64,
-        placement: ResolvedPlacement,
-        affected_consumers: impl IntoIterator<Item = RoutedConsumerId>,
-    ) -> Result<(), RoomRoutingError> {
-        self.remove_session(user_id, affected_consumers)?;
-        self.apply_client_join_on_placement(user_id, router_session_seed, placement)
-    }
-
     #[cfg(test)]
     pub(super) fn primary_router_id(&self) -> RouterId {
         self.primary_router
     }
 
-    pub(super) fn attach_placement(&mut self, placement: ResolvedPlacement) {
-        let router_id = placement.router();
+    fn attach_placement(&mut self, placement: LocalRouterRuntimeContext) {
+        match &mut self.local_routers {
+            Some(local_routers) => local_routers.upsert(placement),
+            None => {
+                self.local_routers = Some(LocalRoomRouterPlacements::new(placement, Vec::new()));
+            }
+        }
+        let router_id = placement.router;
         if self.routers.contains_key(&router_id) {
             return;
         }
@@ -400,7 +412,7 @@ impl RoomRoutingState {
         user_id: &UserId,
         media_kind: RouterMediaKind,
     ) -> Result<RoutedProducerId, RoomRoutingError> {
-        let router_id = self.require_home_router_id(user_id)?;
+        let router_id = self.require_session(user_id)?.runtime.router;
         let producer_id = self
             .router_mut_for_user(user_id, router_id)?
             .add_producer(user_id, media_kind)?;
@@ -509,7 +521,7 @@ impl RoomRoutingState {
         user_id: &UserId,
         affected_consumers: impl IntoIterator<Item = RoutedConsumerId>,
     ) -> Result<(), RoomRoutingError> {
-        let home_router_id = self.require_home_router_id(user_id)?;
+        let home_router_id = self.require_session(user_id)?.runtime.router;
         if !self.routers.contains_key(&home_router_id) {
             return Err(RoomRoutingError::MissingRouterForSession {
                 user_id: user_id.clone(),
@@ -523,8 +535,7 @@ impl RoomRoutingState {
             .shadow_sessions
             .unregister_consumers(affected_consumers);
         self.prune_shadow_sessions(shadow_sessions)?;
-        self.session_home_router.remove(user_id);
-        self.session_seed_by_user.remove(user_id);
+        self.sessions.remove(user_id);
         Ok(())
     }
 
@@ -534,7 +545,10 @@ impl RoomRoutingState {
         affected_consumers: impl IntoIterator<Item = RoutedConsumerId>,
     ) -> RoomRoutingRepairReport {
         let mut report = RoomRoutingRepairReport::default();
-        match self.require_home_router_id(user_id) {
+        match self
+            .require_session(user_id)
+            .map(|session| session.runtime.router)
+        {
             Ok(home_router_id) if !self.routers.contains_key(&home_router_id) => {
                 report.record(RoomRoutingError::MissingRouterForSession {
                     user_id: user_id.clone(),
@@ -556,39 +570,19 @@ impl RoomRoutingState {
             .shadow_sessions
             .unregister_consumers(affected_consumers);
         self.prune_shadow_sessions_repairing(shadow_sessions, &mut report);
-        self.session_home_router.remove(user_id);
-        self.session_seed_by_user.remove(user_id);
+        self.sessions.remove(user_id);
         report
     }
 
-    fn require_home_router_id(&self, user_id: &UserId) -> Result<RouterId, RoomRoutingError> {
-        self.session_home_router
-            .get(user_id)
-            .copied()
+    fn require_session(
+        &self,
+        user_id: &UserId,
+    ) -> Result<&CommittedSessionPlacement, RoomRoutingError> {
+        self.sessions
+            .active(user_id)
             .ok_or_else(|| RoomRoutingError::MissingSessionPlacement {
                 user_id: user_id.clone(),
             })
-    }
-
-    fn ensure_session_on_placement(
-        &mut self,
-        user_id: &UserId,
-        router_session_seed: u64,
-        placement: ResolvedPlacement,
-    ) -> Result<(), RoomRoutingError> {
-        if let Some(router_id) = self.session_home_router.get(user_id).copied() {
-            let router = self.router_mut_for_user(user_id, router_id)?;
-            router.ensure_session(user_id, router_session_seed)?;
-            return Ok(());
-        }
-        let router_id = placement.router();
-        self.attach_placement(placement);
-        let router = self.router_mut_for_user(user_id, router_id)?;
-        router.ensure_session(user_id, router_session_seed)?;
-        self.session_home_router.insert(user_id.clone(), router_id);
-        self.session_seed_by_user
-            .insert(user_id.clone(), router_session_seed);
-        Ok(())
     }
 
     /// create a receiver shadow when the source router differs from the home router
@@ -597,12 +591,9 @@ impl RoomRoutingState {
         user_id: &UserId,
         router_id: RouterId,
     ) -> Result<ReceiverRouterSession, RoomRoutingError> {
-        let Some(router_session_seed) = self.session_seed_by_user.get(user_id).copied() else {
-            return Err(RoomRoutingError::MissingSessionPlacement {
-                user_id: user_id.clone(),
-            });
-        };
-        let home_router_id = self.require_home_router_id(user_id)?;
+        let session = self.require_session(user_id)?;
+        let router_session_seed = session.router_session_seed;
+        let home_router_id = session.runtime.router;
         let shadow_key = (home_router_id != router_id)
             .then(|| ShadowSessionKey::new(router_id, user_id.clone()));
         if !self.routers.contains_key(&router_id) {
@@ -661,9 +652,10 @@ impl RoomRoutingState {
 
     pub(in crate::engine::room) fn idle_spillover_routers(&self) -> Vec<RouterId> {
         let active_home_routers = self
-            .session_home_router
+            .sessions
+            .by_connection
             .values()
-            .copied()
+            .map(|session| session.runtime.router)
             .collect::<BTreeSet<_>>();
         self.routers
             .iter()

--- a/crates/core/src/engine/room/routing/test_support.rs
+++ b/crates/core/src/engine/room/routing/test_support.rs
@@ -35,7 +35,7 @@ impl RoomRoutingState {
 
     #[cfg(test)]
     pub fn user_count(&self) -> u64 {
-        u64::try_from(self.session_home_router.len()).unwrap_or(u64::MAX)
+        u64::try_from(self.sessions.active_connection_by_user.len()).unwrap_or(u64::MAX)
     }
 
     pub fn router_count(&self) -> usize {
@@ -50,7 +50,9 @@ impl RoomRoutingState {
     }
 
     pub fn home_router_id_for_user(&self, user_id: &UserId) -> Option<RouterId> {
-        self.session_home_router.get(user_id).copied()
+        self.sessions
+            .active(user_id)
+            .map(|session| session.runtime.router)
     }
 
     #[cfg(test)]
@@ -60,7 +62,7 @@ impl RoomRoutingState {
 
     #[cfg(test)]
     pub fn remove_session_mapping_for_test(&mut self, user_id: &UserId) {
-        let Some(router_id) = self.session_home_router.get(user_id).copied() else {
+        let Some(router_id) = self.home_router_id_for_user(user_id) else {
             return;
         };
         let Some(router) = self.routers.get_mut(&router_id) else {
@@ -71,7 +73,7 @@ impl RoomRoutingState {
 
     #[cfg(test)]
     pub fn remove_transport_mapping_for_test(&mut self, user_id: &UserId) {
-        let Some(router_id) = self.session_home_router.get(user_id).copied() else {
+        let Some(router_id) = self.home_router_id_for_user(user_id) else {
             return;
         };
         let Some(router) = self.routers.get_mut(&router_id) else {

--- a/crates/core/src/engine/room/state/membership/mod.rs
+++ b/crates/core/src/engine/room/state/membership/mod.rs
@@ -27,9 +27,9 @@ use super::{
         BroadcastPayload, BroadcastPayloadError, ResolvedPlacement, RoomEventMessage,
         RoomJoinError, RoomUserPermissions, UserCloseReason,
         cleanup::TransportCleanupOperation,
-        media_graph::{ResolvedRelayRouteEffect, TransportMediaRemoval},
+        media_graph::ResolvedRelayRouteEffect,
         outbound::{MessageFanout, OutboundSender},
-        routing::CommittedRoutingReceipt,
+        routing::{CommittedRoutingReceipt, DisplacedRoutingSession},
         user_negotiation::{UserNegotiation, UserNegotiationUpdate},
     },
     shared::{ActiveUser, RoomState},
@@ -176,34 +176,47 @@ impl RoomState {
         connection_id: ConnectionId,
         is_new: bool,
         home_placement: ResolvedPlacement,
-    ) -> Result<CommittedRoutingReceipt, RoomJoinError> {
+    ) -> Result<(CommittedRoutingReceipt, Option<DisplacedRoutingSession>), RoomJoinError> {
+        if !is_new {
+            let Some(previous_connection) = self.users.get(user_id).map(|user| user.connection_id)
+            else {
+                error!(
+                    ?user_id,
+                    "missing previous room user for replacement join routing"
+                );
+                return Err(RoomJoinError::RouterState);
+            };
+            if self
+                .routing
+                .committed_transport_user_key(user_id, previous_connection)
+                .is_none()
+            {
+                error!(
+                    ?user_id,
+                    connection_id = ?previous_connection,
+                    "missing committed routing session for replacement join"
+                );
+                return Err(RoomJoinError::RouterState);
+            }
+        }
         let mut routing = self.routing.clone();
         let affected_consumers = if is_new {
             Vec::new()
         } else {
             self.media.routed_consumer_ids_affected_by_user(user_id)
         };
-        let routing_result = if is_new {
-            routing.apply_client_join_on_placement(user_id, connection_id.as_u64(), home_placement)
-        } else {
-            routing.replace_client_session_on_placement(
-                user_id,
-                connection_id.as_u64(),
-                home_placement,
-                affected_consumers,
-            )
-        };
-        if let Err(error) = routing_result {
-            error!(
-                ?user_id,
-                ?error,
-                "failed to mirror user join into room router"
-            );
-            return Err(RoomJoinError::RouterState);
-        }
-        let receipt = routing.register_committed_placement(user_id, connection_id, home_placement);
+        let commit = routing
+            .commit_session_placement(user_id, connection_id, home_placement, affected_consumers)
+            .map_err(|error| {
+                error!(
+                    ?user_id,
+                    ?error,
+                    "failed to mirror user join into room router"
+                );
+                RoomJoinError::RouterState
+            })?;
         self.routing = routing;
-        Ok(receipt)
+        Ok(commit)
     }
 
     #[cfg(test)]
@@ -212,17 +225,6 @@ impl RoomState {
             router: self.routing.primary_router_id(),
             media_worker: MediaWorkerId::from_raw(0),
         })
-    }
-
-    fn join_transport_removals(
-        &self,
-        user_id: &UserId,
-        is_new: bool,
-    ) -> Vec<TransportMediaRemoval> {
-        if is_new {
-            return Vec::new();
-        }
-        self.collect_user_transport_removals(&BTreeSet::from([user_id.clone()]))
     }
 
     fn install_joined_session(
@@ -305,17 +307,25 @@ impl RoomState {
             return Err(RoomJoinError::RoomFull);
         }
         let connection_id = ConnectionId::allocate(&mut self.next_connection_id);
-        let routing_receipt =
+        let (routing_receipt, displaced_session) =
             self.apply_join_routing(user_id, connection_id, is_new, home_placement)?;
-        let transport_cleanup =
-            self.transport_cleanup_operations(self.join_transport_removals(user_id, is_new));
+        let transport_cleanup = displaced_session.as_ref().map_or_else(Vec::new, |session| {
+            vec![TransportCleanupOperation::CloseUser {
+                session_key: session.transport_session_key.clone(),
+                connection_id: session.connection_id,
+            }]
+        });
 
         let previous_sender =
             self.install_joined_session(user_id, label, permissions, sender, connection_id);
         let had_previous_sender = previous_sender.is_some();
         let relay_effects = if had_previous_sender {
             let relay_effects = self.purge_user_media_state(user_id);
-            self.resolved_relay_route_effects(relay_effects)
+            if let Some(session) = displaced_session.as_ref() {
+                self.resolved_relay_route_effects_with_displaced(relay_effects, user_id, session)
+            } else {
+                self.resolved_relay_route_effects(relay_effects)
+            }
         } else {
             Vec::new()
         };
@@ -373,6 +383,8 @@ impl RoomState {
             self.collect_user_transport_removals(&departing_user_ids),
         );
         let affected_consumers = self.media.routed_consumer_ids_affected_by_user(user_id);
+        let relay_effects = self.purge_user_media_state(user_id);
+        let relay_effects = self.resolved_relay_route_effects(relay_effects);
         let topology_repair = self
             .routing
             .remove_session_repairing(user_id, affected_consumers);
@@ -383,12 +395,7 @@ impl RoomState {
                 "repaired user topology during room teardown"
             );
         }
-        let relay_effects = self.purge_user_media_state(user_id);
-        Some((
-            user,
-            transport_cleanup,
-            self.resolved_relay_route_effects(relay_effects),
-        ))
+        Some((user, transport_cleanup, relay_effects))
     }
 
     /// commit a leave for one current runtime connection
@@ -406,7 +413,6 @@ impl RoomState {
             return None;
         }
         let (user, transport_cleanup, relay_effects) = self.remove_runtime_user(user_id)?;
-        self.routing.unregister_committed_placement(connection_id);
         Some(LeaveUserOutcome {
             effects: LifecycleEffects {
                 close_requests: vec![UserCloseRequest {
@@ -496,17 +502,18 @@ impl RoomState {
         let mut fanouts = Vec::new();
         let mut relay_effects = Vec::new();
         for user_id in user_ids {
+            let Some(connection_id) = self.users.get(user_id).map(|user| user.connection_id) else {
+                continue;
+            };
+            let close_operation = TransportCleanupOperation::CloseUser {
+                session_key: self.transport_user_key(user_id, connection_id),
+                connection_id,
+            };
             let Some((user, user_transport_cleanup, user_relay_effects)) =
                 self.remove_runtime_user(user_id)
             else {
                 continue;
             };
-            let connection_id = user.connection_id;
-            let close_operation = TransportCleanupOperation::CloseUser {
-                session_key: self.transport_user_key(user_id, connection_id),
-                connection_id,
-            };
-            self.routing.unregister_committed_placement(connection_id);
             transport_cleanup.extend(user_transport_cleanup);
             relay_effects.extend(user_relay_effects);
             disconnected_users.push(DisconnectedUser {

--- a/crates/core/src/engine/room/state/membership/tests.rs
+++ b/crates/core/src/engine/room/state/membership/tests.rs
@@ -8,21 +8,25 @@
 
 use std::{slice::from_ref, sync::Arc};
 
-use o_sfu_router::{ConsumerId, MediaKind, MediaStream, ProducerId, RouterId};
+use o_sfu_router::{
+    ConsumerId, MediaKind, MediaStream, ProducerId, RouterId,
+    test_support::rtp_samples::{sample_client_rtp_capabilities, sample_video_rtp_parameters},
+};
 
 use super::*;
 use crate::{
     MediaCodecFlags, RoomMediaLimits,
     engine::{
         ConnectionId, MediaWorkerId, RoomInstanceId, TestSourceKind, UserPermissions,
-        media_transport::TransportMediaId,
+        media_transport::{TransportMediaId, TransportRelayRouteAction, TransportSessionKey},
         metrics::RuntimeMetrics,
         packet_sink_registry::RoomPacketSinkRegistry,
         recording::RecordingService,
         room::{
             LocalRouterRuntimeContext, RoomAdmissionPolicy, RoomRuntimeContext, UserOutboundSender,
             media_graph::{
-                ConsumerKey, ConsumerState, ProducerRuntimeId, PublishedProducer,
+                ConsumerKey, ConsumerSetupCommitOutcome, ConsumerSetupProducerSnapshot,
+                ConsumerSetupTarget, ConsumerState, ProducerRuntimeId, PublishedProducer,
                 PublishedSourceInstall,
             },
             routing::{RoutedConsumerId, RoutedProducerId},
@@ -71,6 +75,7 @@ fn install_test_published_producer(
     stream_type: TestSourceKind,
     routed_producer_id: RoutedProducerId,
     transport_media_id: TransportMediaId,
+    consumable_rtp_parameters: MediaStream,
 ) -> (ProducerRuntimeId, PublishedSourceId) {
     let producer_id = ProducerRuntimeId::allocate(&mut state.next_producer_id);
     let source_id = PublishedSourceId::allocate(&mut state.next_source_id);
@@ -109,7 +114,7 @@ fn install_test_published_producer(
             owner_connection_id: connection_id,
             stream_id: stream_id_for_source(stream_type),
             media_kind: MediaKind::Video,
-            consumable_rtp_parameters: MediaStream::new(vec![], vec![], vec![]),
+            consumable_rtp_parameters,
             routed_producer_id,
             transport_media_id: Some(transport_media_id),
             active: true,
@@ -117,6 +122,120 @@ fn install_test_published_producer(
         transport_media_id,
     });
     (producer_id, source_id)
+}
+
+#[derive(Debug)]
+struct RelayedSource {
+    publisher: UserId,
+    publisher_connection: ConnectionId,
+    publisher_session: TransportSessionKey,
+    source_media: TransportMediaId,
+}
+
+fn install_relayed_source(state: &mut RoomState) -> RelayedSource {
+    let publisher = UserId::Integer(1);
+    let subscriber = UserId::Integer(2);
+    assert!(
+        state
+            .apply_join(
+                &publisher,
+                None,
+                UserPermissions::default(),
+                test_sender(),
+                false,
+            )
+            .is_ok()
+    );
+    assert!(
+        state
+            .apply_join(
+                &subscriber,
+                None,
+                UserPermissions::default(),
+                test_sender(),
+                false,
+            )
+            .is_ok()
+    );
+    let publisher_connection = state
+        .user_connection_id(&publisher)
+        .expect("publisher should be joined");
+    let subscriber_connection = state
+        .user_connection_id(&subscriber)
+        .expect("subscriber should be joined");
+    assert!(
+        state
+            .set_user_negotiated(
+                &subscriber,
+                subscriber_connection,
+                sample_client_rtp_capabilities()
+            )
+            .is_some()
+    );
+    let publisher_session = state.transport_user_key(&publisher, publisher_connection);
+    let source_media = TransportMediaId::new(11);
+    let consumer_media = TransportMediaId::new(21);
+    let routed_producer_id = state
+        .routing
+        .add_producer(&publisher, MediaKind::Video)
+        .expect("relayed source producer route should be added");
+    let (producer_id, source_id) = install_test_published_producer(
+        state,
+        &publisher,
+        publisher_connection,
+        TestSourceKind::ScalableVideo,
+        routed_producer_id,
+        source_media,
+        sample_video_rtp_parameters(None, 77_777),
+    );
+    let target = {
+        let producer = state
+            .media
+            .producer_for_source(source_id)
+            .expect("relayed source producer should exist");
+        ConsumerSetupTarget::new(
+            subscriber,
+            subscriber_connection,
+            ConsumerSetupProducerSnapshot::from_producer(producer_id, producer, source_media),
+        )
+    };
+    let mut setups = state.plan_consumers(vec![target], |connection| {
+        if connection == subscriber_connection {
+            MediaWorkerId::from_raw(1)
+        } else {
+            MediaWorkerId::from_raw(0)
+        }
+    });
+    let setup = setups
+        .pop()
+        .expect("relay consumer setup should be planned");
+    assert!(setups.is_empty());
+    assert!(
+        setup
+            .relay_effects()
+            .iter()
+            .any(|effect| effect.action == TransportRelayRouteAction::Install)
+    );
+    assert!(matches!(
+        state.commit_consumer_setup(setup, consumer_media, None),
+        ConsumerSetupCommitOutcome::Committed(_)
+    ));
+    RelayedSource {
+        publisher,
+        publisher_connection,
+        publisher_session,
+        source_media,
+    }
+}
+
+fn has_source_relay_release(effects: &[ResolvedRelayRouteEffect], relay: &RelayedSource) -> bool {
+    effects.iter().any(|effect| {
+        effect.source_session_key == relay.publisher_session
+            && effect.route.source_user == relay.publisher
+            && effect.route.source_connection == relay.publisher_connection
+            && effect.route.source_media == relay.source_media
+            && effect.action == TransportRelayRouteAction::Release
+    })
 }
 
 #[test]
@@ -243,6 +362,7 @@ fn leave_removes_consumer_routes_for_departed_session() {
         TestSourceKind::ScalableVideo,
         routed_producer_id,
         TransportMediaId::new(11),
+        MediaStream::new(vec![], vec![], vec![]),
     );
     let consumer_key = ConsumerKey::new(&UserId::Integer(2), source_id);
     assert!(state.media.commit_consumer(
@@ -352,6 +472,7 @@ fn replacement_join_clears_transport_media_owner_index() {
         TestSourceKind::ScalableVideo,
         routed_producer_id,
         transport_media_id,
+        MediaStream::new(vec![], vec![], vec![]),
     );
 
     assert_eq!(
@@ -393,4 +514,61 @@ fn replacement_join_clears_transport_media_owner_index() {
             )
             .is_none()
     );
+}
+
+#[test]
+fn replacement_join_releases_relay_with_displaced_source_session() {
+    let mut state = test_state();
+    let relay = install_relayed_source(&mut state);
+
+    let outcome = state
+        .apply_join(
+            &relay.publisher,
+            Some(String::from("replacement")),
+            UserPermissions::default(),
+            test_sender(),
+            false,
+        )
+        .expect("replacement join should succeed");
+
+    assert!(has_source_relay_release(&outcome.relay_effects, &relay));
+    assert!(outcome.transport_cleanup.iter().any(|operation| {
+        matches!(
+            operation,
+            TransportCleanupOperation::CloseUser {
+                session_key,
+                connection_id,
+            } if session_key == &relay.publisher_session
+                && *connection_id == relay.publisher_connection
+        )
+    }));
+    assert!(!outcome.transport_cleanup.iter().any(|operation| {
+        matches!(
+            operation,
+            TransportCleanupOperation::RemoveMedia { session_key, .. }
+                if session_key == &relay.publisher_session
+        )
+    }));
+}
+
+#[test]
+fn leave_releases_relay_before_forgetting_source_session() {
+    let mut state = test_state();
+    let relay = install_relayed_source(&mut state);
+
+    let outcome = state
+        .apply_leave(&relay.publisher, relay.publisher_connection)
+        .expect("publisher leave should succeed");
+
+    assert!(has_source_relay_release(&outcome.relay_effects, &relay));
+}
+
+#[test]
+fn disconnect_releases_relay_before_forgetting_source_session() {
+    let mut state = test_state();
+    let relay = install_relayed_source(&mut state);
+
+    let outcome = state.apply_disconnect_users(from_ref(&relay.publisher));
+
+    assert!(has_source_relay_release(&outcome.relay_effects, &relay));
 }

--- a/crates/core/src/engine/room/state/shared.rs
+++ b/crates/core/src/engine/room/state/shared.rs
@@ -13,7 +13,7 @@ use super::super::{
         RoomMediaGraph, TransportMediaRemoval,
     },
     outbound::OutboundSender,
-    routing::{RoomRouterStateFactory, RoomRoutingState},
+    routing::{DisplacedRoutingSession, RoomRouterStateFactory, RoomRoutingState},
     user_negotiation::UserNegotiation,
 };
 use crate::{
@@ -247,6 +247,34 @@ impl RoomState {
                     .transport_user_key(&effect.route.source_user, effect.route.source_connection),
                 route: effect.route,
                 action: effect.action,
+            })
+            .collect()
+    }
+
+    pub(super) fn resolved_relay_route_effects_with_displaced(
+        &self,
+        effects: impl IntoIterator<Item = RelayRouteEffect>,
+        user_id: &UserId,
+        session: &DisplacedRoutingSession,
+    ) -> Vec<ResolvedRelayRouteEffect> {
+        effects
+            .into_iter()
+            .map(|effect| {
+                let source_session_key = if effect.route.source_user == *user_id
+                    && effect.route.source_connection == session.connection_id
+                {
+                    session.transport_session_key.clone()
+                } else {
+                    self.transport_user_key(
+                        &effect.route.source_user,
+                        effect.route.source_connection,
+                    )
+                };
+                ResolvedRelayRouteEffect {
+                    source_session_key,
+                    route: effect.route,
+                    action: effect.action,
+                }
             })
             .collect()
     }

--- a/crates/core/src/engine/room/tests/api/lifecycle.rs
+++ b/crates/core/src/engine/room/tests/api/lifecycle.rs
@@ -46,7 +46,7 @@ impl RoomTestLifecycle<'_> {
                 || RouterId(0),
             )
             .await
-            .map(|receipt| receipt.connection_id())
+            .map(|receipt| receipt.connection_id)
     }
 
     /// Join one user while keeping transport cleanup outside the lifecycle path.
@@ -79,7 +79,7 @@ impl RoomTestLifecycle<'_> {
                 || RouterId(0),
             )
             .await
-            .map(|receipt| receipt.connection_id())
+            .map(|receipt| receipt.connection_id)
     }
 
     pub async fn force_cleanup_retry_cycle(self, media_transport: &MediaTransport) {

--- a/crates/core/src/engine/room/tests/fixtures.rs
+++ b/crates/core/src/engine/room/tests/fixtures.rs
@@ -26,7 +26,7 @@ pub(super) use crate::{
     engine::{
         ConnectionId, TestSourceKind, UserId, UserPermissions, VideoLayoutIntent,
         media_transport::{
-            AppliedSessionAnswer, MediaTransport, TransportMediaId,
+            AppliedSessionAnswer, MediaTransport, TransportMediaId, TransportSessionHealth,
             test_support::{test_media_transport_builder, test_rtc_port_range},
         },
         metrics::{RuntimeMetrics, test_support::RuntimeMetricsSnapshotTestExt},

--- a/crates/core/src/engine/room/tests/membership_tests.rs
+++ b/crates/core/src/engine/room/tests/membership_tests.rs
@@ -128,6 +128,114 @@ async fn negotiated_session_rejects_stale_connection() {
 }
 
 #[tokio::test]
+async fn mismatched_stale_close_keeps_other_user_routing() {
+    let manager = RoomManager::for_test();
+    let room = manager
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
+        .await;
+    let alice_id = UserId::Integer(1);
+    let bob_id = UserId::Integer(2);
+    let (alice_tx, _alice_rx) = test_sender();
+    let (bob_tx, _bob_rx) = test_sender();
+    let alice_connection = join_user_with_sender(&room, alice_id.clone(), alice_tx).await;
+    let bob_connection = join_user_with_sender(&room, bob_id.clone(), bob_tx).await;
+
+    assert!(
+        !room
+            .remove_user_with_cleanup(
+                &alice_id,
+                bob_connection,
+                RoomEffectContext::state_only(None),
+            )
+            .await
+    );
+
+    let inspect = room.test_api().inspect();
+    assert_eq!(
+        inspect.user_connection_id(&alice_id).await,
+        Some(alice_connection)
+    );
+    assert_eq!(
+        inspect.user_connection_id(&bob_id).await,
+        Some(bob_connection)
+    );
+    assert!(
+        inspect
+            .routing_home_media_worker_id(&bob_id)
+            .await
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn replacement_join_closes_displaced_transport_user() {
+    let manager = RoomManager::for_test();
+    let room = manager
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
+        .await;
+    let media_transport = real_adapter();
+    let user_id = UserId::Integer(1);
+    let (first_tx, first_rx) = test_sender();
+    let first_admission = manager
+        .join_user(
+            room.uuid(),
+            JoinUserRequest {
+                user_id: user_id.clone(),
+                label: None,
+                permissions: UserPermissions::default(),
+                sender: first_tx,
+            },
+            &media_transport,
+        )
+        .await
+        .expect("first join should succeed");
+    let first_connection = first_admission.connection_id();
+    let first_key = first_admission.transport_session_key().clone();
+    media_transport
+        .create_initial_session_offer(&first_key)
+        .await
+        .expect("first transport user should create an offer");
+    media_transport
+        .test_api()
+        .set_session_transport_health(&first_key, TransportSessionHealth::Disconnected);
+    assert_eq!(
+        media_transport.session_transport_health(&first_key),
+        Some(TransportSessionHealth::Disconnected)
+    );
+    drop(first_rx);
+
+    let (second_tx, _second_rx) = test_sender();
+    let second_connection = manager
+        .join_user(
+            room.uuid(),
+            JoinUserRequest {
+                user_id: user_id.clone(),
+                label: None,
+                permissions: UserPermissions::default(),
+                sender: second_tx,
+            },
+            &media_transport,
+        )
+        .await
+        .expect("replacement join should succeed")
+        .connection_id();
+
+    assert_ne!(first_connection, second_connection);
+    assert_eq!(media_transport.session_transport_health(&first_key), None);
+    assert_eq!(
+        room.test_api().inspect().user_connection_id(&user_id).await,
+        Some(second_connection)
+    );
+    assert!(
+        room.test_api()
+            .inspect()
+            .routing_home_media_worker_id(&user_id)
+            .await
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn removing_publisher_clears_media_state_and_transport_routes() {
     let (room, media_transport, mut publisher_rx, mut subscriber_rx) =
         setup_two_ready_users().await;

--- a/crates/core/src/engine/room/tests/topology_tests.rs
+++ b/crates/core/src/engine/room/tests/topology_tests.rs
@@ -1,12 +1,15 @@
 use o_sfu_router::{ProducerId as RouterProducerId, RouterError};
 
 use super::fixtures::*;
-use crate::engine::{
-    MediaWorkerId,
-    room::{
-        LocalRoomRouterPlacements, LocalRoomRouterPlacementsError, LocalRouterRuntimeContext,
-        ResolvedPlacement,
-        routing::{RoomRoutingError, RoutedProducerId, router_state::RoomRouterStateError},
+use crate::{
+    ConnectionId,
+    engine::{
+        MediaWorkerId,
+        room::{
+            LocalRoomRouterPlacements, LocalRoomRouterPlacementsError, LocalRouterRuntimeContext,
+            ResolvedPlacement,
+            routing::{RoomRoutingError, RoutedProducerId, router_state::RoomRouterStateError},
+        },
     },
 };
 
@@ -20,30 +23,18 @@ fn placement(router: u64, media_worker: usize) -> LocalRouterRuntimeContext {
 fn join_on_router(
     topology: &mut RoomRoutingState,
     user_id: &UserId,
-    seed: u64,
+    connection_id_raw: u64,
     router: u64,
     media_worker: usize,
 ) -> Result<(), RoomRoutingError> {
-    topology.apply_client_join_on_placement(
-        user_id,
-        seed,
-        ResolvedPlacement::for_test(placement(router, media_worker)),
-    )
-}
-
-fn replace_on_router(
-    topology: &mut RoomRoutingState,
-    user_id: &UserId,
-    seed: u64,
-    router: u64,
-    media_worker: usize,
-) -> Result<(), RoomRoutingError> {
-    topology.replace_client_session_on_placement(
-        user_id,
-        seed,
-        ResolvedPlacement::for_test(placement(router, media_worker)),
-        [],
-    )
+    topology
+        .commit_session_placement(
+            user_id,
+            ConnectionId::from_raw(connection_id_raw),
+            ResolvedPlacement::for_test(placement(router, media_worker)),
+            [],
+        )
+        .map(|_| ())
 }
 
 #[test]
@@ -130,7 +121,7 @@ fn topology_replacement_rehomes_from_the_new_connection_seed() {
         Some(RouterId(9))
     );
 
-    assert!(replace_on_router(&mut topology, &user_id, 1, 10, 1).is_ok());
+    assert!(join_on_router(&mut topology, &user_id, 1, 10, 1).is_ok());
 
     assert_eq!(
         topology.home_router_id_for_user(&user_id),
@@ -406,7 +397,7 @@ fn topology_reports_missing_user_mapping_from_router_state() {
     topology.remove_transport_mapping_for_test(&user_id);
 
     assert_eq!(
-        topology.ensure_session_transports(&user_id),
+        topology.add_producer(&user_id, RouterMediaKind::Audio),
         Err(RoomRoutingError::RouterState(
             RoomRouterStateError::MissingSessionMapping { user_id }
         ))


### PR DESCRIPTION
room routing kept a user's placement, home router and router-session seed in separate maps. that made one committed session harder to reason about because callers had to trust that independent maps stayed synchronized across join, replacement and teardown paths

this change stores those facts in one committed session placement record owned by routing state. user and connection lookups now go through the same owner, which keeps transport key construction, worker lookup and session teardown aligned around one invariant