### PR TITLE
[FIX] client: keep browser turns atomic

### DIFF
--- a/crates/client/src/internals/browser_runtime.ts
+++ b/crates/client/src/internals/browser_runtime.ts
@@ -32,6 +32,7 @@ import { PendingRequests } from "./pending_requests.js";
 import { PeerSession } from "./peer_session.js";
 import { RemoteMedia } from "./remote_media.js";
 import { SocketSession } from "./socket_session.js";
+import { TurnQueue, type TurnGuard } from "./turn_queue.js";
 
 type BrowserRuntimeContext = {
     onLog: (detail: ClientLogDetail) => void;
@@ -45,15 +46,28 @@ type PublicState = Pick<ProtocolCoreBindings, "state" | "features" | "recordingS
     sourceDescriptors: readonly SourceDescriptor[];
 };
 
+const TURN_POLICY = {
+    DROP_ON_RECOVERY: "dropOnRecovery",
+    RETAIN_ON_RECOVERY: "retainOnRecovery"
+} as const;
+
+type TurnPolicy = (typeof TURN_POLICY)[keyof typeof TURN_POLICY];
+
 const CLIENT_RECOVERABLE_CLOSE_CODE = 4000;
 const BROWSER_RUNTIME_LOG_SOURCE = "browser_runtime";
 
 export class BrowserRuntime {
     private readonly _clearTimer: (handle: TimerHandle) => void;
     private readonly _core: ProtocolCoreBindings;
+    private readonly _turnQueue = new TurnQueue<TurnPolicy>((error) =>
+        this.handleRuntimeError(error)
+    );
     private readonly _pendingRequests = new PendingRequests(
-        (commands) => this.enqueue(commands),
-        (commands, begin) => this.enqueueRequest(commands, begin),
+        (getCommands) =>
+            this._turnQueue.enqueueAndWait(
+                (isCurrent) => this.processCommands(getCommands(), isCurrent),
+                TURN_POLICY.DROP_ON_RECOVERY
+            ),
         (id, ms) => this.scheduleTimer(id, ms)
     );
     private readonly _media = new RemoteMedia();
@@ -64,9 +78,6 @@ export class BrowserRuntime {
     private readonly _socketSession: SocketSession;
     private readonly _context: BrowserRuntimeContext;
 
-    private _lastAbortError: Error | undefined;
-    private _commandQueue: Promise<void> = Promise.resolve();
-    private _epoch = 0;
     private _timerHandles = new Map<number, TimerHandle>();
 
     constructor(context: BrowserRuntimeContext, dependencies: SfuClientDependencies = {}) {
@@ -82,7 +93,7 @@ export class BrowserRuntime {
             log,
             () => this.enqueueProtocolCommands(() => this._core.onWsOpen()),
             (frame) => this.enqueueProtocolCommands(() => this._core.onWsMessage(frame)),
-            (code) => this.enqueueProtocolCommands(() => this._core.onWsClose(code))
+            (code) => this.handleSocketClose(code)
         );
         this._peerSession = new PeerSession(
             dependencies.createPeerConnection ??
@@ -107,6 +118,7 @@ export class BrowserRuntime {
             const commands = this._core.connect(url, jwt, room);
             if (commands.some((command) => command.kind === COMMAND_KIND.CONNECT)) {
                 this._peerSession.clearPublications();
+                this._media.resetAll();
                 this._peerSession.setIceServers(iceServers);
             }
             return commands;
@@ -114,30 +126,49 @@ export class BrowserRuntime {
     }
 
     disconnect(): void {
-        this.enqueueProtocolCommands(() => this._core.disconnect());
+        const commands = this.tryControlTransition(() => this._core.disconnect());
+        if (!commands) {
+            return;
+        }
+        this.interrupt(commands, false);
     }
 
     subscribe(sessionId: SessionId, states: DownloadStates): void {
-        this.enqueueTask(() => {
-            this._media.updateSubscriptionStates(sessionId, states, this._context.onUpdate);
-        });
-        this.enqueueProtocolCommands(() => this._core.subscribe(sessionId, states));
+        const snapshot = { ...states };
+        this._turnQueue.enqueue((isCurrent) => {
+            const commands = this._core.subscribe(sessionId, snapshot);
+            if (!isCurrent()) {
+                return;
+            }
+            this._media.updateSubscriptionStates(sessionId, snapshot, this._context.onUpdate);
+            return this.processCommands(commands, isCurrent);
+        }, TURN_POLICY.RETAIN_ON_RECOVERY);
     }
 
     updateInfo(info: SessionInfo): void {
-        this.enqueueProtocolCommands(() => this._core.updateInfo(info));
+        const snapshot = { ...info };
+        this.enqueueProtocolCommands(
+            () => this._core.updateInfo(snapshot),
+            TURN_POLICY.RETAIN_ON_RECOVERY
+        );
     }
 
     broadcast(message: unknown): void {
-        this.enqueueProtocolCommands(() => this._core.broadcast(message));
+        try {
+            const snapshot = structuredClone(message);
+            this.enqueueProtocolCommands(() => this._core.broadcast(snapshot));
+        } catch (error) {
+            this.handleRuntimeError(error);
+        }
     }
 
     startRecording(options: RecordingOptions = {}): Promise<boolean> {
-        return this.processRequestCommands(() => this._core.startRecording(options));
+        const input = { ...options };
+        return this._pendingRequests.drainRequestCommands(() => this._core.startRecording(input));
     }
 
     stopRecording(): Promise<boolean> {
-        return this.processRequestCommands(() => this._core.stopRecording());
+        return this._pendingRequests.drainRequestCommands(() => this._core.stopRecording());
     }
 
     async getStats(): Promise<SfuStats> {
@@ -145,22 +176,26 @@ export class BrowserRuntime {
     }
 
     publish(type: StreamType, track: MediaStreamTrack | null): void {
-        const { active, peerTask } = this._peerSession.setPublication(
-            type,
-            track,
-            this._core.state
-        );
-        if (peerTask) {
-            this.enqueueTask(peerTask);
-        }
-        if (active !== undefined) {
-            this.enqueueProtocolCommands(() => this._core.publish(type, active));
-        }
+        this._turnQueue.enqueue(async (isCurrent) => {
+            const { active, peerTask } = this._peerSession.setPublication(
+                type,
+                track,
+                this._core.state
+            );
+            if (!isCurrent()) {
+                return;
+            }
+            const commands = active === undefined ? undefined : this._core.publish(type, active);
+            if (peerTask) {
+                await peerTask();
+            }
+            if (commands) {
+                return this.processCommands(commands, isCurrent);
+            }
+        }, TURN_POLICY.RETAIN_ON_RECOVERY);
     }
 
-    private abort(): void {
-        this._epoch += 1;
-        this._commandQueue = Promise.resolve();
+    private abortResources(): void {
         this._timerHandles.forEach((handle) => this._clearTimer(handle));
         this._timerHandles.clear();
         this._peerSession.close();
@@ -169,65 +204,61 @@ export class BrowserRuntime {
         this._socketSession.abort(CLIENT_RECOVERABLE_CLOSE_CODE);
     }
 
-    private processRequestCommands(getCommands: () => HostCommand[]): Promise<boolean> {
-        let commands: HostCommand[];
+    private enqueueProtocolCommands(
+        getCommands: () => HostCommand[],
+        policy: TurnPolicy = TURN_POLICY.DROP_ON_RECOVERY
+    ): void {
+        this._turnQueue.enqueue(
+            (isCurrent) => this.processCommands(getCommands(), isCurrent),
+            policy
+        );
+    }
+
+    private handleSocketClose(code: number): void {
+        const commands = this.tryControlTransition(() => this._core.onWsClose(code));
+        if (!commands?.length) {
+            return;
+        }
+        this.interrupt(commands, this._core.state === SFU_CLIENT_STATE.RECOVERING);
+    }
+
+    private tryControlTransition(getCommands: () => HostCommand[]): HostCommand[] | undefined {
         try {
-            commands = getCommands();
+            return getCommands();
         } catch (error) {
             this.handleRuntimeError(error);
-            return Promise.reject(error);
-        }
-        return this._pendingRequests.drainRequestCommands(commands);
-    }
-
-    private enqueueProtocolCommands(getCommands: () => HostCommand[]): void {
-        try {
-            this.enqueue(getCommands());
-        } catch (error) {
-            this.handleRuntimeError(error);
+            return undefined;
         }
     }
 
-    private enqueue(commands: HostCommand[]): void {
-        this.enqueueTask((epoch) => this.processCommands(commands, epoch));
+    private interrupt(commands: HostCommand[], recovering: boolean, error?: Error): void {
+        if (commands.length === 0 && this._turnQueue.hasControlTurn) {
+            this._turnQueue.cancelPending(error);
+            return;
+        }
+        this._turnQueue.interrupt(
+            (isCurrent) => this.processCommands(commands, isCurrent),
+            (policy) => recovering && policy === TURN_POLICY.RETAIN_ON_RECOVERY,
+            error
+        );
     }
 
-    private enqueueRequest(commands: HostCommand[], begin: () => void): Promise<void> {
-        return this.enqueueTask((epoch) => {
-            begin();
-            return commands.length === 0 ? undefined : this.processCommands(commands, epoch);
-        });
-    }
-
-    private enqueueTask(operation: (epoch: number) => void | Promise<void>): Promise<void> {
-        const epoch = this._epoch;
-        const task = this._commandQueue.then(() => {
-            if (!this.isCurrent(epoch)) {
-                throw this._lastAbortError ?? new Error("runtime command skipped after abort");
-            }
-            return operation(epoch);
-        });
-        this._commandQueue = task.catch((error: unknown) => {
-            if (this.isCurrent(epoch)) {
-                this.handleRuntimeError(error);
-            }
-        });
-        return task;
-    }
-
-    private async processCommands(commands: HostCommand[], epoch: number): Promise<void> {
+    private async processCommands(commands: HostCommand[], isCurrent: TurnGuard): Promise<void> {
+        if (!isCurrent()) {
+            return;
+        }
         const pending = [...commands];
         if (pending.length === 0) {
             this.syncPublicState();
             return;
         }
         for (let index = 0; index < pending.length; index += 1) {
-            if (!this.isCurrent(epoch)) {
+            if (!isCurrent()) {
                 return;
             }
             const command = pending[index];
-            const followUp = await this.executeCommand(command);
-            if (!this.isCurrent(epoch)) {
+            const followUp = await this.executeCommand(command, isCurrent);
+            if (!isCurrent()) {
                 return;
             }
             this.syncPublicState();
@@ -235,7 +266,10 @@ export class BrowserRuntime {
         }
     }
 
-    private async executeCommand(command: HostCommand): Promise<HostCommand[]> {
+    private async executeCommand(
+        command: HostCommand,
+        isCurrent: TurnGuard
+    ): Promise<HostCommand[]> {
         switch (command.kind) {
             case COMMAND_KIND.SEND_WEB_SOCKET:
                 this._socketSession.send(command.frame);
@@ -247,7 +281,7 @@ export class BrowserRuntime {
                     command.sdp,
                     command.uploadSlots
                 );
-                if (!result) {
+                if (!result || !isCurrent()) {
                     return [];
                 }
                 const commands = this._core.submitNegotiationAnswer(
@@ -275,6 +309,7 @@ export class BrowserRuntime {
                     command.state === SFU_CLIENT_STATE.DISCONNECTED
                 ) {
                     this._peerSession.clearPublications();
+                    this._media.resetAll();
                 }
                 this._context.onStateChange(command.state, command.cause);
                 return [];
@@ -337,7 +372,6 @@ export class BrowserRuntime {
 
     private handleRuntimeError(error: unknown): void {
         const resolvedError = error instanceof Error ? error : new Error(String(error));
-        this._lastAbortError = resolvedError;
         this._pendingRequests.rejectAll(resolvedError);
         let disconnectCommands: HostCommand[] | undefined;
         try {
@@ -348,11 +382,9 @@ export class BrowserRuntime {
                 `protocol disconnect failed: ${String(disconnectError)}`
             );
         }
-        this.abort();
+        this.interrupt(disconnectCommands ?? [], false, resolvedError);
+        this.abortResources();
         this.syncPublicState();
-        if (disconnectCommands) {
-            this.enqueue(disconnectCommands);
-        }
         this._context.onRuntimeError(resolvedError);
     }
 
@@ -371,9 +403,5 @@ export class BrowserRuntime {
             level,
             message
         });
-    }
-
-    private isCurrent(epoch: number): boolean {
-        return epoch === this._epoch;
     }
 }

--- a/crates/client/src/internals/local_uploads.ts
+++ b/crates/client/src/internals/local_uploads.ts
@@ -17,6 +17,7 @@ export type UploadSlot = {
 export class LocalUploads {
     private _attachableTypes = new Set<StreamType>();
     private _localTracks = new Map<StreamType, MediaTrack>();
+    private _peerGeneration = 0;
     private _senderMidByType = new Map<StreamType, string>();
 
     setPublication(
@@ -51,6 +52,7 @@ export class LocalUploads {
     }
 
     clearPeerConnectionState(): void {
+        this._peerGeneration += 1;
         this._senderMidByType.clear();
         this._attachableTypes.clear();
     }
@@ -73,6 +75,7 @@ export class LocalUploads {
         if (!peerConnection) {
             throw new Error("cannot attach track without an active peer connection");
         }
+        const generation = this._peerGeneration;
         const track = this._localTracks.get(streamType) ?? null;
         const transceiver = peerConnection
             .getTransceivers()
@@ -81,6 +84,9 @@ export class LocalUploads {
             throw new Error(`missing transceiver for mid ${mid}`);
         }
         await transceiver.sender.replaceTrack(track);
+        if (generation !== this._peerGeneration) {
+            return;
+        }
         updateTransceiverDirection(transceiver, track);
         if (track) {
             await applyUploadPublicationPolicy(
@@ -88,6 +94,9 @@ export class LocalUploads {
                 transceiver,
                 uploadSlot?.simulcastEncodings ?? []
             );
+            if (generation !== this._peerGeneration) {
+                return;
+            }
         }
         this._senderMidByType.set(streamType, mid);
         this._attachableTypes.delete(streamType);
@@ -100,6 +109,7 @@ export class LocalUploads {
         if (!peerConnection) {
             return;
         }
+        const generation = this._peerGeneration;
         const boundMid = this._senderMidByType.get(streamType);
         if (!boundMid) {
             return;
@@ -109,6 +119,9 @@ export class LocalUploads {
             .find((candidate) => candidate.mid === boundMid);
         if (transceiver) {
             await transceiver.sender.replaceTrack(null);
+            if (generation !== this._peerGeneration) {
+                return;
+            }
             updateTransceiverDirection(transceiver, null);
         }
         this._senderMidByType.delete(streamType);
@@ -121,6 +134,7 @@ export class LocalUploads {
         peerConnection: ClientPeerConnection,
         uploadSlots: UploadSlot[]
     ): Promise<void> {
+        const generation = this._peerGeneration;
         const pendingStreamTypes = STREAM_TYPES.filter(
             (streamType) =>
                 this.hasPendingPublication(streamType) && this._attachableTypes.has(streamType)
@@ -154,6 +168,9 @@ export class LocalUploads {
             }
             const [slot] = remainingSlots.splice(slotIndex, 1);
             await this.attachTrack(peerConnection, slot.mid, streamType, slot);
+            if (generation !== this._peerGeneration) {
+                return;
+            }
         }
     }
 

--- a/crates/client/src/internals/peer_session.ts
+++ b/crates/client/src/internals/peer_session.ts
@@ -106,13 +106,13 @@ export class PeerSession {
 
     close(): void {
         const peer = this._activePeer;
+        this._activePeer = null;
+        this._uploads.clearPeerConnectionState();
+        this._media.clearPeerConnectionState();
         if (peer) {
             peer.close();
             this._log(CLIENT_LOG_LEVEL.INFO, "closed RTCPeerConnection");
         }
-        this._uploads.clearPeerConnectionState();
-        this._media.clearPeerConnectionState();
-        this._activePeer = null;
     }
 
     async getStats(): Promise<SfuStats> {

--- a/crates/client/src/internals/pending_requests.ts
+++ b/crates/client/src/internals/pending_requests.ts
@@ -6,31 +6,24 @@ export class PendingRequests {
     private _pendingRequestResolvers = new Map<string, PendingRequestCallbacks>();
 
     constructor(
-        private readonly _enqueueCommands: (commands: HostCommand[]) => void,
-        private readonly _enqueueRequest: (
-            commands: HostCommand[],
-            begin: () => void
-        ) => Promise<void>,
+        private readonly _enqueueRequest: (getCommands: () => HostCommand[]) => Promise<void>,
         private readonly _scheduleTimer: (timeoutTimerId: number, timeoutMs: number) => void
     ) {}
 
-    drainRequestCommands(commands: HostCommand[]): Promise<boolean> {
-        const first = commands[0];
-        if (first?.kind !== COMMAND_KIND.BEGIN_PENDING_REQUEST) {
-            this._enqueueCommands(commands);
-            return Promise.resolve(false);
-        }
-
-        const req = first.request;
+    drainRequestCommands(getCommands: () => HostCommand[]): Promise<boolean> {
         let completion: Promise<boolean> | undefined;
-        return this._enqueueRequest(commands.slice(1), () => {
-            completion = this.register(req);
+        return this._enqueueRequest(() => {
+            const commands = getCommands();
+            const first = commands[0];
+            if (first?.kind !== COMMAND_KIND.BEGIN_PENDING_REQUEST) {
+                return commands;
+            }
+            completion = this.register(first.request);
             void completion.catch(() => undefined);
-            this._scheduleTimer(req.timeoutTimerId, req.timeoutMs);
+            this._scheduleTimer(first.request.timeoutTimerId, first.request.timeoutMs);
+            return commands.slice(1);
         }).then(
-            () =>
-                completion ??
-                Promise.reject(new Error("pending request skipped before registration")),
+            () => completion ?? false,
             (error) => completion ?? Promise.reject(error)
         );
     }

--- a/crates/client/src/internals/socket_session.ts
+++ b/crates/client/src/internals/socket_session.ts
@@ -43,11 +43,14 @@ export class SocketSession {
             if (this._activeSocket !== socket) {
                 return;
             }
-            const code = this._protocolCloseCode ?? event.code;
+            const protocolCloseCode = this._protocolCloseCode;
+            const code = protocolCloseCode ?? event.code;
             this._protocolCloseCode = null;
             this._activeSocket = null;
             this._log(CLIENT_LOG_LEVEL.INFO, `websocket closed with code ${code}`);
-            this._onClose(code);
+            if (protocolCloseCode === null) {
+                this._onClose(code);
+            }
         };
         socket.onerror = () => undefined;
         this._activeSocket = socket;
@@ -61,11 +64,18 @@ export class SocketSession {
     }
 
     close(code: number): void {
-        if (!this._activeSocket || this._activeSocket.readyState >= 2) {
+        const socket = this._activeSocket;
+        if (!socket || socket.readyState >= 2 || this._protocolCloseCode !== null) {
             return;
         }
         this._protocolCloseCode = code;
-        this._activeSocket.close(browserCloseCode(code));
+        try {
+            socket.close(browserCloseCode(code));
+        } catch (error) {
+            this._protocolCloseCode = null;
+            throw error;
+        }
+        this._onClose(code);
     }
 
     abort(code: number): void {

--- a/crates/client/src/internals/turn_queue.ts
+++ b/crates/client/src/internals/turn_queue.ts
@@ -1,0 +1,158 @@
+/*
+ * Runs queued operations one at a time and lets an interrupt invalidate the
+ * active operation.
+ *
+ * `BrowserRuntime` awaits WebRTC effects that yield to callbacks. Without this
+ * boundary a later Rust transition can overtake earlier browser effects or an
+ * obsolete Promise completion can submit feedback after recovery or teardown.
+ */
+export type TurnGuard = () => boolean;
+
+type TurnOperation = (isCurrent: TurnGuard) => void | Promise<void>;
+
+type TurnSettlement = {
+    reject: (reason: unknown) => void;
+    resolve: () => void;
+};
+
+type TaggedTurn<Tag> = {
+    operation: TurnOperation;
+    settlement?: TurnSettlement;
+    tag: Tag;
+};
+
+type ControlTurn = {
+    operation: TurnOperation;
+};
+
+type Turn<Tag> = TaggedTurn<Tag> | ControlTurn;
+
+export class TurnQueue<Tag> {
+    private _active: Turn<Tag> | null = null;
+    private _incoming: TaggedTurn<Tag>[] = [];
+    private _pumpScheduled = false;
+    private _ready: TaggedTurn<Tag>[] = [];
+
+    constructor(private readonly _onError: (error: unknown) => void) {}
+
+    get hasControlTurn(): boolean {
+        return this._active !== null && !("tag" in this._active);
+    }
+
+    enqueue(operation: TurnOperation, tag: Tag): void {
+        this._incoming.push({ operation, tag });
+        this.schedulePump();
+    }
+
+    enqueueAndWait(operation: TurnOperation, tag: Tag): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this._incoming.push({ operation, settlement: { reject, resolve }, tag });
+            this.schedulePump();
+        });
+    }
+
+    interrupt(operation: TurnOperation, retain: (tag: Tag) => boolean, error?: Error): void {
+        const active = this._active;
+        const retained: TaggedTurn<Tag>[] = [];
+        const control = { operation };
+        this._active = control;
+        const outcome = error === undefined ? "resolve" : "reject";
+        this.settle(active, outcome, error);
+        for (const turn of this.takePending()) {
+            if (retain(turn.tag)) {
+                retained.push(turn);
+            } else {
+                this.settle(turn, outcome, error);
+            }
+        }
+        this._incoming = retained;
+        queueMicrotask(() => {
+            if (this._active === control) {
+                this.run(control);
+            }
+        });
+    }
+
+    cancelPending(error?: Error): void {
+        const outcome = error === undefined ? "resolve" : "reject";
+        for (const turn of this.takePending()) {
+            this.settle(turn, outcome, error);
+        }
+    }
+
+    private schedulePump(): void {
+        if (this._active || this._pumpScheduled) {
+            return;
+        }
+        this._pumpScheduled = true;
+        queueMicrotask(() => {
+            this._pumpScheduled = false;
+            if (this._active) {
+                return;
+            }
+            const turn = this.takeNext();
+            if (!turn) {
+                return;
+            }
+            this._active = turn;
+            this.run(turn);
+        });
+    }
+
+    private run(turn: Turn<Tag>): void {
+        let result: void | Promise<void>;
+        try {
+            result = turn.operation(() => this._active === turn);
+        } catch (error) {
+            this.complete(turn, "reject", error);
+            return;
+        }
+        if (result === undefined) {
+            this.complete(turn, "resolve");
+            return;
+        }
+        void result.then(
+            () => this.complete(turn, "resolve"),
+            (error: unknown) => this.complete(turn, "reject", error)
+        );
+    }
+
+    private complete(turn: Turn<Tag>, outcome: "reject" | "resolve", error?: unknown): void {
+        if (this._active !== turn) {
+            return;
+        }
+        this._active = null;
+        this.settle(turn, outcome, error);
+        if (outcome === "reject") {
+            this._onError(error);
+        }
+        this.schedulePump();
+    }
+
+    private settle(turn: Turn<Tag> | null, outcome: "reject" | "resolve", error?: unknown): void {
+        if (!turn || !("settlement" in turn) || !turn.settlement) {
+            return;
+        }
+        if (outcome === "resolve") {
+            turn.settlement.resolve();
+        } else {
+            turn.settlement.reject(error);
+        }
+    }
+
+    private takeNext(): TaggedTurn<Tag> | undefined {
+        if (this._ready.length === 0) {
+            this._ready = this._incoming.reverse();
+            this._incoming = [];
+        }
+        return this._ready.pop();
+    }
+
+    private takePending(): TaggedTurn<Tag>[] {
+        const pending = this._ready.reverse();
+        pending.push(...this._incoming);
+        this._incoming = [];
+        this._ready = [];
+        return pending;
+    }
+}

--- a/crates/client/test/sfu_client.test.mjs
+++ b/crates/client/test/sfu_client.test.mjs
@@ -62,6 +62,38 @@ test("ignored duplicate connect keeps the accepted ICE server config", async () 
     assert.deepEqual(peerConnections[0].config.iceServers, iceServers);
 });
 
+test("immediate disconnect prevents pending connect and subscription", async () => {
+    const core = new FakeProtocolCore();
+    core.disconnect = () => [];
+    const { client, sockets } = createSfuClientHarness({ protocolCore: core });
+
+    client.connect("ws://example.test/ws", "jwt-token", { channelUUID: "channel-a" });
+    client.subscribe(42, { camera: false });
+    client.disconnect();
+    await tick();
+
+    assert.deepEqual(sockets, []);
+    assert.deepEqual(core.subscriptionUpdates, []);
+});
+
+test("last same-turn disconnect drops a queued reconnect without canceling cleanup", async () => {
+    const harness = createRecoveryHarness();
+    const { client, emitMessage, peerConnections, sockets } = harness;
+
+    await connectRealWithWelcome(harness);
+    await emitMessage(buildNegotiationFrame("offer", "7", "1"));
+
+    client.disconnect();
+    client.connect("ws://other.example.test/ws", "jwt-token", { channelUUID: "channel-b" });
+    client.disconnect();
+    await tick();
+
+    assert.equal(client.state, "disconnected");
+    assert.equal(sockets.length, 1);
+    assert.equal(sockets[0].closeCode, WS_CLOSE_CODE.CLEAN);
+    assert.equal(peerConnections[0].closed, true);
+});
+
 test("oversized server text frames close before protocol decoding", async () => {
     const core = new FakeProtocolCore();
     let decoded = false;
@@ -109,12 +141,50 @@ for (const [name, startRequest, ok, expected] of [
 
 test("recording requests without protocol registration resolve false", async () => {
     const core = new FakeProtocolCore();
-    core.startRecording = () => [];
+    core.startRecording = (options) => {
+        assert.deepEqual(options, { audio: true });
+        return [];
+    };
     core.stopRecording = () => [];
     const { client } = createSfuClientHarness({ protocolCore: core });
+    const options = { audio: true };
 
-    assert.equal(await client.startRecording({ audio: true }), false);
+    const recording = client.startRecording(options);
+    options.audio = false;
+    assert.equal(await recording, false);
     assert.equal(await client.stopRecording(), false);
+});
+
+test("disconnect resolves a registered recording request", { timeout: 2_000 }, async () => {
+    const harness = createRecoveryHarness();
+    const { client, timers } = harness;
+
+    await connectRealWithWelcome(harness);
+    const recording = client.startRecording({ audio: true });
+    await tick();
+
+    assert.equal(timers.hasDelay(5000), true);
+    client.disconnect();
+
+    assert.equal(await recording, false);
+    assert.equal(timers.hasDelay(5000), false);
+});
+
+test("socket recovery resolves a registered recording request", { timeout: 2_000 }, async () => {
+    const harness = createRecoveryHarness();
+    const { client, sockets, timers } = harness;
+
+    await connectRealWithWelcome(harness);
+    const recording = client.startRecording({ audio: true });
+    await tick();
+
+    assert.equal(timers.hasDelay(5000), true);
+    sockets[0].emitClose(1011);
+
+    assert.equal(await recording, false);
+    await tick();
+    assert.equal(timers.hasDelay(5000), false);
+    assert.equal(client.state, "recovering");
 });
 
 test("duplicate recording request id is handled as a runtime error", async () => {
@@ -209,6 +279,16 @@ test("recording request timer setup failures reject through the public promise",
     assert.equal(handledErrors.length, 1);
     assert.match(handledErrors[0].message, /timer setup failed/);
     assert.deepEqual(unhandledRejections, []);
+});
+
+test("startRecording rejects when the protocol core throws undefined", async () => {
+    const core = new FakeProtocolCore();
+    core.startRecording = () => {
+        throw undefined;
+    };
+    const { client } = createSfuClientHarness({ protocolCore: core });
+
+    await assert.rejects(client.startRecording(), (error) => error === undefined);
 });
 
 test("default runtime creates the protocol core from generated wasm bindings", () => {
@@ -310,10 +390,10 @@ function lastSentEnvelope(socket) {
     return decodeSentFrame(socket, socket.sent.length - 1).at(-1);
 }
 
-function hasSentPublish(socket) {
-    return socket.sent.some((_, index) =>
-        decodeSentFrame(socket, index).some((envelope) => envelope.t === "publish")
-    );
+function sentPublishCount(socket) {
+    return socket.sent
+        .flatMap((_, index) => decodeSentFrame(socket, index))
+        .filter((envelope) => envelope.t === "publish").length;
 }
 
 function assertLastNegotiationResponse(socket, tag, responseTo) {
@@ -336,6 +416,19 @@ async function emitOfferWithBinding({ core, emitMessage }, binding = {}) {
     });
     await emitMessage("offer");
 }
+
+test("authenticated publication waits for transport readiness", async () => {
+    const harness = createRecoveryHarness();
+    const { client, emitMessage, sockets } = harness;
+
+    await connectRealWithWelcome(harness);
+    client.publish("camera", createCameraTrack("camera-track"));
+    await tick();
+
+    assert.equal(sentPublishCount(sockets[0]), 0);
+    await emitMessage(buildNegotiationFrame("offer", "server-initial", "1"));
+    assert.equal(sentPublishCount(sockets[0]), 1);
+});
 
 test("real protocol core replays sticky publish after recovery transport readiness", async () => {
     const harness = createRecoveryHarness();
@@ -447,7 +540,7 @@ test("real protocol core waits for transport-ready replay before binding recover
             .some((section) => section.senderTrack === track),
         false
     );
-    assert.equal(hasSentPublish(sockets[1]), true);
+    assert.equal(sentPublishCount(sockets[1]), 1);
 
     await emitMessage(buildVideoRenegotiationFrame("server-republish", { mid: "2" }), 1);
 
@@ -622,6 +715,160 @@ test("offer waits for the ICE-complete local description before replying", async
             sdp: "answer-sdp\r\na=candidate:1 1 udp 2113937151 127.0.0.1 54400 typ host"
         }
     ]);
+});
+
+test("protocol inputs wait for an in-flight negotiation to finish", async () => {
+    const { promise: answerGate, resolve: releaseAnswer } = Promise.withResolvers();
+    const callOrder = [];
+    class GatedPeerConnection extends FakePeerConnection {
+        async createAnswer() {
+            await answerGate;
+            return super.createAnswer();
+        }
+    }
+    class LoggingProtocolCore extends FakeProtocolCore {
+        onWsMessage(frame) {
+            callOrder.push(`onWsMessage:${frame}`);
+            return super.onWsMessage(frame);
+        }
+
+        submitNegotiationAnswer(...args) {
+            callOrder.push("submitNegotiationAnswer");
+            super.submitNegotiationAnswer(...args);
+            return [{ kind: "sendWebSocket", frame: "answer-feedback" }];
+        }
+    }
+    const { connect, emitMessage, open, sockets } = createSfuClientHarness({
+        createPeerConnection: (config) => new GatedPeerConnection(config),
+        protocolCore: new LoggingProtocolCore()
+    });
+
+    await connect();
+    await open();
+    await emitMessage("welcome");
+    const send = sockets[0].send.bind(sockets[0]);
+    sockets[0].send = (frame) => {
+        callOrder.push(`send:${frame}`);
+        send(frame);
+    };
+    await emitMessage("offer");
+    sockets[0].emitMessage("peer-left");
+    await tick();
+
+    assert.equal(callOrder.includes("onWsMessage:peer-left"), false);
+
+    releaseAnswer();
+    await tick();
+
+    assert.deepEqual(callOrder.slice(-3), [
+        "submitNegotiationAnswer",
+        "send:answer-feedback",
+        "onWsMessage:peer-left"
+    ]);
+});
+
+test("reentrant disconnect cannot reorder a subscription behind cleanup", async () => {
+    const core = new FakeProtocolCore();
+    const calls = [];
+    const subscribe = core.subscribe.bind(core);
+    core.subscribe = (...args) => {
+        calls.push("subscribe");
+        return subscribe(...args);
+    };
+    const { client, connectWithWelcome, emitMessage, peerConnections } = createSfuClientHarness({
+        protocolCore: core
+    });
+
+    await connectWithWelcome();
+    await emitOfferWithBinding({ core, emitMessage });
+    peerConnections[0].emitTrack(createCameraTrack("camera-track"), "0");
+    await tick();
+
+    client.addEventListener("update", (event) => {
+        if (event.detail.name === CLIENT_UPDATE.TRACK && !event.detail.payload.active) {
+            calls.push("disconnect");
+            client.disconnect();
+        }
+    });
+    client.subscribe(42, { camera: false });
+    await tick();
+
+    assert.deepEqual(calls, ["subscribe", "disconnect"]);
+    assert.equal(core.disconnectCalls, 1);
+});
+
+test("reentrant disconnect cancels publication signaling", async () => {
+    const core = new FakeProtocolCore();
+    const { client, connectWithWelcome } = createSfuClientHarness({ protocolCore: core });
+
+    await connectWithWelcome();
+    client.addEventListener("log", () => client.disconnect(), { once: true });
+    client.publish("camera", createCameraTrack("camera-track"));
+    await tick();
+
+    assert.equal(core.disconnectCalls, 1);
+    assert.deepEqual(core.publicationUpdates, []);
+});
+
+test("socket close cancels an in-flight negotiation before recovery", async () => {
+    const { promise: answerGate, resolve: releaseAnswer } = Promise.withResolvers();
+    const core = new FakeProtocolCore();
+    core.transportFailureState = "recovering";
+    const onWsClose = core.onWsClose.bind(core);
+    core.onWsClose = (code) => [{ kind: "closePeerConnection" }, ...onWsClose(code)];
+    class GatedPeerConnection extends FakePeerConnection {
+        async createAnswer() {
+            await answerGate;
+            return super.createAnswer();
+        }
+    }
+    const { client, connectWithWelcome, emitMessage, handledErrors, peerConnections, sockets } =
+        createSfuClientHarness({
+            createPeerConnection: (config) => new GatedPeerConnection(config),
+            protocolCore: core
+        });
+
+    await connectWithWelcome();
+    await emitMessage("offer");
+    const socket = sockets[0];
+    socket.close = (code) => {
+        socket.closeCode = code;
+        socket.readyState = 2;
+    };
+    peerConnections[0].emitConnectionState("failed");
+    releaseAnswer();
+    await tick();
+
+    assert.equal(client.state, "recovering");
+    assert.equal(peerConnections[0].closed, true);
+    assert.deepEqual(core.wsCloseCodes, [4000]);
+    assert.deepEqual(core.submittedAnswers, []);
+    assert.deepEqual(handledErrors, []);
+
+    socket.readyState = 3;
+    socket.onclose?.({ code: socket.closeCode });
+    await tick();
+
+    assert.deepEqual(core.wsCloseCodes, [4000]);
+});
+
+test("same-turn recovery retains queued sticky inputs", async () => {
+    const core = new FakeProtocolCore();
+    core.transportFailureState = "recovering";
+    const { client, connectWithWelcome, sockets } = createSfuClientHarness({ protocolCore: core });
+
+    await connectWithWelcome();
+    client.publish("camera", createCameraTrack("camera-before-recovery"));
+    client.subscribe(42, { camera: false });
+    client.updateInfo({ isCameraOn: false });
+    client.broadcast({ dropped: true });
+    sockets[0].emitClose(1011);
+    await tick();
+
+    assert.deepEqual(core.publicationUpdates, [{ active: true, type: "camera" }]);
+    assert.deepEqual(core.subscriptionUpdates, [{ sessionId: 42, states: { camera: false } }]);
+    assert.deepEqual(core.updateInfoCalls, [{ isCameraOn: false }]);
+    assert.deepEqual(core.broadcasts, []);
 });
 
 test("info_change map payloads are normalized into plain objects", async () => {
@@ -926,12 +1173,15 @@ test("subscribe overlays local download state onto existing remote tracks", asyn
 
 test("subscribe forwards additive video layout intent to the protocol core", async () => {
     const { client, core } = createSfuClientHarness();
-
-    client.subscribe(42, {
+    const states = {
         camera: true,
         cameraLayout: "pinned",
         screenLayout: "hidden"
-    });
+    };
+
+    client.subscribe(42, states);
+    states.camera = false;
+    await tick();
 
     assert.deepEqual(core.subscriptionUpdates, [
         {
@@ -982,6 +1232,47 @@ test("subscribe preferences apply to future remote track bindings", async () => 
         }
     ]);
     assert.equal(client._consumers.get(42).camera.track, track);
+});
+
+test("fresh connect clears subscription overlays from the previous session", async () => {
+    const { client, core, connectWithWelcome, emitMessage, peerConnections, updates } =
+        createSfuClientHarness();
+
+    client.subscribe(42, { camera: false });
+    await tick();
+    await connectWithWelcome();
+    await emitOfferWithBinding({ core, emitMessage });
+    peerConnections[0].emitTrack(createCameraTrack("camera-track"), "0");
+    await tick();
+
+    assert.equal(updates.at(-1).payload.active, true);
+});
+
+test("recovery retains subscription overlays for rebound tracks", async () => {
+    const core = new FakeProtocolCore();
+    core.transportFailureState = "recovering";
+    const onWsClose = core.onWsClose.bind(core);
+    core.onWsClose = (code) => [
+        { kind: "closePeerConnection" },
+        ...onWsClose(code),
+        { kind: "connect", url: "ws://example.test/recovery" }
+    ];
+    const { client, connectWithWelcome, emitMessage, open, peerConnections, sockets, updates } =
+        createSfuClientHarness({ protocolCore: core });
+
+    await connectWithWelcome();
+    client.subscribe(42, { camera: false });
+    await tick();
+    sockets[0].emitClose(1011);
+    await tick();
+    await open(1);
+    await emitMessage("welcome", 1);
+    core.trackBindings.set("0", { active: true, mid: "0", sessionId: 42, type: "camera" });
+    await emitMessage("offer", 1);
+    peerConnections[0].emitTrack(createCameraTrack("rebound-camera"), "0");
+    await tick();
+
+    assert.equal(updates.at(-1).payload.active, false);
 });
 
 test("offer waits for peer connection transport readiness before emitting connected", async () => {
@@ -1106,6 +1397,7 @@ test("stale peer connection callbacks cannot affect the active session", async (
 
     assert.equal(peerConnections.length, 2);
     assert.equal(stalePeerConnection.closed, true);
+    const transportReadyCalls = core.transportReadyCalls;
 
     stalePeerConnection.emitTrack(createCameraTrack("stale-camera"), "0");
     stalePeerConnection.emitConnectionState("connected");
@@ -1113,7 +1405,7 @@ test("stale peer connection callbacks cannot affect the active session", async (
     await tick();
 
     assert.deepEqual(updates, []);
-    assert.equal(core.transportReadyCalls, 2);
+    assert.equal(core.transportReadyCalls, transportReadyCalls);
     assert.equal(sockets.length, 1);
     assert.equal(sockets[0].closeCode, null);
     assert.equal(client.state, "connected");
@@ -1362,6 +1654,98 @@ test("publish replaces an already attached local sender track without re-publish
     );
 });
 
+test("cancelled track replacement cannot retain a stale peer binding", async () => {
+    const { promise: replacementGate, resolve: releaseReplacement } = Promise.withResolvers();
+    const harness = createRecoveryHarness();
+    const { client, emitMessage, peerConnections, sockets } = harness;
+    const firstTrack = createCameraTrack("camera-before-recovery");
+    const secondTrack = createCameraTrack("camera-after-recovery");
+
+    await connectRealWithWelcome(harness);
+    client.publish("camera", firstTrack);
+    await tick();
+    await emitMessage(buildNegotiationFrame("offer", "7", "1"));
+
+    const sender = peerConnections[0].transceivers[1].sender;
+    const replaceTrack = sender.replaceTrack.bind(sender);
+    let replacementStarted = false;
+    sender.replaceTrack = async (track) => {
+        if (track === secondTrack) {
+            replacementStarted = true;
+            await replacementGate;
+        }
+        await replaceTrack(track);
+    };
+
+    client.publish("camera", secondTrack);
+    await tick();
+    assert.equal(replacementStarted, true);
+    sockets[0].emitClose(1011);
+    await tick();
+    releaseReplacement();
+    await tick();
+
+    await finishRecovery(harness);
+    await emitMessage(buildNegotiationFrame("offer", "recovery-offer", "1"), 1);
+    await emitMessage(
+        buildVideoRenegotiationFrame("recovery-renegotiation", {
+            simulcastEncodings: []
+        }),
+        1
+    );
+
+    assert.equal(
+        peerConnections[1].transceivers.find((transceiver) => transceiver.mid === "2").sender.track,
+        secondTrack
+    );
+});
+
+test("cancelled track detach cannot clear a recovered peer binding", async () => {
+    const { promise: detachGate, resolve: releaseDetach } = Promise.withResolvers();
+    const harness = createRecoveryHarness();
+    const { client, emitMessage, peerConnections, sockets } = harness;
+    const secondTrack = createCameraTrack("camera-after-recovery");
+    const thirdTrack = createCameraTrack("camera-after-stale-detach");
+
+    await connectRealWithWelcome(harness);
+    client.publish("camera", createCameraTrack("camera-before-recovery"));
+    await tick();
+    await emitMessage(buildNegotiationFrame("offer", "7", "1"));
+
+    const sender = peerConnections[0].transceivers[1].sender;
+    const replaceTrack = sender.replaceTrack.bind(sender);
+    let detachStarted = false;
+    sender.replaceTrack = async (track) => {
+        if (track === null) {
+            detachStarted = true;
+            await detachGate;
+        }
+        await replaceTrack(track);
+    };
+
+    client.publish("camera", null);
+    await tick();
+    assert.equal(detachStarted, true);
+    sockets[0].emitClose(1011);
+    await tick();
+    client.publish("camera", secondTrack);
+    await tick();
+
+    await finishRecovery(harness);
+    await emitMessage(buildNegotiationFrame("offer", "recovery-offer", "1"), 1);
+    await emitMessage(buildVideoRenegotiationFrame("recovery-renegotiation", { mid: "2" }), 1);
+    releaseDetach();
+    await tick();
+
+    client.publish("camera", thirdTrack);
+    await tick();
+
+    const recoveredSender = peerConnections[1].transceivers.find(
+        (transceiver) => transceiver.mid === "2"
+    ).sender;
+    assert.equal(recoveredSender.track, thirdTrack);
+});
+
 test("publish detaches the local sender before signaling unpublish", async () => {
     const track = createCameraTrack("camera-track-1");
     const { client, core, emitMessage, open, peerConnections, sockets, connect } =
@@ -1495,14 +1879,14 @@ test("explicit disconnect clears publication intent before reconnect", async () 
             .some((section) => section.senderTrack === track),
         false
     );
-    assert.equal(hasSentPublish(sockets[1]), false);
+    assert.equal(sentPublishCount(sockets[1]), 0);
 
     client.publish("camera", track);
     await tick();
     timers.fireByDelay(100);
     await tick();
 
-    assert.equal(hasSentPublish(sockets[1]), true);
+    assert.equal(sentPublishCount(sockets[1]), 1);
 
     await emitMessage(buildVideoRenegotiationFrame("10", { mid: "2", simulcastEncodings: [] }), 1);
 
@@ -1533,7 +1917,7 @@ test("pre-connect publish does not survive a fresh connect", async () => {
             .some((section) => section.senderTrack === track),
         false
     );
-    assert.equal(hasSentPublish(sockets[0]), false);
+    assert.equal(sentPublishCount(sockets[0]), 0);
 });
 
 test("canceling pending camera publish does not detach an attached screen sender", async () => {
@@ -1792,8 +2176,10 @@ test("getStats exposes compatibility-shaped transport and producer stats", async
 
 test("updateInfo keeps the legacy needRefresh option as a compatibility no-op", async () => {
     const { client, core } = createSfuClientHarness();
+    const info = { isCameraOn: true, isRaisingHand: true };
 
-    client.updateInfo({ isCameraOn: true, isRaisingHand: true }, { needRefresh: true });
+    client.updateInfo(info, { needRefresh: true });
+    info.isCameraOn = false;
     await tick();
 
     assert.deepEqual(core.updateInfoCalls, [
@@ -1802,6 +2188,102 @@ test("updateInfo keeps the legacy needRefresh option as a compatibility no-op", 
             isRaisingHand: true
         }
     ]);
+});
+
+test("broadcast snapshots nested payloads at call time", async () => {
+    const { client, core } = createSfuClientHarness();
+    const message = { metadata: { label: "before" } };
+
+    client.broadcast(message);
+    message.metadata.label = "after";
+    await tick();
+
+    assert.deepEqual(core.broadcasts, [{ metadata: { label: "before" } }]);
+});
+
+test("broadcast clone failures use the runtime error boundary", async () => {
+    const { client, handledErrors } = createSfuClientHarness();
+
+    client.broadcast(() => undefined);
+    await tick();
+
+    assert.equal(handledErrors.length, 1);
+    assert.equal(handledErrors[0].name, "DataCloneError");
+});
+
+test("same-turn disconnect preserves fatal cleanup effects", async () => {
+    const harness = createRecoveryHarness();
+    const { client, handledErrors } = harness;
+    const stateChanges = [];
+    client.addEventListener("stateChange", (event) => stateChanges.push(event.detail.state));
+
+    await connectRealWithWelcome(harness);
+    client.broadcast(() => undefined);
+    client.disconnect();
+    await tick();
+
+    assert.equal(handledErrors.length, 1);
+    assert.equal(stateChanges.at(-1), "disconnected");
+});
+
+test("fatal cleanup runs before a reconnect requested by teardown callbacks", async () => {
+    const harness = createRecoveryHarness();
+    const { client, emitMessage, sockets } = harness;
+
+    await connectRealWithWelcome(harness);
+    await emitMessage(buildNegotiationFrame("offer", "7", "1"));
+    client.addEventListener("log", (event) => {
+        if (event.detail.message === "closed RTCPeerConnection") {
+            client.connect("ws://other.example.test/ws", "jwt-token", {
+                channelUUID: "channel-b"
+            });
+        }
+    });
+
+    client.broadcast(() => undefined);
+    await tick();
+
+    assert.equal(sockets.length, 2);
+    assert.equal(sockets[1].closeCode, null);
+});
+
+test("repeated fatal inputs preserve installed cleanup effects", async () => {
+    const harness = createRecoveryHarness();
+    const { client, handledErrors } = harness;
+    const stateChanges = [];
+    client.addEventListener("stateChange", (event) => stateChanges.push(event.detail.state));
+
+    await connectRealWithWelcome(harness);
+    client.broadcast(() => undefined);
+    client.broadcast(() => undefined);
+    await tick();
+
+    assert.equal(handledErrors.length, 2);
+    assert.equal(stateChanges.at(-1), "disconnected");
+});
+
+test("fatal teardown clears the active peer before logging", async () => {
+    const harness = createRecoveryHarness();
+    const { client, emitMessage, handledErrors } = harness;
+    let closeLogs = 0;
+
+    await connectRealWithWelcome(harness);
+    await emitMessage(buildNegotiationFrame("offer", "7", "1"));
+    client.addEventListener("log", (event) => {
+        if (event.detail.message !== "closed RTCPeerConnection") {
+            return;
+        }
+        closeLogs += 1;
+        if (closeLogs === 1) {
+            client.broadcast(() => undefined);
+        }
+    });
+
+    client.broadcast(() => undefined);
+    await tick();
+
+    assert.equal(closeLogs, 1);
+    assert.equal(handledErrors.length, 2);
 });
 
 test("fatal runtime errors reset the public client surface", async () => {
@@ -1858,35 +2340,55 @@ test("fatal runtime errors reset the public client surface", async () => {
     assert.deepEqual(core.wsCloseCodes, []);
 });
 
-test("fatal runtime errors ignore stale remote-description failures after abort", async () => {
-    let rejectRemoteDescription;
-    const { client, core, connect, emitMessage, handledErrors, open } = createSfuClientHarness({
+test(
+    "disconnect cancels a stalled negotiation and ignores late failures",
+    { timeout: 2_000 },
+    async () => {
+        const { promise: remoteDescription, reject: rejectRemoteDescription } =
+            Promise.withResolvers();
+        const harness = createRecoveryHarness({
+            createPeerConnection(config) {
+                const peerConnection = new FakePeerConnection(config);
+                peerConnection.setRemoteDescription = () => remoteDescription;
+                return peerConnection;
+            }
+        });
+        const { client, emitMessage, handledErrors, peerConnections, sockets } = harness;
+
+        await connectRealWithWelcome(harness);
+        await emitMessage(buildNegotiationFrame("offer", "7", "1"));
+
+        client.disconnect();
+        await tick();
+
+        assert.equal(client.state, "disconnected");
+        assert.equal(peerConnections[0].closed, true);
+        assert.equal(sockets[0].closeCode, WS_CLOSE_CODE.CLEAN);
+        assert.equal(handledErrors.length, 0);
+
+        rejectRemoteDescription(new Error("late negotiation failure"));
+        await tick();
+
+        assert.equal(handledErrors.length, 0);
+    }
+);
+
+test("fatal abort ignores late negotiation failures", async () => {
+    const { promise: remoteDescription, reject: rejectRemoteDescription } = Promise.withResolvers();
+    const { client, connectWithWelcome, emitMessage, handledErrors } = createSfuClientHarness({
         createPeerConnection(config) {
             const peerConnection = new FakePeerConnection(config);
-            peerConnection.setRemoteDescription = () =>
-                new Promise((_, reject) => {
-                    rejectRemoteDescription = reject;
-                });
+            peerConnection.setRemoteDescription = () => remoteDescription;
             return peerConnection;
         }
     });
 
-    await connect();
-    await open();
-    await emitMessage("welcome");
-    await emitMessage("source-descriptors");
+    await connectWithWelcome();
     await emitMessage("offer");
-
-    await emitMessage("explode");
-
-    assert.equal(client.state, "disconnected");
-    assert.deepEqual(client.sourceDescriptors, []);
-    assert.equal(handledErrors.length, 1);
-
+    client.broadcast(() => undefined);
     rejectRemoteDescription(new Error("late negotiation failure"));
     await tick();
 
-    assert.equal(core.disconnectCalls, 1);
     assert.equal(handledErrors.length, 1);
 });
 

--- a/crates/client/test/support/protocol_fakes.mjs
+++ b/crates/client/test/support/protocol_fakes.mjs
@@ -40,6 +40,7 @@ const remoteMediaUpdate = (bindings) => ({
 export class FakeProtocolCore {
     constructor() {
         this.features = { ...EMPTY_FEATURES };
+        this.broadcasts = [];
         this.recordingState = {};
         this.state = "disconnected";
         this.disconnectCalls = 0;
@@ -55,7 +56,8 @@ export class FakeProtocolCore {
         this.wsCloseCodes = [];
     }
 
-    broadcast() {
+    broadcast(message) {
+        this.broadcasts.push(message);
         return [];
     }
 
@@ -79,7 +81,7 @@ export class FakeProtocolCore {
     }
 
     onTransportReady() {
-        if (this.pendingNegotiationKind === "offer") {
+        if (this.pendingNegotiationKind === "offer" || this.state === "connected") {
             return [];
         }
         this.transportReadyCalls += 1;

--- a/crates/protocol/src/core.rs
+++ b/crates/protocol/src/core.rs
@@ -538,13 +538,13 @@ impl ProtocolCore {
         command_batch(commands)
     }
 
-    /// Stores the desired publication state and sends it when signaling is ready.
+    /// Stores the desired publication state and sends it when the media transport is ready.
     ///
     /// Publish intent is sticky across reconnects, which lets UI toggles be issued
     /// before authentication completes without losing the latest desired state.
     pub fn publish(&mut self, stream_type: StreamType, active: bool) -> CommandBatch {
         self.sticky_replay.set_publish_active(stream_type, active);
-        if !self.can_send_client_messages() {
+        if !matches!(&self.phase, ProtocolPhase::Connected(_)) {
             return CommandBatch::default();
         }
         let message = if active {

--- a/crates/protocol/src/core/TESTS/batching.rs
+++ b/crates/protocol/src/core/TESTS/batching.rs
@@ -81,6 +81,23 @@ fn protocol_core_publish_and_unpublish_flush_only_websocket_envelopes() -> Resul
     Ok(())
 }
 
+#[test]
+fn protocol_core_defers_publish_until_transport_ready() {
+    let mut core = ProtocolCore::new();
+    let _ = core.connect("wss://sfu.example.com/socket", "signed-token", None);
+    let _ = core.accept_welcome(sample_welcome_payload());
+
+    assert!(core.publish(StreamType::Camera, true).is_empty());
+    assert_sent_client_envelopes(
+        &core.on_transport_ready(),
+        vec![ClientEnvelope::Message(ClientMessage::Publish(
+            StreamIntentPayload {
+                stream_type: StreamType::Camera,
+            },
+        ))],
+    );
+}
+
 fn expect_flush_timer(commands: &[Command], label: &str) -> Result<u32, String> {
     let [
         Command::ScheduleTimer {


### PR DESCRIPTION
Browser inputs could mutate protocol state while an earlier turn still applied browser effects. Reentrant callbacks could also restore stale intent after cancellation.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->

First experiment with claude:

1) Claude found and proved the issue
2) Claude came up with a suggestion for a fix but it was rejected (too shallow and naive with remaining ordering issues)
