### PR TITLE
[FIX] core: use codec order for simulcast

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -528,7 +528,7 @@ media policy and codecs:
 | `CODEC_VP9` | `false` | enables VP9 video |
 | `CODEC_AV1` | `false` | enables AV1 video |
 | `CODEC_AUDIO_PREFERENCE` | `opus,PCMU,PCMA` | optional comma-separated audio codec preference order |
-| `CODEC_VIDEO_PREFERENCE` | `VP8,H264,H265,VP9,AV1` | optional comma-separated video codec preference order |
+| `CODEC_VIDEO_PREFERENCE` | `VP8,H264,H265,VP9,AV1` | optional comma-separated video codec preference order. The first enabled entry selects layered upload eligibility |
 
 telemetry:
 

--- a/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
+++ b/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
@@ -179,13 +179,10 @@ async fn rtc_initial_session_offer_advertises_vp8_simulcast_receive_surface() {
 }
 
 #[tokio::test]
-async fn rtc_initial_session_offer_advertises_h264_simulcast_when_vp8_is_disabled() {
-    let adapter = rtc_with_codec_flags(
-        MediaCodecFlags::default()
-            .with_vp8(false)
-            .with_h264(true)
-            .with_vp9(true)
-            .with_av1(true),
+async fn rtc_initial_session_offer_advertises_h264_simulcast_when_h264_leads() {
+    let adapter = rtc_with_codec_policy(
+        MediaCodecFlags::default().with_h264(true),
+        CodecPreferences::default().with_video_order(&[VideoCodecPreference::H264]),
     );
     let session_key = transport_key(1, 136, UserId::Integer(136));
 
@@ -201,14 +198,14 @@ async fn rtc_initial_session_offer_advertises_h264_simulcast_when_vp8_is_disable
             webrtc::sdp::rid::DIRECTION_RECV,
             Some(150_000)
         )),
-        "H264-only video offers should claim the low RID on the promoted matrix"
+        "H264-first video offers should claim the low RID on the promoted matrix"
     );
     assert!(
         offer_sdp.contains(&sdp_simulcast_line(
             webrtc::sdp::simulcast::DIRECTION_RECV,
             &["lo", "hi"]
         )),
-        "H264-only video offers should claim the promoted RID simulcast matrix"
+        "H264-first video offers should claim the promoted RID simulcast matrix"
     );
     let video_slot = upload_slots
         .iter()
@@ -216,11 +213,7 @@ async fn rtc_initial_session_offer_advertises_h264_simulcast_when_vp8_is_disable
         .expect("initial offer should include a video upload slot");
     assert_eq!(
         video_slot.codecs,
-        vec![
-            String::from("H264"),
-            String::from("VP9"),
-            String::from("AV1")
-        ]
+        vec![String::from("H264"), String::from("VP8")]
     );
     assert_eq!(video_slot.simulcast_encodings.len(), 2);
     assert_eq!(video_slot.simulcast_encodings[0].rid, "lo");
@@ -304,7 +297,14 @@ async fn rtc_initial_session_offer_reports_configured_codec_preferences() {
         assert_eq!(sdp_names.join(","), expected);
         assert_eq!(router_names, sdp_names);
         assert_eq!(slot.codecs, sdp_names);
+        if video {
+            assert!(slot.simulcast_encodings.is_empty());
+        }
     }
+    assert!(!offer_sdp.contains(&sdp_simulcast_line(
+        webrtc::sdp::simulcast::DIRECTION_RECV,
+        &["lo", "hi"]
+    )));
 }
 
 #[tokio::test]

--- a/crates/core/src/engine/media_transport/rtc/profile.rs
+++ b/crates/core/src/engine/media_transport/rtc/profile.rs
@@ -76,11 +76,21 @@ impl RtpProfile {
                 VideoCodecPreference::Av1 => codecs.enable_av1(true),
             }
         }
+        let simulcast_codec = preferences
+            .video_order()
+            .into_iter()
+            .find(|codec| codec.enabled_by(flags))
+            .and_then(|codec| match codec {
+                VideoCodecPreference::Vp8 => Some(Codec::Vp8),
+                VideoCodecPreference::H264 => Some(Codec::H264),
+                VideoCodecPreference::H265
+                | VideoCodecPreference::Vp9
+                | VideoCodecPreference::Av1 => None,
+            });
 
         let mut router_codecs = Vec::new();
         let mut audio_names = Vec::new();
         let mut video_names = Vec::new();
-        let mut simulcast_codec = None;
         for payload in config.codec_config().params() {
             let kind = rtp_projection::media_kind(payload);
             router_codecs.push(rtp_projection::media_capability(kind, payload)?);
@@ -93,11 +103,6 @@ impl RtpProfile {
             let name = payload.spec().codec.to_string();
             if !names.contains(&name) {
                 names.push(name);
-            }
-            match payload.spec().codec {
-                Codec::Vp8 => simulcast_codec = Some(Codec::Vp8),
-                Codec::H264 if simulcast_codec.is_none() => simulcast_codec = Some(Codec::H264),
-                _ => {}
             }
         }
         let header_extensions = config

--- a/crates/core/src/engine/media_transport/rtc/simulcast/TESTS/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/simulcast/TESTS/mod.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use o_sfu_rfc::{rtp as rfc_rtp, rtp::h264::PacketizationMode, webrtc};
 use o_sfu_router::{
     MediaKind as RouterMediaKind,
@@ -380,7 +382,7 @@ fn answer_send_rid_projection_rejects_extra_simulcast_streams() {
 }
 
 #[test]
-fn h264_and_vp8_profiles_are_promoted_simulcast_publication_paths() {
+fn publication_profile_follows_first_primary_codec() {
     let h264 = h264_parameters(PacketizationMode::NonInterleaved, "42e01f");
 
     assert!(publish_recv_simulcast(MediaKind::Video, &h264).is_some());
@@ -403,6 +405,32 @@ fn h264_and_vp8_profiles_are_promoted_simulcast_publication_paths() {
     );
 
     let vp8 = vp8_parameters();
+    let h264_then_vp8 = video_parameters(h264.formats().chain(vp8.formats()).cloned());
+    assert_eq!(
+        publish_upload_encodings(MediaKind::Video, &h264_then_vp8),
+        publish_upload_encodings(MediaKind::Video, &h264)
+    );
+    for codec in [
+        rfc_rtp::CodecName::Av1,
+        rfc_rtp::CodecName::Vp9,
+        rfc_rtp::CodecName::H265,
+    ] {
+        let parameters = video_parameters(
+            iter::once(MediaFormat::new(
+                RouterMediaKind::Video,
+                codec.clone(),
+                PayloadType::new(98),
+                90_000,
+            ))
+            .chain(vp8.formats().cloned()),
+        );
+        assert!(
+            publish_recv_simulcast(MediaKind::Video, &parameters).is_none(),
+            "{}-first publication should stay single-encoding",
+            codec.as_str()
+        );
+        assert!(publish_upload_encodings(MediaKind::Video, &parameters).is_empty());
+    }
 
     assert!(publish_recv_simulcast(MediaKind::Video, &vp8).is_some());
     assert_eq!(
@@ -458,35 +486,33 @@ fn h264_profile_accepts_only_the_promoted_chromium_matrix() {
 }
 
 fn vp8_parameters() -> RouterRtpParameters {
-    video_parameters(MediaFormat::new(
+    video_parameters([MediaFormat::new(
         RouterMediaKind::Video,
         rfc_rtp::CodecName::Vp8,
         PayloadType::new(96),
         90_000,
-    ))
+    )])
 }
 
 fn h264_parameters(
     packetization_mode: PacketizationMode,
     profile_level_id: &str,
 ) -> RouterRtpParameters {
-    video_parameters(
-        MediaFormat::new(
-            RouterMediaKind::Video,
-            rfc_rtp::CodecName::H264,
-            PayloadType::new(102),
-            90_000,
-        )
-        .with_setting(CodecSetting::H264PacketizationMode(packetization_mode))
-        .with_setting(CodecSetting::H264ProfileLevelId(
-            profile_level_id.to_owned(),
-        )),
+    video_parameters([MediaFormat::new(
+        RouterMediaKind::Video,
+        rfc_rtp::CodecName::H264,
+        PayloadType::new(102),
+        90_000,
     )
+    .with_setting(CodecSetting::H264PacketizationMode(packetization_mode))
+    .with_setting(CodecSetting::H264ProfileLevelId(
+        profile_level_id.to_owned(),
+    ))])
 }
 
-fn video_parameters(format: MediaFormat) -> RouterRtpParameters {
+fn video_parameters(formats: impl IntoIterator<Item = MediaFormat>) -> RouterRtpParameters {
     RouterRtpParameters::new(
-        vec![format],
+        formats.into_iter().collect(),
         Vec::new(),
         vec![
             StreamBinding::new().with_rid(common::DEFAULT_LOW_RID),

--- a/crates/core/src/engine/media_transport/rtc/simulcast/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/simulcast/mod.rs
@@ -9,7 +9,7 @@ mod h264;
 mod vp8;
 
 pub use common::{NegotiatedRid, SimulcastAnswerError};
-use o_sfu_router::rtp::MediaStream as RouterRtpParameters;
+use o_sfu_router::rtp::{MediaCodec, MediaStream as RouterRtpParameters};
 use str0m::{
     format::Codec,
     media::{MediaKind, Mid, Simulcast as Str0mSimulcast},
@@ -57,13 +57,19 @@ impl SimulcastCodecProfile {
         if !media_kind.is_video() {
             return None;
         }
-        if vp8::Vp8SimulcastProfile::layers_from_parameters(rtp_parameters).is_some() {
-            return Some(Self::Vp8(vp8::Vp8SimulcastProfile::new(
-                video_bitrate_limits,
-            )));
+        let primary_codec = rtp_parameters
+            .formats()
+            .find(|format| !format.codec().is_rtx())?
+            .codec();
+        match primary_codec {
+            MediaCodec::Vp8 => vp8::Vp8SimulcastProfile::layers_from_parameters(rtp_parameters)
+                .map(|_| Self::Vp8(vp8::Vp8SimulcastProfile::new(video_bitrate_limits))),
+            MediaCodec::H264 => {
+                h264::H264SimulcastProfile::from_parameters(rtp_parameters, video_bitrate_limits)
+                    .map(Self::H264)
+            }
+            _ => None,
         }
-        h264::H264SimulcastProfile::from_parameters(rtp_parameters, video_bitrate_limits)
-            .map(Self::H264)
     }
 
     fn recv_simulcast(


### PR DESCRIPTION
<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->

AI (vscode ai) phrased the md documentation addition