### PR TITLE
[REF] core: own consumer setup rollback in graph

### DIFF
--- a/crates/core/src/engine/room/effects/batch.rs
+++ b/crates/core/src/engine/room/effects/batch.rs
@@ -16,7 +16,7 @@ use crate::{
             Room, RoomMediaCounts, SourcePolicyEvent, TrackBindingUpdate, UserOutbound,
             cleanup::TransportCleanupOperation,
             media_graph::{
-                ConsumerRouteUpdate, ConsumerSetupOrigin, ConsumerSetupPlan,
+                ConsumerRouteUpdate, ConsumerSetupOrigin, PendingConsumerSetup,
                 ResolvedRelayRouteEffect,
             },
             outbound::OutboundSender,
@@ -274,7 +274,7 @@ impl RoomCommit {
 
     pub fn with_consumer_setups(
         mut self,
-        setups: Vec<ConsumerSetupPlan>,
+        setups: Vec<PendingConsumerSetup>,
         origin: ConsumerSetupOrigin,
     ) -> Self {
         self.consumer_setups.extend(

--- a/crates/core/src/engine/room/effects/consumer_setup.rs
+++ b/crates/core/src/engine/room/effects/consumer_setup.rs
@@ -12,19 +12,19 @@ use crate::engine::{
         Room, SourcePolicyEvent, UserOutbound,
         cleanup::TransportCleanupOperation,
         media_graph::{
-            ConsumerSetupCommitOutcome, ConsumerSetupOrigin, ConsumerSetupPlan, ConsumerSetupTarget,
+            ConsumerSetupOrigin, ConsumerSetupOutcome, ConsumerSetupTarget, PendingConsumerSetup,
         },
     },
 };
 
 #[derive(Debug)]
 pub(super) struct ConsumerSetupEffect {
-    setup: ConsumerSetupPlan,
+    setup: PendingConsumerSetup,
     origin: ConsumerSetupOrigin,
 }
 
 impl ConsumerSetupEffect {
-    pub(super) const fn new(setup: ConsumerSetupPlan, origin: ConsumerSetupOrigin) -> Self {
+    pub(super) const fn new(setup: PendingConsumerSetup, origin: ConsumerSetupOrigin) -> Self {
         Self { setup, origin }
     }
 
@@ -33,15 +33,17 @@ impl ConsumerSetupEffect {
         room: &Room,
         media_transport: &MediaTransport,
     ) -> Option<DiagnosticsEventData> {
-        if !execute_relay_route_effects(room, media_transport, self.setup.relay_effects()).await {
+        let relays = self.setup.transport_input().relays;
+        if !execute_relay_route_effects(room, media_transport, relays).await {
             release_failed_setup(room, self.setup, media_transport).await;
             return None;
         }
-        let target = self.setup.target().clone();
-        let activity = ConsumerActivity::from_active(self.setup.consumer_active());
+        let input = self.setup.transport_input();
+        let target = input.target.clone();
+        let activity = ConsumerActivity::from_active(input.active);
         let Some((route, mid)) = declare_consumer(
             &target,
-            self.setup.rtp(),
+            input.rtp,
             activity,
             self.origin,
             room,
@@ -55,8 +57,9 @@ impl ConsumerSetupEffect {
         let (before, outbound, after) = {
             let mut state = room.state.write().await;
             let before = state.media_counts();
-            let outbound =
-                state.commit_consumer_setup(self.setup, route.consumer_transport_media_id(), mid);
+            let outbound = self
+                .setup
+                .commit(&mut state, route.consumer_transport_media_id(), mid);
             let after = state.media_counts();
             drop(state);
             (before, outbound, after)
@@ -156,11 +159,11 @@ async fn finish(
     origin: ConsumerSetupOrigin,
     route: TransportConsumerRoute,
     delta: MediaCountDelta,
-    outcome: ConsumerSetupCommitOutcome,
+    outcome: ConsumerSetupOutcome,
 ) -> Option<DiagnosticsEventData> {
     let commit = match outcome {
-        ConsumerSetupCommitOutcome::Committed(commit) => commit,
-        ConsumerSetupCommitOutcome::Released(relays) => {
+        ConsumerSetupOutcome::Committed(commit) => commit,
+        ConsumerSetupOutcome::Released(relays) => {
             delta.record(room);
             execute_relay_route_effects(room, media_transport, &relays).await;
             room.handle_source_policy_event(
@@ -243,13 +246,13 @@ async fn sync_activity(
 
 async fn release_failed_setup(
     room: &Room,
-    setup: ConsumerSetupPlan,
+    setup: PendingConsumerSetup,
     media_transport: &MediaTransport,
 ) {
     let (before, after, relays) = {
         let mut state = room.state.write().await;
         let before = state.media_counts();
-        let relays = state.release_consumer_setup_plan(setup);
+        let relays = setup.release(&mut state);
         let after = state.media_counts();
         drop(state);
         (before, after, relays)

--- a/crates/core/src/engine/room/media_graph/mod.rs
+++ b/crates/core/src/engine/room/media_graph/mod.rs
@@ -32,8 +32,8 @@ pub(super) use self::{
     producer::ValidatedPublish,
     route_graph::{RelayRouteEffect, RelayRouteKey, ResolvedRelayRouteEffect},
     subscription::{
-        ConsumerRouteUpdate, ConsumerSetupCommitOutcome, ConsumerSetupOrigin, ConsumerSetupPlan,
-        ConsumerSetupTarget,
+        ConsumerRouteUpdate, ConsumerSetupOrigin, ConsumerSetupOutcome, ConsumerSetupTarget,
+        PendingConsumerSetup,
     },
 };
 

--- a/crates/core/src/engine/room/media_graph/route_graph.rs
+++ b/crates/core/src/engine/room/media_graph/route_graph.rs
@@ -28,7 +28,7 @@ type RelayOwners = BTreeMap<ConsumerKey, RelayRouteActivity>;
 struct RouteReservationId(u64);
 
 #[derive(Debug)]
-pub(in crate::engine::room) struct ConsumerRouteReservation {
+pub(super) struct ConsumerRouteReservation {
     key: ConsumerKey,
     selection: ConsumerSourceSelection,
     id: RouteReservationId,
@@ -442,11 +442,11 @@ impl RouteGraph {
 }
 
 impl ConsumerRouteReservation {
-    pub(in crate::engine::room) const fn key(&self) -> &ConsumerKey {
+    pub(super) const fn key(&self) -> &ConsumerKey {
         &self.key
     }
 
-    pub(in crate::engine::room) const fn selection(&self) -> ConsumerSourceSelection {
+    pub(super) const fn selection(&self) -> ConsumerSourceSelection {
         self.selection
     }
 }

--- a/crates/core/src/engine/room/media_graph/subscription.rs
+++ b/crates/core/src/engine/room/media_graph/subscription.rs
@@ -12,7 +12,7 @@ use super::{
         RoomEventRequest, outbound::OutboundSender, routing::RoutedProducerId, state::RoomState,
     },
     ConsumerKey, ConsumerRouteTransportRef, ConsumerRuntimeId, ConsumerState, ProducerRuntimeId,
-    PublishedProducer,
+    PublishedProducer, RoomMediaGraph,
     route_graph::{ConsumerRouteReservation, RelayRouteEffect, ResolvedRelayRouteEffect},
 };
 use crate::engine::{
@@ -52,7 +52,7 @@ pub struct ConsumerKeyframeRefreshTarget {
 #[derive(Debug, Default)]
 pub struct PlannedSubscriptionChange {
     updates: Vec<ConsumerRouteUpdate>,
-    setups: Vec<ConsumerSetupPlan>,
+    setups: Vec<PendingConsumerSetup>,
     relays: Vec<ResolvedRelayRouteEffect>,
 }
 
@@ -77,10 +77,10 @@ pub struct ConsumerSetupProducerSnapshot {
 }
 
 #[derive(Debug)]
-#[must_use = "consumer setup plans reserve route graph state and must be committed or released"]
-pub struct ConsumerSetupPlan {
+#[must_use = "pending consumer setups reserve route graph state and must be committed or released"]
+pub(in crate::engine::room) struct PendingConsumerSetup {
     target: ConsumerSetupTarget,
-    route_reservation: ConsumerRouteReservation,
+    reservation: ConsumerRouteReservation,
     sender: OutboundSender,
     track: RemoteTrackSetup,
     relays: Vec<ResolvedRelayRouteEffect>,
@@ -97,9 +97,16 @@ pub(in crate::engine::room) struct ConsumerSetupCommit {
     clippy::large_enum_variant,
     reason = "consumer setup outcomes are returned and matched immediately so boxing the committed setup would allocate on every successful consumer setup"
 )]
-pub(in crate::engine::room) enum ConsumerSetupCommitOutcome {
+pub(in crate::engine::room) enum ConsumerSetupOutcome {
     Committed(ConsumerSetupCommit),
     Released(Vec<ResolvedRelayRouteEffect>),
+}
+
+pub(in crate::engine::room) struct ConsumerSetupTransportInput<'a> {
+    pub target: &'a ConsumerSetupTarget,
+    pub rtp: &'a RouterRtpParameters,
+    pub active: bool,
+    pub relays: &'a [ResolvedRelayRouteEffect],
 }
 
 /// consumer track setup payload sent to the receiver after transport commit
@@ -130,6 +137,44 @@ impl ConsumerSetupOrigin {
             Self::Publish => "publish",
             Self::Subscribe => "subscribe",
         }
+    }
+}
+
+impl RoomMediaGraph {
+    fn reserve_pending_consumer_setup(
+        &mut self,
+        target: ConsumerSetupTarget,
+        sender: OutboundSender,
+        track: RemoteTrackSetup,
+        selection: ConsumerSourceSelection,
+        source_worker: MediaWorkerId,
+        target_worker: MediaWorkerId,
+    ) -> Option<(PendingConsumerSetup, Vec<RelayRouteEffect>)> {
+        let key = ConsumerKey::new(&target.user, target.source_id());
+        let active = selection.delivery_active();
+        let reservation = self.routes.reserve_consumer_setup(key, selection)?;
+        let relay_effects = if source_worker == target_worker {
+            Vec::new()
+        } else {
+            self.routes.reserve_relay(
+                &reservation,
+                &target,
+                target.producer_connection_id(),
+                target.transport_media_id(),
+                target_worker,
+                active,
+            )
+        };
+        Some((
+            PendingConsumerSetup {
+                target,
+                reservation,
+                sender,
+                track,
+                relays: Vec::new(),
+            },
+            relay_effects,
+        ))
     }
 }
 
@@ -190,7 +235,7 @@ impl RoomState {
         user_id: &UserId,
         connection_id: ConnectionId,
         worker_for: impl Fn(ConnectionId) -> MediaWorkerId,
-    ) -> Option<Vec<ConsumerSetupPlan>> {
+    ) -> Option<Vec<PendingConsumerSetup>> {
         let user = self.users.get(user_id)?;
         if user.connection_id != connection_id {
             return None;
@@ -205,7 +250,7 @@ impl RoomState {
         &mut self,
         targets: Vec<ConsumerSetupTarget>,
         worker_for: impl Fn(ConnectionId) -> MediaWorkerId,
-    ) -> Vec<ConsumerSetupPlan> {
+    ) -> Vec<PendingConsumerSetup> {
         let mut targets = targets;
         let active_speakers = BTreeSet::new();
         targets.sort_by_key(|target| self.setup_rank(target, &active_speakers));
@@ -368,7 +413,7 @@ impl RoomState {
         &mut self,
         target: ConsumerSetupTarget,
         worker_for: &impl Fn(ConnectionId) -> MediaWorkerId,
-    ) -> Option<ConsumerSetupPlan> {
+    ) -> Option<PendingConsumerSetup> {
         let (sender, client_caps) = {
             let user = self.users.get(&target.user)?;
             if user.connection_id != target.connection || !user.negotiation.can_consume() {
@@ -387,30 +432,11 @@ impl RoomState {
             &producer.consumable_rtp_parameters
         };
         let descriptor = self.media.source(target.producer.source_id)?.clone();
-        let key = ConsumerKey::new(&target.user, target.source_id());
-        if self.media.has_consumer_setup_or_route(&key) {
-            return None;
-        }
         let selection = self.setup_selection(&target, target.producer.active);
-        let active = selection.delivery_active();
         let rtp = negotiate_consumer_rtp_parameters(producer_rtp, client_caps).ok()?;
-        let route_reservation = self.media.routes.reserve_consumer_setup(key, selection)?;
         let consumer = ConsumerRuntimeId::allocate(&mut self.next_consumer_id);
         let source_worker = worker_for(target.producer_connection_id());
         let target_worker = worker_for(target.consumer_connection_id());
-        let relays = if source_worker == target_worker {
-            Vec::new()
-        } else {
-            self.media.routes.reserve_relay(
-                &route_reservation,
-                &target,
-                target.producer_connection_id(),
-                target.transport_media_id(),
-                target_worker,
-                active,
-            )
-        };
-        let relays = self.resolved_relay_route_effects(relays);
         let track = RemoteTrackSetup {
             consumer,
             kind: target.producer.kind,
@@ -424,13 +450,16 @@ impl RoomState {
             active: target.producer.active,
             stream: target.producer.stream.clone(),
         };
-        Some(ConsumerSetupPlan {
+        let (mut setup, relay_effects) = self.media.reserve_pending_consumer_setup(
             target,
-            route_reservation,
             sender,
             track,
-            relays,
-        })
+            selection,
+            source_worker,
+            target_worker,
+        )?;
+        setup.relays = self.resolved_relay_route_effects(relay_effects);
+        Some(setup)
     }
 
     fn setup_selection(
@@ -503,114 +532,6 @@ impl RoomState {
             })
             .count();
         committed + pending
-    }
-
-    pub fn commit_consumer_setup(
-        &mut self,
-        setup: ConsumerSetupPlan,
-        media: TransportMediaId,
-        mid: Option<String>,
-    ) -> ConsumerSetupCommitOutcome {
-        let ConsumerSetupPlan {
-            target,
-            route_reservation,
-            sender,
-            mut track,
-            ..
-        } = setup;
-        let planned_selection = route_reservation.selection();
-        let Some(user) = self.users.get(&target.user) else {
-            return self.release_consumer_setup_route(route_reservation);
-        };
-        if user.connection_id != target.connection || !user.negotiation.can_consume() {
-            return self.release_consumer_setup_route(route_reservation);
-        }
-        let Some(producer) = self.media.producer(target.producer.id) else {
-            return self.release_consumer_setup_route(route_reservation);
-        };
-        if !target.producer.matches_identity(producer) {
-            return self.release_consumer_setup_route(route_reservation);
-        }
-        let producer_active = producer.active;
-        if self.media.contains_consumer(route_reservation.key()) {
-            return self.release_consumer_setup_route(route_reservation);
-        }
-        let selection = self.setup_selection(&target, producer_active);
-        let active = selection.delivery_active();
-        let state = if active {
-            RouterConsumerRouteState::Active
-        } else {
-            RouterConsumerRouteState::Paused
-        };
-        let routed_consumer_id = match self.routing.add_consumer_with_route_state(
-            &target.user,
-            target.producer.routed,
-            target.producer.kind,
-            ConsumerCapability::Compatible,
-            state,
-        ) {
-            Ok(id) => id,
-            Err(error) => {
-                warn!(
-                    consumer_user_id = ?target.user,
-                    producer_id = %target.producer.id,
-                    ?error,
-                    "router rejected consumer creation"
-                );
-                return self.release_consumer_setup_route(route_reservation);
-            }
-        };
-        if let Some(mid) = mid {
-            track.mid = mid;
-        }
-        track.active = producer_active;
-        let transport_activity_update =
-            (active != planned_selection.delivery_active()).then_some(active);
-        if !self.media.routes.commit(
-            &route_reservation,
-            ConsumerState {
-                routed_consumer_id,
-                consumer_connection_id: target.connection,
-                source_connection_id: target.producer.connection,
-                source_media: target.transport_media_id(),
-                consumer_media: media,
-            },
-            selection,
-        ) {
-            if let Err(error) = self.routing.remove_consumer(routed_consumer_id) {
-                warn!(
-                    consumer_user_id = ?target.user,
-                    routed_consumer_id = ?routed_consumer_id,
-                    ?error,
-                    "failed to roll back topology consumer after graph consumer commit rejection"
-                );
-            }
-            return self.release_consumer_setup_route(route_reservation);
-        }
-        ConsumerSetupCommitOutcome::Committed(ConsumerSetupCommit {
-            sender,
-            track,
-            transport_activity_update,
-        })
-    }
-
-    pub fn release_consumer_setup_plan(
-        &mut self,
-        setup: ConsumerSetupPlan,
-    ) -> Vec<ResolvedRelayRouteEffect> {
-        let relays = self
-            .media
-            .routes
-            .release_consumer_setup(setup.route_reservation);
-        self.resolved_relay_route_effects(relays)
-    }
-
-    fn release_consumer_setup_route(
-        &mut self,
-        route_reservation: ConsumerRouteReservation,
-    ) -> ConsumerSetupCommitOutcome {
-        let relays = self.media.routes.release_consumer_setup(route_reservation);
-        ConsumerSetupCommitOutcome::Released(self.resolved_relay_route_effects(relays))
     }
 
     pub fn desired_source_active(
@@ -697,10 +618,114 @@ impl PlannedSubscriptionChange {
         self,
     ) -> (
         Vec<ConsumerRouteUpdate>,
-        Vec<ConsumerSetupPlan>,
+        Vec<PendingConsumerSetup>,
         Vec<ResolvedRelayRouteEffect>,
     ) {
         (self.updates, self.setups, self.relays)
+    }
+}
+
+impl PendingConsumerSetup {
+    pub(in crate::engine::room) fn transport_input(&self) -> ConsumerSetupTransportInput<'_> {
+        ConsumerSetupTransportInput {
+            target: &self.target,
+            rtp: &self.track.rtp,
+            active: self.reservation.selection().delivery_active(),
+            relays: &self.relays,
+        }
+    }
+
+    pub(in crate::engine::room) fn commit(
+        mut self,
+        state: &mut RoomState,
+        media: TransportMediaId,
+        mid: Option<String>,
+    ) -> ConsumerSetupOutcome {
+        let planned = self.reservation.selection();
+        let Some(user) = state.users.get(&self.target.user) else {
+            return self.release_into_outcome(state);
+        };
+        if user.connection_id != self.target.connection || !user.negotiation.can_consume() {
+            return self.release_into_outcome(state);
+        }
+        let Some(producer) = state.media.producer(self.target.producer.id) else {
+            return self.release_into_outcome(state);
+        };
+        if !self.target.producer.matches_identity(producer) {
+            return self.release_into_outcome(state);
+        }
+        let producer_active = producer.active;
+        if state.media.contains_consumer(self.reservation.key()) {
+            return self.release_into_outcome(state);
+        }
+        let selection = state.setup_selection(&self.target, producer_active);
+        let active = selection.delivery_active();
+        let route_state = if active {
+            RouterConsumerRouteState::Active
+        } else {
+            RouterConsumerRouteState::Paused
+        };
+        let routed_consumer_id = match state.routing.add_consumer_with_route_state(
+            &self.target.user,
+            self.target.producer.routed,
+            self.target.producer.kind,
+            ConsumerCapability::Compatible,
+            route_state,
+        ) {
+            Ok(id) => id,
+            Err(error) => {
+                warn!(
+                    consumer_user_id = ?self.target.user,
+                    producer_id = %self.target.producer.id,
+                    ?error,
+                    "router rejected consumer creation"
+                );
+                return self.release_into_outcome(state);
+            }
+        };
+        if let Some(mid) = mid {
+            self.track.mid = mid;
+        }
+        self.track.active = producer_active;
+        let transport_activity_update = (active != planned.delivery_active()).then_some(active);
+        if !state.media.routes.commit(
+            &self.reservation,
+            ConsumerState {
+                routed_consumer_id,
+                consumer_connection_id: self.target.connection,
+                source_connection_id: self.target.producer.connection,
+                source_media: self.target.transport_media_id(),
+                consumer_media: media,
+            },
+            selection,
+        ) {
+            if let Err(error) = state.routing.remove_consumer(routed_consumer_id) {
+                warn!(
+                    consumer_user_id = ?self.target.user,
+                    routed_consumer_id = ?routed_consumer_id,
+                    ?error,
+                    "failed to roll back topology consumer after graph consumer commit rejection"
+                );
+            }
+            return self.release_into_outcome(state);
+        }
+        ConsumerSetupOutcome::Committed(ConsumerSetupCommit {
+            sender: self.sender,
+            track: self.track,
+            transport_activity_update,
+        })
+    }
+
+    pub(in crate::engine::room) fn release(
+        self,
+        state: &mut RoomState,
+    ) -> Vec<ResolvedRelayRouteEffect> {
+        let relays = state.media.routes.release_consumer_setup(self.reservation);
+        state.resolved_relay_route_effects(relays)
+    }
+
+    fn release_into_outcome(self, state: &mut RoomState) -> ConsumerSetupOutcome {
+        ConsumerSetupOutcome::Released(self.release(state))
     }
 }
 
@@ -747,24 +772,6 @@ impl ConsumerSetupTarget {
 
     pub fn stream_id(&self) -> &UserStreamId {
         &self.producer.stream
-    }
-}
-
-impl ConsumerSetupPlan {
-    pub fn consumer_active(&self) -> bool {
-        self.route_reservation.selection().delivery_active()
-    }
-
-    pub fn target(&self) -> &ConsumerSetupTarget {
-        &self.target
-    }
-
-    pub fn rtp(&self) -> &RouterRtpParameters {
-        &self.track.rtp
-    }
-
-    pub fn relay_effects(&self) -> &[ResolvedRelayRouteEffect] {
-        &self.relays
     }
 }
 

--- a/crates/core/src/engine/room/media_graph/tests.rs
+++ b/crates/core/src/engine/room/media_graph/tests.rs
@@ -9,7 +9,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use o_sfu_router::{
-    ConsumerCapability, MediaKind as RouterMediaKind, ProducerId, RouterId,
+    ConsumerCapability, ConsumerId, MediaKind as RouterMediaKind, ProducerId, RouterId,
     derive_consumable_rtp_parameters,
     test_support::rtp_samples::{
         sample_client_rtp_capabilities, sample_simulcast_video_rtp_parameters,
@@ -18,8 +18,8 @@ use o_sfu_router::{
 };
 
 use super::{
-    ConsumerKey, ConsumerRouteState, ConsumerSetupPlan, ConsumerState, ProducerRuntimeId,
-    PublishedProducer, PublishedSourceInstall, subscription::ConsumerSetupCommitOutcome,
+    ConsumerKey, ConsumerRouteState, ConsumerSetupOutcome, ConsumerState, PendingConsumerSetup,
+    ProducerRuntimeId, PublishedProducer, PublishedSourceInstall,
 };
 use crate::{
     Bitrate, MediaCodecFlags, RoomMediaLimits,
@@ -396,7 +396,7 @@ fn pending_consumer_setup() -> (
     UserId,
     ConnectionId,
     UserStreamId,
-    Vec<ConsumerSetupPlan>,
+    PendingConsumerSetup,
 ) {
     let mut state = test_state();
     let publisher_user_id = UserId::Integer(1);
@@ -414,12 +414,13 @@ fn pending_consumer_setup() -> (
         TransportMediaId::new(10),
         22_222,
     );
-    let planned_setups = state
+    let mut planned_setups = state
         .plan_missing_consumers(&subscriber_user_id, subscriber_connection_id, |_| {
             MediaWorkerId::from_raw(0)
         })
         .expect("subscriber session should exist");
     assert_eq!(planned_setups.len(), 1);
+    let setup = planned_setups.pop().expect("setup should be planned");
 
     (
         state,
@@ -427,8 +428,15 @@ fn pending_consumer_setup() -> (
         subscriber_user_id,
         subscriber_connection_id,
         stream_id,
-        planned_setups,
+        setup,
     )
+}
+
+fn commit_pending_setup(
+    state: &mut RoomState,
+    setup: PendingConsumerSetup,
+) -> ConsumerSetupOutcome {
+    setup.commit(state, TransportMediaId::new(20), Some(String::from("m0")))
 }
 
 #[test]
@@ -630,7 +638,7 @@ fn consumer_setup_commit_uses_latest_room_state() {
         subscriber_user_id,
         subscriber_connection_id,
         stream_id,
-        mut planned_setups,
+        setup,
     ) = pending_consumer_setup();
 
     let publisher_connection_id = state
@@ -663,10 +671,7 @@ fn consumer_setup_commit_uses_latest_room_state() {
         .into_parts();
     assert!(retry_setups.is_empty());
 
-    let setup = planned_setups.pop().expect("setup should be planned");
-    let outcome =
-        state.commit_consumer_setup(setup, TransportMediaId::new(20), Some(String::from("m0")));
-    let ConsumerSetupCommitOutcome::Committed(commit) = outcome else {
+    let ConsumerSetupOutcome::Committed(commit) = commit_pending_setup(&mut state, setup) else {
         panic!("current room state should still accept the setup");
     };
     assert!(!commit.track.active());
@@ -688,7 +693,7 @@ fn consumer_setup_commit_releases_stale_receiver_plan() {
         subscriber_user_id,
         _subscriber_connection_id,
         _stream_id,
-        mut planned_setups,
+        setup,
     ) = pending_consumer_setup();
     assert_eq!(state.subscription_count(), 1);
 
@@ -697,10 +702,7 @@ fn consumer_setup_commit_releases_stale_receiver_plan() {
         .get_mut(&subscriber_user_id)
         .expect("subscriber should exist")
         .connection_id = ConnectionId::from_raw(900);
-    let setup = planned_setups.pop().expect("setup should be planned");
-    let outcome =
-        state.commit_consumer_setup(setup, TransportMediaId::new(20), Some(String::from("m0")));
-    let ConsumerSetupCommitOutcome::Released(relays) = outcome else {
+    let ConsumerSetupOutcome::Released(relays) = commit_pending_setup(&mut state, setup) else {
         panic!("stale receiver setup should be released");
     };
 
@@ -716,7 +718,7 @@ fn consumer_setup_commit_releases_stale_producer_plan() {
         _subscriber_user_id,
         _subscriber_connection_id,
         stream_id,
-        mut planned_setups,
+        setup,
     ) = pending_consumer_setup();
     assert_eq!(state.subscription_count(), 1);
 
@@ -728,15 +730,49 @@ fn consumer_setup_commit_releases_stale_producer_plan() {
         .media
         .remove_source(source_id)
         .expect("publisher source should be removable");
-    let setup = planned_setups.pop().expect("setup should be planned");
-    let outcome =
-        state.commit_consumer_setup(setup, TransportMediaId::new(20), Some(String::from("m0")));
-    let ConsumerSetupCommitOutcome::Released(relays) = outcome else {
+    let ConsumerSetupOutcome::Released(relays) = commit_pending_setup(&mut state, setup) else {
         panic!("stale producer setup should be released");
     };
 
     assert!(relays.is_empty());
     assert_eq!(state.subscription_count(), 0);
+}
+
+#[test]
+fn consumer_setup_commit_rolls_back_routed_consumer_after_graph_rejection() {
+    let (
+        mut state,
+        publisher_user_id,
+        subscriber_user_id,
+        _subscriber_connection_id,
+        stream_id,
+        setup,
+    ) = pending_consumer_setup();
+    assert_eq!(state.subscription_count(), 1);
+
+    let source_id = state
+        .media
+        .source_id_for_owner_stream(&publisher_user_id, &stream_id)
+        .expect("publisher source should exist");
+    let key = ConsumerKey::new(&subscriber_user_id, source_id);
+    assert!(state.media.has_consumer_setup_or_route(&key));
+    assert!(state.media.remove_consumer_key_state(&key).is_empty());
+    assert!(!state.media.has_consumer_setup_or_route(&key));
+
+    let ConsumerSetupOutcome::Released(relays) = commit_pending_setup(&mut state, setup) else {
+        panic!("setup with rejected graph commit should be released");
+    };
+
+    assert!(relays.is_empty());
+    assert_eq!(state.consumer_count(), 0);
+    assert_eq!(state.subscription_count(), 0);
+    assert!(
+        state
+            .routing
+            .remove_consumer(RoutedConsumerId::new(RouterId(1), ConsumerId(1)))
+            .is_err(),
+        "routed consumer created before graph rejection must be rolled back"
+    );
 }
 
 #[test]

--- a/crates/core/src/engine/room/state/membership/tests.rs
+++ b/crates/core/src/engine/room/state/membership/tests.rs
@@ -25,7 +25,7 @@ use crate::{
         room::{
             LocalRouterRuntimeContext, RoomAdmissionPolicy, RoomRuntimeContext, UserOutboundSender,
             media_graph::{
-                ConsumerKey, ConsumerSetupCommitOutcome, ConsumerSetupProducerSnapshot,
+                ConsumerKey, ConsumerSetupOutcome, ConsumerSetupProducerSnapshot,
                 ConsumerSetupTarget, ConsumerState, ProducerRuntimeId, PublishedProducer,
                 PublishedSourceInstall,
             },
@@ -212,13 +212,14 @@ fn install_relayed_source(state: &mut RoomState) -> RelayedSource {
     assert!(setups.is_empty());
     assert!(
         setup
-            .relay_effects()
+            .transport_input()
+            .relays
             .iter()
             .any(|effect| effect.action == TransportRelayRouteAction::Install)
     );
     assert!(matches!(
-        state.commit_consumer_setup(setup, consumer_media, None),
-        ConsumerSetupCommitOutcome::Committed(_)
+        setup.commit(state, consumer_media, None),
+        ConsumerSetupOutcome::Committed(_)
     ));
     RelayedSource {
         publisher,

--- a/crates/core/src/engine/room/transition/subscription.rs
+++ b/crates/core/src/engine/room/transition/subscription.rs
@@ -551,7 +551,9 @@ mod tests {
                 .expect("subscriber session should still be current");
             assert_eq!(setups.len(), 1);
             let setup = setups.pop().expect("retry setup should be planned");
-            state.release_consumer_setup_plan(setup)
+            let relays = setup.release(&mut state);
+            drop(state);
+            relays
         };
         assert_eq!(retry_relays.len(), 1);
     }


### PR DESCRIPTION
consumer setup leaked route reservation details from the room media graph into RoomState and the post-lock effect executor. that made subscription setup depend on a multi-step private protocol instead of one graph-owned pending transaction