### PR TITLE
[FIX] links from absolute root

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,5 +61,5 @@ Verification commands and the `tests/` layout are at [tests/README.md](https://g
 
 ## Deployment
 
-Deployment and local container usage are covered in [DEPLOYMENT.md](../DEPLOYMENT.md).
-For Odoo development, refer to [Odoo SFU Dev Deployment Guide](./odoo_setup.md).
+Deployment and local container usage are covered in [DEPLOYMENT.md](/DEPLOYMENT.md).
+For Odoo development, refer to [Odoo SFU Dev Deployment Guide](/.github/odoo_setup.md).


### PR DESCRIPTION
Before this commit, CONTRIBUTING.md being in ./github, would have some relative links broken because in github CONTRIBUTING.md is displayed in the front page of the repository so the links are treated as relative to root.

This commit fixes this issue by having links always relative to root.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [x] No AI involvement at all.
- [ ] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
