### PR TITLE
Master magic solver num zel

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -531,6 +531,17 @@ media policy and codecs:
 | `CODEC_AUDIO_PREFERENCE` | `opus,PCMU,PCMA` | optional comma-separated audio codec preference order |
 | `CODEC_VIDEO_PREFERENCE` | `VP8,H264,H265,VP9,AV1` | optional comma-separated video codec preference order. The first enabled entry selects layered upload eligibility |
 
+receiver video adaptation tuning:
+
+| variable | default | description |
+| --- | --- | --- |
+| `ROOM_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD` | `3` | receiver count at or above which scalable video is layer-selected per receiver instead of forwarded at full quality |
+| `ROOM_THUMBNAIL_BUDGET_DIVISOR` | `2` | divisor applied to the per-source budget when a source is shown as a thumbnail |
+| `ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS` | `2` | consecutive over-budget observations required before dropping a receiver to a lower layer |
+| `ROOM_UPSWITCH_STABLE_OBSERVATIONS` | `3` | consecutive within-budget observations required before raising a receiver to a higher layer |
+| `ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT` | `0` | percent of the receiver bandwidth estimate held back from the video budget for RTP, RTX and FEC overhead, from `0` to `100` |
+| `ROOM_AUDIO_RESERVE_PER_SPEAKER_BPS` | `0` | fixed bitrate in bps held back from each receiver's video budget for every admitted audio speaker that receiver consumes; a receiver with audio disabled reserves nothing; `0` disables audio reservation |
+
 telemetry:
 
 | variable | default | description |

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/bwe.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/bwe.rs
@@ -1,8 +1,9 @@
 //! receiver-side bandwidth-estimation target updates.
 //!
-//! Room policy owns selected receiver video demand. The RTC worker only applies
-//! that demand to the session-local str0m BWE controller after capping it to the
-//! configured outgoing ceiling.
+//! Room policy owns the receiver send demand (selected video plus the admitted
+//! audio delivered to that receiver). The RTC worker only applies that demand to
+//! the session-local str0m BWE controller after capping it to the configured
+//! outgoing ceiling.
 
 use str0m::bwe::Bitrate as Str0mBitrate;
 

--- a/crates/core/src/engine/room/TESTS/fixtures.rs
+++ b/crates/core/src/engine/room/TESTS/fixtures.rs
@@ -2,7 +2,8 @@ pub(super) use std::{sync::Arc, time::Instant};
 
 use o_sfu_router::test_support::rtp_samples::{
     sample_audio_rtp_parameters, sample_client_rtp_capabilities,
-    sample_simulcast_video_rtp_parameters, sample_video_rtp_parameters,
+    sample_simulcast_video_rtp_parameters, sample_three_layer_simulcast_video_rtp_parameters,
+    sample_video_rtp_parameters,
 };
 pub(super) use o_sfu_router::{
     MediaKind,
@@ -15,7 +16,7 @@ pub(super) use super::super::{
     UserOutboundSender, source_policy::SourcePolicyTurn, transition::PublishStageOutcome,
 };
 pub(super) use crate::{
-    RoomMediaLimits,
+    RoomMediaLimits, VideoAdaptationTuning,
     engine::{
         ConnectionId, TestSourceKind, UserId, UserPermissions, VideoLayoutIntent,
         media_transport::{
@@ -405,6 +406,24 @@ pub(super) async fn setup_ready_users_with_transport_and_media_limits(
     (room, adapter)
 }
 
+pub(super) async fn setup_ready_users_with_transport_and_tuning(
+    user_ids: &[i64],
+    tuning: VideoAdaptationTuning,
+) -> (Arc<super::super::Room>, MediaTransport) {
+    let manager = RoomManager::for_test_with_video_adaptation_tuning(tuning);
+    let room = manager
+        .serve_room("issuer-a", TEST_ROOM_KEY, &RoomConfig::default(), None)
+        .await;
+    let adapter = real_adapter();
+    for &raw_user_id in user_ids {
+        let (sender, _receiver) = test_sender();
+        let user_id = UserId::Integer(raw_user_id);
+        join_user_without_transport_teardown(&room, &adapter, user_id.clone(), sender).await;
+        make_session_ready_with_transport(&room, &user_id, &adapter).await;
+    }
+    (room, adapter)
+}
+
 pub(super) async fn setup_ready_users_with_transport_receivers(
     user_ids: &[i64],
 ) -> (
@@ -450,6 +469,14 @@ impl SourcePolicyScenario {
     ) -> Self {
         let (room, adapter) =
             setup_ready_users_with_transport_and_media_limits(user_ids, media_limits).await;
+        Self { room, adapter }
+    }
+
+    pub(super) async fn with_ready_users_and_tuning(
+        user_ids: &[i64],
+        tuning: VideoAdaptationTuning,
+    ) -> Self {
+        let (room, adapter) = setup_ready_users_with_transport_and_tuning(user_ids, tuning).await;
         Self { room, adapter }
     }
 
@@ -574,6 +601,22 @@ pub(super) async fn publish_simulcast_camera(
         TestSourceKind::ScalableVideo,
         MediaKind::Video,
         test_simulcast_video_rtp_parameters(),
+        media_transport,
+    )
+    .await
+}
+
+pub(super) async fn publish_three_layer_camera(
+    room: &Arc<super::super::Room>,
+    user_id: &UserId,
+    media_transport: &MediaTransport,
+) -> UserStreamId {
+    publish_track(
+        room,
+        user_id,
+        TestSourceKind::ScalableVideo,
+        MediaKind::Video,
+        sample_three_layer_simulcast_video_rtp_parameters(None),
         media_transport,
     )
     .await

--- a/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
@@ -534,6 +534,171 @@ async fn audio_speaker_limit_ignores_foreign_and_inactive_sources() {
 }
 
 #[tokio::test]
+async fn per_receiver_audio_reserve_excludes_own_and_counts_only_consumed_audio() {
+    // Reserve 40 kbps of video budget per admitted audio speaker the receiver
+    // actually consumes; no headroom so the arithmetic is exact.
+    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 0, Bitrate::from_kbps(40))
+        .expect("valid tuning should build");
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
+    scenario
+        .publish_audio_and_camera_for_users(&[1, 2, 3])
+        .await;
+
+    let first_audio = scenario.audio_media_id(1).await;
+    let second_audio = scenario.audio_media_id(2).await;
+    let third_audio = scenario.audio_media_id(3).await;
+    let observed_at = Instant::now();
+    let speakers = [
+        ActiveSpeakerSource::new(first_audio, observed_at + Duration::from_millis(2)),
+        ActiveSpeakerSource::new(second_audio, observed_at + Duration::from_millis(1)),
+        ActiveSpeakerSource::new(third_audio, observed_at),
+    ];
+
+    // Receiver user 2 has 900 kbps and consumes admitted audio from users 1 and 3
+    // (not its own), so the video budget loses 2 * 40 = 80 kbps -> 820 kbps.
+    let receiver_user_id = UserId::Integer(2);
+    let receiver_connection_id = user_connection_id(&scenario.room, &receiver_user_id).await;
+    let receiver_session_key = scenario
+        .room
+        .transport_user_key(&receiver_user_id, receiver_connection_id)
+        .await;
+    let receiver_bandwidth_snapshot = ReceiverBandwidthSnapshot {
+        per_session: vec![(receiver_session_key, Bitrate::from_kbps(900))],
+    };
+
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan_from_state(&state, &speakers, &receiver_bandwidth_snapshot)
+            .expect("policy pass should produce budget updates")
+    };
+    tx.execute(&scenario.room, &scenario.adapter).await;
+
+    assert_subscription_selected_video_budget(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(820),
+    )
+    .await;
+
+    // str0m's desired bitrate is the total send allocation, so it must cover the
+    // 80 kbps of admitted audio on top of the selected video; otherwise BWE
+    // under-probes by exactly the reserved audio.
+    let selected_video =
+        receiver_selected_video_bitrate(&scenario.room, &scenario.adapter, &receiver_user_id).await;
+    assert_receiver_bwe_target(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        selected_video.saturating_add(Bitrate::from_kbps(80)),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn audio_only_receiver_reports_its_audio_reserve_as_bwe_demand() {
+    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 0, Bitrate::from_kbps(40))
+        .expect("valid tuning should build");
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
+    // Only audio is published, so receiver user 2 has audio routes but no video
+    // routes — the case where the last video route was dropped while audio keeps
+    // flowing.
+    for user_id in [UserId::Integer(1), UserId::Integer(3)] {
+        publish_track(
+            &scenario.room,
+            &user_id,
+            TestSourceKind::AudioDetector,
+            MediaKind::Audio,
+            test_audio_rtp_parameters(),
+            &scenario.adapter,
+        )
+        .await;
+    }
+    let first_audio = scenario.audio_media_id(1).await;
+    let third_audio = scenario.audio_media_id(3).await;
+    let observed_at = Instant::now();
+    let speakers = [
+        ActiveSpeakerSource::new(first_audio, observed_at + Duration::from_millis(1)),
+        ActiveSpeakerSource::new(third_audio, observed_at),
+    ];
+
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan_from_state(
+            &state,
+            &speakers,
+            &ReceiverBandwidthSnapshot::default(),
+        )
+        .expect("audio-only receiver should still report BWE demand")
+    };
+    tx.execute(&scenario.room, &scenario.adapter).await;
+
+    // User 2 consumes admitted audio from users 1 and 3 and has no video, so its
+    // desired bitrate is the audio reserve alone (2 * 40 kbps) rather than zero.
+    assert_receiver_bwe_target(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        Bitrate::from_kbps(80),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
+    // A high multiparty threshold forces each route to start at its top layer, so
+    // the aggregate overload loop — not per-route selection — does the stepping.
+    let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
+        .expect("valid tuning should build");
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
+    // Three layers (lo=150, mid=450, hi=900 kbps) so one down-step lands on the
+    // middle layer rather than the cheapest.
+    publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
+
+    // Receiver user 2 has 500 kbps: the top layer (900) is over budget but one
+    // step down to the middle layer (450) fits, so the loop stops there.
+    let receiver_user_id = UserId::Integer(2);
+    let receiver_connection_id = user_connection_id(&scenario.room, &receiver_user_id).await;
+    let receiver_session_key = scenario
+        .room
+        .transport_user_key(&receiver_user_id, receiver_connection_id)
+        .await;
+    let receiver_bandwidth_snapshot = ReceiverBandwidthSnapshot {
+        per_session: vec![(receiver_session_key, Bitrate::from_kbps(500))],
+    };
+
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan_from_state(&state, &[], &receiver_bandwidth_snapshot)
+            .expect("overload should step the thumbnail down")
+    };
+    tx.execute(&scenario.room, &scenario.adapter).await;
+
+    // The route survives at the middle layer and stays deliverable (no pause),
+    // rather than being dropped to the cheapest layer or paused.
+    assert_subscription_selected_rid(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+        "mid",
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn video_download_limit_pauses_lowest_ranked_receiver_routes() {
     let scenario = SourcePolicyScenario::with_ready_users_and_media_limits(
         &[1, 2, 3],

--- a/crates/core/src/engine/room/TESTS/producer_tests/support.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/support.rs
@@ -161,6 +161,54 @@ pub(super) async fn assert_subscription_selected_rid(
     );
 }
 
+pub(super) async fn receiver_selected_video_bitrate(
+    room: &Arc<Room>,
+    adapter: &MediaTransport,
+    consumer_user_id: &UserId,
+) -> Bitrate {
+    let (diagnostics, _) = diagnostics_room_views(room, adapter).await;
+    let Some(user) = diagnostics
+        .iter()
+        .find(|view| &view.user_id == consumer_user_id)
+    else {
+        panic!("diagnostics should include the consumer user");
+    };
+    let selected_video_bitrate_bps = user
+        .subscriptions
+        .iter()
+        .map(|subscription| subscription.selection.selected_video_bitrate_bps)
+        .max()
+        .unwrap_or_default();
+    Bitrate::from_bps(selected_video_bitrate_bps)
+}
+
+pub(super) async fn assert_subscription_selected_video_budget(
+    room: &Arc<Room>,
+    adapter: &MediaTransport,
+    consumer_user_id: &UserId,
+    producer_user_id: &UserId,
+    stream_type: TestSourceKind,
+    expected_budget: Bitrate,
+) {
+    let (diagnostics, _) = diagnostics_room_views(room, adapter).await;
+    let Some(user) = diagnostics
+        .iter()
+        .find(|view| &view.user_id == consumer_user_id)
+    else {
+        panic!("diagnostics should include the consumer user");
+    };
+    assert!(
+        user.subscriptions.iter().any(|subscription| {
+            subscription.producer_user_id == *producer_user_id
+                && subscription.stream_id == stream_id_for_source(stream_type).to_string()
+                && subscription.selection.selected_video_budget_bps
+                    == Some(expected_budget.as_bps())
+        }),
+        "diagnostics should expose the reserved video budget: {:?}",
+        user.subscriptions
+    );
+}
+
 pub(super) async fn assert_subscription_policy_pause_reason(
     room: &Arc<Room>,
     adapter: &MediaTransport,

--- a/crates/core/src/engine/room/factory.rs
+++ b/crates/core/src/engine/room/factory.rs
@@ -98,7 +98,6 @@ impl RoomRuntimePolicy {
         self
     }
 
-    /// return a room policy that uses the provided video adaptation tuning
     #[must_use]
     pub fn with_video_adaptation_tuning(
         mut self,

--- a/crates/core/src/engine/room/factory.rs
+++ b/crates/core/src/engine/room/factory.rs
@@ -20,7 +20,7 @@ use o_sfu_router::{RouterId, rtp::MediaCapabilities};
 
 use super::{Room, RoomRuntimeContext};
 use crate::{
-    RoomMediaLimits, RoomWorkerPolicy, RuntimeFeatureFlags,
+    RoomMediaLimits, RoomWorkerPolicy, RuntimeFeatureFlags, VideoAdaptationTuning,
     engine::{RoomInstanceId, metrics::RuntimeMetrics, sync::lock_unpoisoned},
 };
 
@@ -63,6 +63,8 @@ pub struct RoomRuntimePolicy {
     pub room_worker_policy: RoomWorkerPolicy,
     /// room media activation caps applied by source policy
     pub media_limits: RoomMediaLimits,
+    /// receiver video adaptation knobs applied by source policy
+    pub video_adaptation_tuning: VideoAdaptationTuning,
 }
 
 impl RoomRuntimePolicy {
@@ -78,6 +80,7 @@ impl RoomRuntimePolicy {
             router_rtp_capabilities,
             room_worker_policy: RoomWorkerPolicy::strict_single_router(),
             media_limits: RoomMediaLimits::default(),
+            video_adaptation_tuning: VideoAdaptationTuning::default(),
         }
     }
 
@@ -92,6 +95,16 @@ impl RoomRuntimePolicy {
     #[must_use]
     pub fn with_media_limits(mut self, media_limits: RoomMediaLimits) -> Self {
         self.media_limits = media_limits;
+        self
+    }
+
+    /// return a room policy that uses the provided video adaptation tuning
+    #[must_use]
+    pub fn with_video_adaptation_tuning(
+        mut self,
+        video_adaptation_tuning: VideoAdaptationTuning,
+    ) -> Self {
+        self.video_adaptation_tuning = video_adaptation_tuning;
         self
     }
 }

--- a/crates/core/src/engine/room/instance.rs
+++ b/crates/core/src/engine/room/instance.rs
@@ -75,6 +75,7 @@ impl Room {
                 &runtime_context,
                 runtime_policy.admission_policy,
                 runtime_policy.media_limits,
+                runtime_policy.video_adaptation_tuning,
                 runtime_policy.router_rtp_capabilities,
             )),
         }

--- a/crates/core/src/engine/room/manager/TESTS/support.rs
+++ b/crates/core/src/engine/room/manager/TESTS/support.rs
@@ -10,7 +10,9 @@ use super::{
 };
 #[cfg(any(test, feature = "testing-transport"))]
 use crate::engine::sync::lock_unpoisoned;
-use crate::{RoomMediaLimits, RuntimeFeatureFlags, engine::metrics::RuntimeMetrics};
+use crate::{
+    RoomMediaLimits, RuntimeFeatureFlags, VideoAdaptationTuning, engine::metrics::RuntimeMetrics,
+};
 
 const DEFAULT_TEST_MAX_SESSIONS: usize = 100;
 
@@ -37,6 +39,15 @@ impl RoomManager {
             1,
             test_runtime_policy(RoomAdmissionPolicy::new(DEFAULT_TEST_MAX_SESSIONS))
                 .with_media_limits(media_limits),
+        ))
+    }
+
+    #[must_use]
+    pub fn for_test_with_video_adaptation_tuning(tuning: VideoAdaptationTuning) -> Self {
+        Self::for_test_with_config(RoomManagerConfig::new(
+            1,
+            test_runtime_policy(RoomAdmissionPolicy::new(DEFAULT_TEST_MAX_SESSIONS))
+                .with_video_adaptation_tuning(tuning),
         ))
     }
 

--- a/crates/core/src/engine/room/media_graph/TESTS/mod.rs
+++ b/crates/core/src/engine/room/media_graph/TESTS/mod.rs
@@ -23,7 +23,7 @@ use super::{
     DeclaredConsumerSetup, PendingConsumerSetup, SubscriptionKey, ValidatedPublish,
 };
 use crate::{
-    Bitrate, RoomMediaLimits,
+    Bitrate, RoomMediaLimits, VideoAdaptationTuning,
     engine::{
         ConnectionId, MediaWorkerId, RoomInstanceId, TestSourceKind, UserId, UserPermissions,
         media_transport::{
@@ -89,6 +89,7 @@ fn test_state_with_media_limits(media_limits: RoomMediaLimits) -> RoomState {
         &runtime_context,
         RoomAdmissionPolicy::new(4),
         media_limits,
+        VideoAdaptationTuning::default(),
         sample_client_rtp_capabilities(),
     )
 }

--- a/crates/core/src/engine/room/source_policy/input.rs
+++ b/crates/core/src/engine/room/source_policy/input.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::action::FeaturedUserUpdate;
 use crate::{
-    Bitrate, RoomMediaLimits,
+    Bitrate, RoomMediaLimits, VideoAdaptationTuning,
     engine::{
         ConnectionId, UserId,
         media_transport::{
@@ -30,6 +30,7 @@ pub(super) struct SourcePolicySnapshot<'a> {
     pub(super) featured_user_updates: Vec<FeaturedUserUpdate>,
     pub(super) user_count: usize,
     pub(super) media_limits: RoomMediaLimits,
+    pub(super) video_adaptation_tuning: VideoAdaptationTuning,
 }
 
 impl<'a> SourcePolicySnapshot<'a> {
@@ -66,6 +67,7 @@ impl<'a> SourcePolicySnapshot<'a> {
             featured_user_updates,
             user_count: state.user_count(),
             media_limits,
+            video_adaptation_tuning: state.video_adaptation_tuning,
         }
     }
 }

--- a/crates/core/src/engine/room/source_policy/input.rs
+++ b/crates/core/src/engine/room/source_policy/input.rs
@@ -3,6 +3,8 @@ use std::{
     collections::{BTreeMap, BTreeSet},
 };
 
+use o_sfu_router::MediaKind;
+
 use super::action::FeaturedUserUpdate;
 use crate::{
     Bitrate, RoomMediaLimits, VideoAdaptationTuning,
@@ -31,6 +33,7 @@ pub(super) struct SourcePolicySnapshot<'a> {
     pub(super) user_count: usize,
     pub(super) media_limits: RoomMediaLimits,
     pub(super) video_adaptation_tuning: VideoAdaptationTuning,
+    pub(super) audio_reserve_by_connection: BTreeMap<ConnectionId, Bitrate>,
 }
 
 impl<'a> SourcePolicySnapshot<'a> {
@@ -41,6 +44,7 @@ impl<'a> SourcePolicySnapshot<'a> {
     ) -> Self {
         let ranked_sources = rank_room_active_speakers(state, active_speaker_sources);
         let media_limits = state.media_limits;
+        let tuning = state.video_adaptation_tuning;
         let active_speakers = active_speaker_media_ids(&ranked_sources);
         let admitted_audio_speakers =
             admitted_audio_media_ids(&ranked_sources, media_limits.max_active_audio_speakers());
@@ -53,10 +57,15 @@ impl<'a> SourcePolicySnapshot<'a> {
         let routes = state
             .committed_consumer_routes()
             .filter(|route| route.source.active && route.selection.active())
-            .collect();
+            .collect::<Vec<_>>();
+        let audio_reserve_by_connection = audio_reserve_by_connection(
+            &routes,
+            &admitted_audio_speakers,
+            tuning.audio_reserve_per_speaker,
+        );
         Self {
             routes,
-            receiver_bwe_targets: receiver_bwe_targets(state),
+            receiver_bwe_targets: receiver_bwe_targets(state, &audio_reserve_by_connection),
             receiver_bandwidth_by_connection: receiver_bandwidth_by_connection(
                 receiver_bandwidth_snapshot,
             ),
@@ -67,19 +76,60 @@ impl<'a> SourcePolicySnapshot<'a> {
             featured_user_updates,
             user_count: state.user_count(),
             media_limits,
-            video_adaptation_tuning: state.video_adaptation_tuning,
+            video_adaptation_tuning: tuning,
+            audio_reserve_by_connection,
         }
     }
 }
 
-fn receiver_bwe_targets(state: &RoomState) -> BTreeMap<UserId, ReceiverBweTargetUpdate> {
+/// Bandwidth reserved for admitted audio before video budgeting, per receiver
+/// connection.
+///
+/// Each receiver reserves `per_speaker` for every admitted audio route it
+/// actually consumes, so a receiver that disabled audio (or a publisher with no
+/// consumer routes) reserves nothing and keeps its full video budget. The
+/// reserve is fixed per route, so it is deterministic and independent of
+/// policy-turn cadence. A zero per-speaker rate disables the reservation and
+/// returns an empty map.
+fn audio_reserve_by_connection(
+    routes: &[ConsumerRouteView<'_>],
+    admitted_audio_media_ids: &BTreeSet<TransportMediaId>,
+    per_speaker: Bitrate,
+) -> BTreeMap<ConnectionId, Bitrate> {
+    if per_speaker.as_bps() == 0 {
+        return BTreeMap::new();
+    }
+    let mut reserve_by_connection = BTreeMap::new();
+    for route in routes {
+        if route.source.descriptor.media_kind() != MediaKind::Audio
+            || !admitted_audio_media_ids.contains(&route.route.source_transport_media_id())
+        {
+            continue;
+        }
+        let connection_id = route.route.consumer_session_key().connection_id();
+        let reserve = reserve_by_connection
+            .entry(connection_id)
+            .or_insert_with(Bitrate::zero);
+        *reserve = reserve.saturating_add(per_speaker);
+    }
+    reserve_by_connection
+}
+
+fn receiver_bwe_targets(
+    state: &RoomState,
+    audio_reserve_by_connection: &BTreeMap<ConnectionId, Bitrate>,
+) -> BTreeMap<UserId, ReceiverBweTargetUpdate> {
     state
         .transport_user_entries()
         .map(|(user_id, connection_id)| {
             let session = state.transport_user_key(user_id, connection_id);
+            let audio_reserve = audio_reserve_by_connection
+                .get(&connection_id)
+                .copied()
+                .unwrap_or_else(Bitrate::zero);
             (
                 user_id.clone(),
-                ReceiverBweTargetUpdate::new(session, Bitrate::zero()),
+                ReceiverBweTargetUpdate::new(session, audio_reserve),
             )
         })
         .collect()

--- a/crates/core/src/engine/room/source_policy/video/TESTS/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/TESTS/solver.rs
@@ -1,0 +1,40 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test assertions use unwrap and expect for clear failure messages"
+)]
+
+use super::{Bitrate, VideoAdaptationTuning, effective_video_budget};
+
+#[test]
+fn effective_video_budget_no_reserve_returns_full_estimate() {
+    // Default tuning reserves no headroom and no audio, so the whole estimate
+    // is available to video.
+    let tuning = VideoAdaptationTuning::default();
+    assert_eq!(
+        effective_video_budget(Bitrate::from_kbps(1000), tuning, Bitrate::zero()),
+        Bitrate::from_kbps(1000),
+    );
+}
+
+#[test]
+fn effective_video_budget_applies_headroom_then_audio() {
+    // 20% headroom on 1000 kbps -> 800 kbps, minus a 50 kbps audio reserve -> 750 kbps.
+    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 20, Bitrate::from_kbps(16))
+        .expect("valid tuning should build");
+    assert_eq!(
+        effective_video_budget(Bitrate::from_kbps(1000), tuning, Bitrate::from_kbps(50)),
+        Bitrate::from_kbps(750),
+    );
+}
+
+#[test]
+fn effective_video_budget_saturates_to_zero_when_over_reserved() {
+    // 50% of 100 kbps = 50 kbps, minus a 200 kbps audio reserve saturates to zero.
+    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 50, Bitrate::zero())
+        .expect("valid tuning should build");
+    assert_eq!(
+        effective_video_budget(Bitrate::from_kbps(100), tuning, Bitrate::from_kbps(200)),
+        Bitrate::zero(),
+    );
+}

--- a/crates/core/src/engine/room/source_policy/video/input.rs
+++ b/crates/core/src/engine/room/source_policy/video/input.rs
@@ -100,6 +100,11 @@ pub(super) fn receiver_video_routes<'a>(
                 .receiver_bandwidth_by_connection
                 .get(&route.route.consumer_session_key().connection_id())
                 .copied(),
+            audio_budget_reserve: input
+                .audio_reserve_by_connection
+                .get(&route.route.consumer_session_key().connection_id())
+                .copied()
+                .unwrap_or_else(Bitrate::zero),
         });
     }
     for route in &mut routes {
@@ -122,6 +127,7 @@ pub(super) struct ReceiverVideoRouteInput<'a> {
     pub(super) visible_scalable_route_count: usize,
     pub(super) active_speaker_rank: Option<usize>,
     pub(super) receiver_bandwidth: Option<Bitrate>,
+    pub(super) audio_budget_reserve: Bitrate,
 }
 
 impl RoomState {

--- a/crates/core/src/engine/room/source_policy/video/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/solver.rs
@@ -11,7 +11,7 @@ use super::{
     projection,
 };
 use crate::{
-    Bitrate,
+    Bitrate, VideoAdaptationTuning,
     engine::{
         UserId,
         media_transport::ReceiverBweTargetUpdate,
@@ -24,15 +24,6 @@ use crate::{
         },
     },
 };
-
-/// room size where scalable video starts using receiver-bandwidth share
-const MULTIPARTY_SCALABLE_VIDEO_SELECTION_THRESHOLD: usize = 3;
-/// multiplier that halves each thumbnail share before layer selection
-const THUMBNAIL_BUDGET_DIVISOR: u64 = 2;
-/// consecutive pressure observations before a soft downswitch or budget pause
-const DOWNSWITCH_PRESSURE_OBSERVATIONS: u8 = 2;
-/// consecutive stable observations before a soft resume or upswitch
-const UPSWITCH_STABLE_OBSERVATIONS: u8 = 3;
 
 /// ordering key shared by policy refresh and pre-setup receiver admission
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -240,13 +231,18 @@ pub(in crate::engine::room::source_policy) fn append_receiver_video_policy(
 ) {
     let routes = receiver_video_routes(state, input);
     let max_video_downloads_per_receiver = input.media_limits.max_video_downloads_per_receiver();
+    let tuning = input.video_adaptation_tuning;
     for receiver_routes in routes.chunk_by(|left, right| left.key.receiver == right.key.receiver) {
         let Some(first_route) = receiver_routes.first() else {
             continue;
         };
         let consumer_user_id = &first_route.key.receiver;
-        let receiver_bwe_target =
-            append_receiver_policy_updates(tx, receiver_routes, max_video_downloads_per_receiver);
+        let receiver_bwe_target = append_receiver_policy_updates(
+            tx,
+            receiver_routes,
+            max_video_downloads_per_receiver,
+            tuning,
+        );
         if let Some(update) = receiver_bwe_targets.get_mut(consumer_user_id) {
             update.set_target(receiver_bwe_target);
         }
@@ -258,6 +254,7 @@ fn append_receiver_policy_updates<'a>(
     tx: &mut SourcePolicyTransaction,
     receiver_routes: &'a [ReceiverVideoRouteInput<'a>],
     max_video_downloads_per_receiver: usize,
+    tuning: VideoAdaptationTuning,
 ) -> Bitrate {
     let receiver_bandwidth = receiver_routes
         .iter()
@@ -265,7 +262,7 @@ fn append_receiver_policy_updates<'a>(
     let mut planned_routes = receiver_routes
         .iter()
         .filter_map(|route| {
-            route_plan(route).map(|selection| PlannedReceiverRoute::new(route, selection))
+            route_plan(route, tuning).map(|selection| PlannedReceiverRoute::new(route, selection))
         })
         .collect::<Vec<_>>();
     apply_video_download_limit(&mut planned_routes, max_video_downloads_per_receiver);
@@ -274,7 +271,7 @@ fn append_receiver_policy_updates<'a>(
     }
     let budget_diagnostics = receiver_video_budget_diagnostics(&planned_routes, receiver_bandwidth);
     for planned_route in planned_routes {
-        let selection = resolve_hysteresis(&planned_route);
+        let selection = resolve_hysteresis(&planned_route, tuning);
         let Some(update) = projection::consumer_packet_selection_update(
             &planned_route,
             selection,
@@ -291,7 +288,10 @@ fn append_receiver_policy_updates<'a>(
     budget_diagnostics.selected_video_bitrate()
 }
 
-fn route_plan(route: &ReceiverVideoRouteInput<'_>) -> Option<ReceiverRouteSelection> {
+fn route_plan(
+    route: &ReceiverVideoRouteInput<'_>,
+    tuning: VideoAdaptationTuning,
+) -> Option<ReceiverRouteSelection> {
     let policy = route.source.policy().adaptation();
     let source_cap = route.source.policy().video_bitrate_cap();
     match policy {
@@ -301,7 +301,7 @@ fn route_plan(route: &ReceiverVideoRouteInput<'_>) -> Option<ReceiverRouteSelect
             None
         }
         SourceAdaptationPolicy::ReadableDetail => highest_allowed_plan(route),
-        SourceAdaptationPolicy::ScalableVideo => scalable_plan(route),
+        SourceAdaptationPolicy::ScalableVideo => scalable_plan(route, tuning),
         SourceAdaptationPolicy::None if source_cap.is_some() => highest_allowed_plan(route),
         SourceAdaptationPolicy::None => None,
     }
@@ -375,14 +375,17 @@ fn highest_allowed_plan(route: &ReceiverVideoRouteInput<'_>) -> Option<ReceiverR
     ))
 }
 
-fn scalable_plan(route: &ReceiverVideoRouteInput<'_>) -> Option<ReceiverRouteSelection> {
+fn scalable_plan(
+    route: &ReceiverVideoRouteInput<'_>,
+    tuning: VideoAdaptationTuning,
+) -> Option<ReceiverRouteSelection> {
     let source_cap = route.source.policy().video_bitrate_cap();
     if route.source.selectable_encoding_count() < 2 && source_cap.is_none() {
         return None;
     }
     let current = route.current_selection;
     let current_index = selector_index(route.source, current.selector());
-    let target_index = desired_encoding_index(route, source_cap)?;
+    let target_index = desired_encoding_index(route, source_cap, tuning)?;
     let target_selector = SourceSelector::Encoding(
         route
             .source
@@ -397,14 +400,16 @@ fn scalable_plan(route: &ReceiverVideoRouteInput<'_>) -> Option<ReceiverRouteSel
         if source_cap.is_some_and(|cap| selector_bitrate(route.source, current.selector()) > cap) {
             return Some(adaptation_send(target_selector, request_keyframe));
         }
-        let counts = AdaptationCounts::next_pressure(current, DOWNSWITCH_PRESSURE_OBSERVATIONS);
-        if counts.pressure >= DOWNSWITCH_PRESSURE_OBSERVATIONS {
+        let pressure_limit = tuning.downswitch_pressure_observations();
+        let counts = AdaptationCounts::next_pressure(current, pressure_limit);
+        if counts.pressure >= pressure_limit {
             return Some(adaptation_send(target_selector, request_keyframe));
         }
         return Some(adaptation_hold(current, counts));
     }
-    let counts = AdaptationCounts::next_upgrade(current, UPSWITCH_STABLE_OBSERVATIONS);
-    if counts.upgrade >= UPSWITCH_STABLE_OBSERVATIONS {
+    let stable_limit = tuning.upswitch_stable_observations();
+    let counts = AdaptationCounts::next_upgrade(current, stable_limit);
+    if counts.upgrade >= stable_limit {
         return Some(adaptation_send(target_selector, true));
     }
     Some(adaptation_hold(current, counts))
@@ -427,8 +432,9 @@ const fn adaptation_hold(
 fn desired_encoding_index(
     route: &ReceiverVideoRouteInput<'_>,
     source_cap: Option<Bitrate>,
+    tuning: VideoAdaptationTuning,
 ) -> Option<usize> {
-    if route.user_count < MULTIPARTY_SCALABLE_VIDEO_SELECTION_THRESHOLD {
+    if route.user_count < tuning.multiparty_scalable_video_threshold() {
         return allowed_encoding_indices(route.source, source_cap).next_back();
     }
     let uses_featured_quality = route.layout_intent.uses_featured_quality();
@@ -444,7 +450,7 @@ fn desired_encoding_index(
     } else {
         let divisor = u64::try_from(route.visible_scalable_route_count)
             .unwrap_or(u64::MAX)
-            .saturating_mul(THUMBNAIL_BUDGET_DIVISOR);
+            .saturating_mul(tuning.thumbnail_budget_divisor());
         receiver_bandwidth.divided_by(divisor)
     };
     highest_affordable_encoding_index(route.source, budget, uses_featured_quality, source_cap)
@@ -641,7 +647,10 @@ fn pause_reason_for_route(route: &PlannedReceiverRoute<'_>) -> PolicyPauseReason
     }
 }
 
-fn resolve_hysteresis(route: &PlannedReceiverRoute<'_>) -> ReceiverRouteSelection {
+fn resolve_hysteresis(
+    route: &PlannedReceiverRoute<'_>,
+    tuning: VideoAdaptationTuning,
+) -> ReceiverRouteSelection {
     let current = route.input.current_selection;
     let current_pause_reason = current.policy_pause_reason();
     let selection = route.selection;
@@ -650,8 +659,9 @@ fn resolve_hysteresis(route: &PlannedReceiverRoute<'_>) -> ReceiverRouteSelectio
             ReceiverRouteSelection::send(selection.selector, AdaptationCounts::reset(), true)
         }
         (None, Some(reason)) => {
-            let counts = AdaptationCounts::next_upgrade(current, UPSWITCH_STABLE_OBSERVATIONS);
-            if counts.upgrade >= UPSWITCH_STABLE_OBSERVATIONS {
+            let stable_limit = tuning.upswitch_stable_observations();
+            let counts = AdaptationCounts::next_upgrade(current, stable_limit);
+            if counts.upgrade >= stable_limit {
                 ReceiverRouteSelection::send(selection.selector, AdaptationCounts::reset(), true)
             } else {
                 ReceiverRouteSelection::hold(current, Some(reason), counts)
@@ -664,8 +674,9 @@ fn resolve_hysteresis(route: &PlannedReceiverRoute<'_>) -> ReceiverRouteSelectio
             ) {
                 return ReceiverRouteSelection::pause(current, reason, AdaptationCounts::reset());
             }
-            let counts = AdaptationCounts::next_pressure(current, DOWNSWITCH_PRESSURE_OBSERVATIONS);
-            if counts.pressure >= DOWNSWITCH_PRESSURE_OBSERVATIONS {
+            let pressure_limit = tuning.downswitch_pressure_observations();
+            let counts = AdaptationCounts::next_pressure(current, pressure_limit);
+            if counts.pressure >= pressure_limit {
                 ReceiverRouteSelection::pause(current, reason, AdaptationCounts::reset())
             } else {
                 ReceiverRouteSelection::hold(current, None, counts)

--- a/crates/core/src/engine/room/source_policy/video/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/solver.rs
@@ -237,14 +237,16 @@ pub(in crate::engine::room::source_policy) fn append_receiver_video_policy(
             continue;
         };
         let consumer_user_id = &first_route.key.receiver;
-        let receiver_bwe_target = append_receiver_policy_updates(
+        let selected_video = append_receiver_policy_updates(
             tx,
             receiver_routes,
             max_video_downloads_per_receiver,
             tuning,
         );
+        // The target is seeded with this receiver's audio reserve, so add the
+        // selected video to report the full send allocation to str0m's BWE.
         if let Some(update) = receiver_bwe_targets.get_mut(consumer_user_id) {
-            update.set_target(receiver_bwe_target);
+            update.set_target(update.target().saturating_add(selected_video));
         }
     }
     tx.set_receiver_bwe_targets(receiver_bwe_targets.into_values().collect());
@@ -259,6 +261,11 @@ fn append_receiver_policy_updates<'a>(
     let receiver_bandwidth = receiver_routes
         .iter()
         .find_map(|route| route.receiver_bandwidth);
+    let audio_reserve = receiver_routes
+        .first()
+        .map_or_else(Bitrate::zero, |route| route.audio_budget_reserve);
+    let video_budget = receiver_bandwidth
+        .map(|bandwidth| effective_video_budget(bandwidth, tuning, audio_reserve));
     let mut planned_routes = receiver_routes
         .iter()
         .filter_map(|route| {
@@ -266,10 +273,11 @@ fn append_receiver_policy_updates<'a>(
         })
         .collect::<Vec<_>>();
     apply_video_download_limit(&mut planned_routes, max_video_downloads_per_receiver);
-    if let Some(receiver_bandwidth) = receiver_bandwidth {
-        apply_overload_policy(&mut planned_routes, receiver_bandwidth);
+    if let Some(video_budget) = video_budget {
+        apply_overload_policy(&mut planned_routes, video_budget);
     }
-    let budget_diagnostics = receiver_video_budget_diagnostics(&planned_routes, receiver_bandwidth);
+    let budget_diagnostics =
+        receiver_video_budget_diagnostics(&planned_routes, receiver_bandwidth, video_budget);
     for planned_route in planned_routes {
         let selection = resolve_hysteresis(&planned_route, tuning);
         let Some(update) = projection::consumer_packet_selection_update(
@@ -359,6 +367,47 @@ fn cheapest_useful_selector(
         })
 }
 
+/// receiver bandwidth left for video after reserving the configured headroom
+///
+/// the reserve stands in for audio, retransmission, FEC and protocol overhead
+/// that share the same downlink but are not counted in the video budget
+fn effective_video_budget(
+    receiver_bandwidth: Bitrate,
+    tuning: VideoAdaptationTuning,
+    audio_reserve: Bitrate,
+) -> Bitrate {
+    let usable_percent = 100u64.saturating_sub(u64::from(tuning.receiver_budget_headroom_percent));
+    let after_overhead =
+        Bitrate::from_bps(receiver_bandwidth.as_bps().saturating_mul(usable_percent) / 100);
+    after_overhead.saturating_sub(audio_reserve)
+}
+
+/// next allowed, non-featured layer one step below `current`, with its bitrate
+///
+/// returns `None` when the route is already at its lowest usable layer, letting
+/// the overload pass stop degrading a route before it bottoms out
+fn step_down_selector(
+    route: &ReceiverVideoRouteInput<'_>,
+    current: SourceSelector,
+) -> Option<(SourceSelector, Bitrate)> {
+    let source = route.source;
+    let source_cap = source.policy().video_bitrate_cap();
+    let current_index = selector_index(source, current);
+    (0..current_index).rev().find_map(|index| {
+        let encoding = source.selectable_encoding_by_rank(index)?;
+        if matches!(
+            encoding.policy_role(),
+            Some(UploadLayerPolicyRole::Featured)
+        ) {
+            return None;
+        }
+        let bitrate = encoding.max_bitrate()?;
+        source_cap
+            .is_none_or(|cap| bitrate <= cap)
+            .then_some((SourceSelector::Encoding(encoding.encoding_id()), bitrate))
+    })
+}
+
 fn highest_allowed_plan(route: &ReceiverVideoRouteInput<'_>) -> Option<ReceiverRouteSelection> {
     let target_index =
         allowed_encoding_indices(route.source, route.source.policy().video_bitrate_cap())
@@ -400,14 +449,14 @@ fn scalable_plan(
         if source_cap.is_some_and(|cap| selector_bitrate(route.source, current.selector()) > cap) {
             return Some(adaptation_send(target_selector, request_keyframe));
         }
-        let pressure_limit = tuning.downswitch_pressure_observations();
+        let pressure_limit = tuning.downswitch_pressure_observations;
         let counts = AdaptationCounts::next_pressure(current, pressure_limit);
         if counts.pressure >= pressure_limit {
             return Some(adaptation_send(target_selector, request_keyframe));
         }
         return Some(adaptation_hold(current, counts));
     }
-    let stable_limit = tuning.upswitch_stable_observations();
+    let stable_limit = tuning.upswitch_stable_observations;
     let counts = AdaptationCounts::next_upgrade(current, stable_limit);
     if counts.upgrade >= stable_limit {
         return Some(adaptation_send(target_selector, true));
@@ -434,7 +483,7 @@ fn desired_encoding_index(
     source_cap: Option<Bitrate>,
     tuning: VideoAdaptationTuning,
 ) -> Option<usize> {
-    if route.user_count < tuning.multiparty_scalable_video_threshold() {
+    if route.user_count < tuning.multiparty_scalable_video_threshold {
         return allowed_encoding_indices(route.source, source_cap).next_back();
     }
     let uses_featured_quality = route.layout_intent.uses_featured_quality();
@@ -445,12 +494,14 @@ fn desired_encoding_index(
             allowed_encoding_indices(route.source, source_cap).next()
         };
     };
+    let receiver_bandwidth =
+        effective_video_budget(receiver_bandwidth, tuning, route.audio_budget_reserve);
     let budget = if uses_featured_quality || route.visible_scalable_route_count <= 1 {
         receiver_bandwidth
     } else {
         let divisor = u64::try_from(route.visible_scalable_route_count)
             .unwrap_or(u64::MAX)
-            .saturating_mul(tuning.thumbnail_budget_divisor());
+            .saturating_mul(tuning.thumbnail_budget_divisor);
         receiver_bandwidth.divided_by(divisor)
     };
     highest_affordable_encoding_index(route.source, budget, uses_featured_quality, source_cap)
@@ -544,27 +595,40 @@ fn video_download_rank(route: &PlannedReceiverRoute<'_>) -> VideoAdmissionRank {
     )
 }
 
-fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], receiver_bandwidth: Bitrate) {
+fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], video_budget: Bitrate) {
     let mut total_bitrate = selected_active_video_bitrate(routes);
-    if total_bitrate <= receiver_bandwidth {
+    if total_bitrate <= video_budget {
         return;
     }
+    // Drop downgradable routes that have no usable layer to fall back to.
     for route in routes.iter_mut().filter(|route| route_can_downgrade(route)) {
-        let Some((selector, bitrate)) = cheapest_useful_selector(route.input) else {
+        if cheapest_useful_selector(route.input).is_none() {
             let selected_bitrate = route.selected_bitrate;
             route.pause(PolicyPauseReason::MissingUsableLayer, RouteOutcome::Neutral);
             total_bitrate = total_bitrate.saturating_sub(selected_bitrate);
-            continue;
-        };
-        if bitrate < route.selected_bitrate {
-            let selected_bitrate = route.selected_bitrate;
-            total_bitrate = total_bitrate
-                .saturating_sub(selected_bitrate)
-                .saturating_add(bitrate);
-            route.send(selector, bitrate, RouteOutcome::Degraded);
         }
     }
-    if total_bitrate <= receiver_bandwidth {
+    // Step the highest-consuming downgradable route down one layer at a time,
+    // stopping as soon as the budget is met so mid-tier layers survive.
+    while total_bitrate > video_budget {
+        let Some((route, selector, bitrate)) = routes
+            .iter_mut()
+            .filter(|route| route_can_downgrade(route))
+            .filter_map(|route| {
+                step_down_selector(route.input, route.selection.selector)
+                    .map(|(selector, bitrate)| (route, selector, bitrate))
+            })
+            .max_by_key(|(route, _selector, _bitrate)| route.selected_bitrate)
+        else {
+            break;
+        };
+        let selected_bitrate = route.selected_bitrate;
+        total_bitrate = total_bitrate
+            .saturating_sub(selected_bitrate)
+            .saturating_add(bitrate);
+        route.send(selector, bitrate, RouteOutcome::Degraded);
+    }
+    if total_bitrate <= video_budget {
         return;
     }
     let mut pause_order = Vec::with_capacity(routes.len());
@@ -579,7 +643,7 @@ fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], receiver_bandw
     }
     pause_order.sort_by_key(|(rank, _)| *rank);
     for (_rank, route) in pause_order {
-        if total_bitrate <= receiver_bandwidth {
+        if total_bitrate <= video_budget {
             break;
         }
         let selected_bitrate = route.selected_bitrate;
@@ -592,14 +656,15 @@ fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], receiver_bandw
 fn receiver_video_budget_diagnostics(
     routes: &[PlannedReceiverRoute<'_>],
     receiver_bandwidth: Option<Bitrate>,
+    video_budget: Option<Bitrate>,
 ) -> ReceiverVideoBudgetDiagnostics {
     let selected_video_bitrate = selected_active_video_bitrate(routes);
-    let over_budget_exception_reason = receiver_bandwidth
+    let over_budget_exception_reason = video_budget
         .filter(|budget| selected_video_bitrate > *budget)
         .map(|_budget| OverBudgetExceptionReason::ProtectedRoute);
     ReceiverVideoBudgetDiagnostics::new(
         receiver_bandwidth,
-        receiver_bandwidth,
+        video_budget,
         active_route_count(routes),
         selected_video_bitrate,
         over_budget_exception_reason,
@@ -659,7 +724,7 @@ fn resolve_hysteresis(
             ReceiverRouteSelection::send(selection.selector, AdaptationCounts::reset(), true)
         }
         (None, Some(reason)) => {
-            let stable_limit = tuning.upswitch_stable_observations();
+            let stable_limit = tuning.upswitch_stable_observations;
             let counts = AdaptationCounts::next_upgrade(current, stable_limit);
             if counts.upgrade >= stable_limit {
                 ReceiverRouteSelection::send(selection.selector, AdaptationCounts::reset(), true)
@@ -674,7 +739,7 @@ fn resolve_hysteresis(
             ) {
                 return ReceiverRouteSelection::pause(current, reason, AdaptationCounts::reset());
             }
-            let pressure_limit = tuning.downswitch_pressure_observations();
+            let pressure_limit = tuning.downswitch_pressure_observations;
             let counts = AdaptationCounts::next_pressure(current, pressure_limit);
             if counts.pressure >= pressure_limit {
                 ReceiverRouteSelection::pause(current, reason, AdaptationCounts::reset())
@@ -685,3 +750,7 @@ fn resolve_hysteresis(
         _ => selection,
     }
 }
+
+#[cfg(test)]
+#[path = "TESTS/solver.rs"]
+mod tests;

--- a/crates/core/src/engine/room/state/membership/TESTS/mod.rs
+++ b/crates/core/src/engine/room/state/membership/TESTS/mod.rs
@@ -16,7 +16,7 @@ use o_sfu_router::{
 
 use super::*;
 use crate::{
-    RoomMediaLimits,
+    RoomMediaLimits, VideoAdaptationTuning,
     engine::{
         ConnectionId, MediaWorkerId, RoomInstanceId, TestSourceKind, UserPermissions,
         media_transport::{TransportConsumerRoute, TransportMediaId, TransportTeardown},
@@ -42,6 +42,7 @@ fn test_state() -> RoomState {
         &runtime_context,
         RoomAdmissionPolicy::new(4),
         RoomMediaLimits::default(),
+        VideoAdaptationTuning::default(),
         sample_client_rtp_capabilities(),
     )
 }

--- a/crates/core/src/engine/room/state/shared.rs
+++ b/crates/core/src/engine/room/state/shared.rs
@@ -12,7 +12,7 @@ use super::super::{
     transition::StagedPublishes,
 };
 use crate::{
-    RoomMediaLimits,
+    RoomMediaLimits, VideoAdaptationTuning,
     engine::{
         ConnectionId, MediaWorkerId, PeerSnapshot, RecordingState, UserId, UserInfo,
         media_transport::TransportSessionKey, room::placement::PlacementSnapshot,
@@ -24,6 +24,7 @@ use crate::{
 pub struct RoomState {
     pub(super) admission_policy: RoomAdmissionPolicy,
     pub media_limits: RoomMediaLimits,
+    pub video_adaptation_tuning: VideoAdaptationTuning,
     pub users: BTreeMap<UserId, ActiveUser>,
     /// rejects stale async callbacks from previous connections
     pub(super) next_connection_id: u64,
@@ -75,11 +76,13 @@ impl RoomState {
         runtime_context: &super::super::RoomRuntimeContext,
         admission_policy: RoomAdmissionPolicy,
         media_limits: RoomMediaLimits,
+        video_adaptation_tuning: VideoAdaptationTuning,
         router_rtp_capabilities: MediaCapabilities,
     ) -> Self {
         Self {
             admission_policy,
             media_limits,
+            video_adaptation_tuning,
             users: BTreeMap::new(),
             next_connection_id: 0,
             next_consumer_id: 1,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -78,7 +78,7 @@ mod sfu;
 pub(crate) use options::{
     AudioCodecPreference, CodecPreferences, LocalSpilloverPolicy, MediaCodecFlags, RoomMediaLimits,
     RoomSpilloverMode, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend, RuntimeFeatureFlags,
-    SessionBitrateLimits, VideoBitrateLimits, VideoCodecPreference,
+    SessionBitrateLimits, VideoAdaptationTuning, VideoBitrateLimits, VideoCodecPreference,
 };
 
 /// Media bitrate stored as bits per second (not bytes per second).

--- a/crates/core/src/options.rs
+++ b/crates/core/src/options.rs
@@ -7,7 +7,7 @@ pub use codecs::{AudioCodecPreference, CodecPreferences, MediaCodecFlags, VideoC
 pub use features::RuntimeFeatureFlags;
 pub use media::{
     RoomMediaLimits, RoomMediaLimitsError, RtcPortRange, RtcUdpIoBackend, SessionBitrateLimits,
-    VideoBitrateLimits,
+    VideoAdaptationTuning, VideoAdaptationTuningError, VideoBitrateLimits,
 };
 pub use routing::{
     LocalSpilloverPolicy, LocalSpilloverPolicyError, LocalSpilloverPolicyParts, RoomSpilloverMode,

--- a/crates/core/src/options/TESTS/media.rs
+++ b/crates/core/src/options/TESTS/media.rs
@@ -1,0 +1,48 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test assertions use unwrap and expect for clear failure messages"
+)]
+
+use super::{Bitrate, VideoAdaptationTuning, VideoAdaptationTuningError};
+
+#[test]
+fn video_adaptation_tuning_accepts_valid_knobs() {
+    let tuning = VideoAdaptationTuning::try_new(4, 3, 1, 2, 10, Bitrate::from_kbps(32))
+        .expect("valid tuning should build");
+    assert_eq!(tuning.multiparty_scalable_video_threshold, 4);
+    assert_eq!(tuning.thumbnail_budget_divisor, 3);
+    assert_eq!(tuning.downswitch_pressure_observations, 1);
+    assert_eq!(tuning.upswitch_stable_observations, 2);
+    assert_eq!(tuning.receiver_budget_headroom_percent, 10);
+    assert_eq!(tuning.audio_reserve_per_speaker, Bitrate::from_kbps(32));
+}
+
+#[test]
+fn video_adaptation_tuning_rejects_invalid_knobs() {
+    let cases = [
+        (
+            VideoAdaptationTuning::try_new(0, 2, 2, 3, 0, Bitrate::zero()),
+            VideoAdaptationTuningError::MultipartyScalableVideoThresholdZero,
+        ),
+        (
+            VideoAdaptationTuning::try_new(3, 0, 2, 3, 0, Bitrate::zero()),
+            VideoAdaptationTuningError::ThumbnailBudgetDivisorZero,
+        ),
+        (
+            VideoAdaptationTuning::try_new(3, 2, 0, 3, 0, Bitrate::zero()),
+            VideoAdaptationTuningError::DownswitchPressureObservationsZero,
+        ),
+        (
+            VideoAdaptationTuning::try_new(3, 2, 2, 0, 0, Bitrate::zero()),
+            VideoAdaptationTuningError::UpswitchStableObservationsZero,
+        ),
+        (
+            VideoAdaptationTuning::try_new(3, 2, 2, 3, 101, Bitrate::zero()),
+            VideoAdaptationTuningError::ReceiverBudgetHeadroomPercentTooHigh,
+        ),
+    ];
+    for (result, expected) in cases {
+        assert_eq!(result.err(), Some(expected));
+    }
+}

--- a/crates/core/src/options/media.rs
+++ b/crates/core/src/options/media.rs
@@ -151,13 +151,14 @@ impl Default for RoomMediaLimits {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoAdaptationTuning {
-    multiparty_scalable_video_threshold: usize,
-    thumbnail_budget_divisor: u64,
-    downswitch_pressure_observations: u8,
-    upswitch_stable_observations: u8,
+    pub(crate) multiparty_scalable_video_threshold: usize,
+    pub(crate) thumbnail_budget_divisor: u64,
+    pub(crate) downswitch_pressure_observations: u8,
+    pub(crate) upswitch_stable_observations: u8,
+    pub(crate) receiver_budget_headroom_percent: u8,
+    pub(crate) audio_reserve_per_speaker: Bitrate,
 }
 
-/// Invalid video adaptation tuning input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum VideoAdaptationTuningError {
     #[error("multiparty scalable video threshold must be greater than zero")]
@@ -168,6 +169,8 @@ pub enum VideoAdaptationTuningError {
     DownswitchPressureObservationsZero,
     #[error("upswitch stable observations must be greater than zero")]
     UpswitchStableObservationsZero,
+    #[error("receiver budget headroom percent must not exceed 100")]
+    ReceiverBudgetHeadroomPercentTooHigh,
 }
 
 impl VideoAdaptationTuning {
@@ -175,17 +178,28 @@ impl VideoAdaptationTuning {
     pub const DEFAULT_THUMBNAIL_BUDGET_DIVISOR: u64 = 2;
     pub const DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS: u8 = 2;
     pub const DEFAULT_UPSWITCH_STABLE_OBSERVATIONS: u8 = 3;
+    /// No headroom is reserved by default, so video is budgeted against the full
+    /// receiver estimate. Deployments that carry audio, retransmission or FEC
+    /// alongside video should raise this.
+    pub const DEFAULT_RECEIVER_BUDGET_HEADROOM_PERCENT: u8 = 0;
+    /// No per-speaker audio reserve by default, so the video budget is unchanged.
+    /// Set to the nominal audio bitrate to hold that much bandwidth back from the
+    /// video budget for each admitted audio speaker; the reserve is fixed at this
+    /// rate times the admitted audio speaker count. Zero disables audio
+    /// reservation entirely.
+    pub const DEFAULT_AUDIO_RESERVE_PER_SPEAKER: Bitrate = Bitrate::zero();
 
-    /// Build video adaptation tuning after validating its invariants.
-    ///
     /// # Errors
     ///
-    /// Returns [`VideoAdaptationTuningError`] when a knob is zero.
+    /// Returns [`VideoAdaptationTuningError`] when an observation knob is zero or
+    /// the headroom percent exceeds 100.
     pub const fn try_new(
         multiparty_scalable_video_threshold: usize,
         thumbnail_budget_divisor: u64,
         downswitch_pressure_observations: u8,
         upswitch_stable_observations: u8,
+        receiver_budget_headroom_percent: u8,
+        audio_reserve_per_speaker: Bitrate,
     ) -> Result<Self, VideoAdaptationTuningError> {
         if multiparty_scalable_video_threshold == 0 {
             return Err(VideoAdaptationTuningError::MultipartyScalableVideoThresholdZero);
@@ -199,48 +213,30 @@ impl VideoAdaptationTuning {
         if upswitch_stable_observations == 0 {
             return Err(VideoAdaptationTuningError::UpswitchStableObservationsZero);
         }
+        if receiver_budget_headroom_percent > 100 {
+            return Err(VideoAdaptationTuningError::ReceiverBudgetHeadroomPercentTooHigh);
+        }
         Ok(Self {
             multiparty_scalable_video_threshold,
             thumbnail_budget_divisor,
             downswitch_pressure_observations,
             upswitch_stable_observations,
+            receiver_budget_headroom_percent,
+            audio_reserve_per_speaker,
         })
-    }
-
-    #[must_use]
-    pub const fn conservative() -> Self {
-        Self {
-            multiparty_scalable_video_threshold: Self::DEFAULT_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD,
-            thumbnail_budget_divisor: Self::DEFAULT_THUMBNAIL_BUDGET_DIVISOR,
-            downswitch_pressure_observations: Self::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS,
-            upswitch_stable_observations: Self::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
-        }
-    }
-
-    #[must_use]
-    pub const fn multiparty_scalable_video_threshold(self) -> usize {
-        self.multiparty_scalable_video_threshold
-    }
-
-    #[must_use]
-    pub const fn thumbnail_budget_divisor(self) -> u64 {
-        self.thumbnail_budget_divisor
-    }
-
-    #[must_use]
-    pub const fn downswitch_pressure_observations(self) -> u8 {
-        self.downswitch_pressure_observations
-    }
-
-    #[must_use]
-    pub const fn upswitch_stable_observations(self) -> u8 {
-        self.upswitch_stable_observations
     }
 }
 
 impl Default for VideoAdaptationTuning {
     fn default() -> Self {
-        Self::conservative()
+        Self {
+            multiparty_scalable_video_threshold: Self::DEFAULT_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD,
+            thumbnail_budget_divisor: Self::DEFAULT_THUMBNAIL_BUDGET_DIVISOR,
+            downswitch_pressure_observations: Self::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS,
+            upswitch_stable_observations: Self::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
+            receiver_budget_headroom_percent: Self::DEFAULT_RECEIVER_BUDGET_HEADROOM_PERCENT,
+            audio_reserve_per_speaker: Self::DEFAULT_AUDIO_RESERVE_PER_SPEAKER,
+        }
     }
 }
 
@@ -294,3 +290,7 @@ impl Default for VideoBitrateLimits {
         Self::new(Self::DEFAULT_MAX_VIDEO_BITRATE)
     }
 }
+
+#[cfg(test)]
+#[path = "TESTS/media.rs"]
+mod tests;

--- a/crates/core/src/options/media.rs
+++ b/crates/core/src/options/media.rs
@@ -150,6 +150,101 @@ impl Default for RoomMediaLimits {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VideoAdaptationTuning {
+    multiparty_scalable_video_threshold: usize,
+    thumbnail_budget_divisor: u64,
+    downswitch_pressure_observations: u8,
+    upswitch_stable_observations: u8,
+}
+
+/// Invalid video adaptation tuning input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum VideoAdaptationTuningError {
+    #[error("multiparty scalable video threshold must be greater than zero")]
+    MultipartyScalableVideoThresholdZero,
+    #[error("thumbnail budget divisor must be greater than zero")]
+    ThumbnailBudgetDivisorZero,
+    #[error("downswitch pressure observations must be greater than zero")]
+    DownswitchPressureObservationsZero,
+    #[error("upswitch stable observations must be greater than zero")]
+    UpswitchStableObservationsZero,
+}
+
+impl VideoAdaptationTuning {
+    pub const DEFAULT_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD: usize = 3;
+    pub const DEFAULT_THUMBNAIL_BUDGET_DIVISOR: u64 = 2;
+    pub const DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS: u8 = 2;
+    pub const DEFAULT_UPSWITCH_STABLE_OBSERVATIONS: u8 = 3;
+
+    /// Build video adaptation tuning after validating its invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VideoAdaptationTuningError`] when a knob is zero.
+    pub const fn try_new(
+        multiparty_scalable_video_threshold: usize,
+        thumbnail_budget_divisor: u64,
+        downswitch_pressure_observations: u8,
+        upswitch_stable_observations: u8,
+    ) -> Result<Self, VideoAdaptationTuningError> {
+        if multiparty_scalable_video_threshold == 0 {
+            return Err(VideoAdaptationTuningError::MultipartyScalableVideoThresholdZero);
+        }
+        if thumbnail_budget_divisor == 0 {
+            return Err(VideoAdaptationTuningError::ThumbnailBudgetDivisorZero);
+        }
+        if downswitch_pressure_observations == 0 {
+            return Err(VideoAdaptationTuningError::DownswitchPressureObservationsZero);
+        }
+        if upswitch_stable_observations == 0 {
+            return Err(VideoAdaptationTuningError::UpswitchStableObservationsZero);
+        }
+        Ok(Self {
+            multiparty_scalable_video_threshold,
+            thumbnail_budget_divisor,
+            downswitch_pressure_observations,
+            upswitch_stable_observations,
+        })
+    }
+
+    #[must_use]
+    pub const fn conservative() -> Self {
+        Self {
+            multiparty_scalable_video_threshold: Self::DEFAULT_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD,
+            thumbnail_budget_divisor: Self::DEFAULT_THUMBNAIL_BUDGET_DIVISOR,
+            downswitch_pressure_observations: Self::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS,
+            upswitch_stable_observations: Self::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
+        }
+    }
+
+    #[must_use]
+    pub const fn multiparty_scalable_video_threshold(self) -> usize {
+        self.multiparty_scalable_video_threshold
+    }
+
+    #[must_use]
+    pub const fn thumbnail_budget_divisor(self) -> u64 {
+        self.thumbnail_budget_divisor
+    }
+
+    #[must_use]
+    pub const fn downswitch_pressure_observations(self) -> u8 {
+        self.downswitch_pressure_observations
+    }
+
+    #[must_use]
+    pub const fn upswitch_stable_observations(self) -> u8 {
+        self.upswitch_stable_observations
+    }
+}
+
+impl Default for VideoAdaptationTuning {
+    fn default() -> Self {
+        Self::conservative()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SessionBitrateLimits {
     max_bitrate_in: Bitrate,
     max_bitrate_out: Bitrate,

--- a/crates/core/src/prelude.rs
+++ b/crates/core/src/prelude.rs
@@ -13,7 +13,8 @@ pub use crate::{
         AudioCodecPreference, CodecPreferences, LocalSpilloverPolicy, LocalSpilloverPolicyError,
         LocalSpilloverPolicyParts, MediaCodecFlags, RoomMediaLimits, RoomMediaLimitsError,
         RoomSpilloverMode, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend, RuntimeFeatureFlags,
-        SessionBitrateLimits, VideoBitrateLimits, VideoCodecPreference,
+        SessionBitrateLimits, VideoAdaptationTuning, VideoAdaptationTuningError,
+        VideoBitrateLimits, VideoCodecPreference,
     },
     sfu::{
         MediaSession, NegotiationOffer, SessionError, SfuCore, SfuCoreError, UploadEncoding,

--- a/crates/router/src/TESTS/test_support/rtp_samples.rs
+++ b/crates/router/src/TESTS/test_support/rtp_samples.rs
@@ -90,6 +90,34 @@ pub fn sample_simulcast_video_rtp_parameters(mid: Option<&str>) -> MediaStream {
     )
 }
 
+#[must_use]
+pub fn sample_three_layer_simulcast_video_rtp_parameters(mid: Option<&str>) -> MediaStream {
+    with_optional_mid(
+        MediaStream::new(
+            vec![video_codec_parameters()],
+            vec![HeaderExtension::new(
+                webrtc::RtpHeaderExtensionUri::Mid,
+                HEADER_EXTENSION_ID_MID,
+            )],
+            vec![
+                StreamBinding::new()
+                    .with_ssrc(32_001)
+                    .with_rid("lo")
+                    .with_max_bitrate(150_000),
+                StreamBinding::new()
+                    .with_ssrc(32_002)
+                    .with_rid("mid")
+                    .with_max_bitrate(450_000),
+                StreamBinding::new()
+                    .with_ssrc(32_003)
+                    .with_rid("hi")
+                    .with_max_bitrate(900_000),
+            ],
+        ),
+        mid,
+    )
+}
+
 fn with_optional_mid(stream: MediaStream, mid: Option<&str>) -> MediaStream {
     match mid {
         Some(mid) => stream.with_mid(mid.to_owned()),

--- a/src/config/TESTS/transport.rs
+++ b/src/config/TESTS/transport.rs
@@ -5,7 +5,7 @@ use o_sfu_core::prelude::{LocalSpilloverPolicy, RoomSpilloverMode};
 
 use super::{
     Bitrate, Env, RoomMediaLimits, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend,
-    TransportConfig, VideoBitrateLimits, default_rtc_media_worker_count,
+    TransportConfig, VideoAdaptationTuning, VideoBitrateLimits, default_rtc_media_worker_count,
 };
 
 fn load_transport_config(get_var: impl Fn(&str) -> Option<String>) -> Result<TransportConfig> {
@@ -60,6 +60,7 @@ fn load_transport_config_accepts_public_ip_and_defaults() {
             rtc_media_worker_count: worker_count,
             room_worker_policy: RoomWorkerPolicy::strict_single_router(),
             room_media_limits: RoomMediaLimits::default(),
+            video_adaptation_tuning: VideoAdaptationTuning::default(),
         })
     );
 }
@@ -161,6 +162,51 @@ fn load_transport_config_accepts_room_media_limits() -> Result<()> {
         8
     );
     Ok(())
+}
+
+#[test]
+fn load_transport_config_accepts_video_adaptation_tuning() -> Result<()> {
+    let config = load_transport_config_with_defaults(&[
+        ("ROOM_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD", "5"),
+        ("ROOM_THUMBNAIL_BUDGET_DIVISOR", "3"),
+        ("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS", "4"),
+        ("ROOM_UPSWITCH_STABLE_OBSERVATIONS", "6"),
+        ("ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT", "15"),
+        ("ROOM_AUDIO_RESERVE_PER_SPEAKER_BPS", "40000"),
+    ])?;
+
+    assert_eq!(
+        config.video_adaptation_tuning,
+        VideoAdaptationTuning::try_new(5, 3, 4, 6, 15, Bitrate::from_bps(40_000))?
+    );
+    Ok(())
+}
+
+#[test]
+fn load_transport_config_defaults_video_adaptation_tuning() -> Result<()> {
+    let config = load_transport_config_with_defaults(&[])?;
+
+    assert_eq!(
+        config.video_adaptation_tuning,
+        VideoAdaptationTuning::default()
+    );
+    Ok(())
+}
+
+#[test]
+fn load_transport_config_rejects_invalid_video_adaptation_tuning() {
+    assert_invalid_transport_cases(&[
+        InvalidTransportCase {
+            name: "zero downswitch pressure observations",
+            overrides: &[("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS", "0")],
+            message: "ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS must be greater than zero",
+        },
+        InvalidTransportCase {
+            name: "headroom percent above 100",
+            overrides: &[("ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT", "150")],
+            message: "ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT must not exceed 100",
+        },
+    ]);
 }
 
 #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,7 +13,7 @@ mod user;
 
 pub use o_sfu_core::prelude::{
     Bitrate, CodecPreferences, MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcPortRange,
-    RtcUdpIoBackend, VideoBitrateLimits,
+    RtcUdpIoBackend, VideoAdaptationTuning, VideoAdaptationTuningError, VideoBitrateLimits,
 };
 
 pub use self::{

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -4,7 +4,7 @@ use o_sfu_core::prelude::Bitrate;
 
 use super::{
     CodecPreferences, MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcPortRange,
-    RtcUdpIoBackend, VideoBitrateLimits, diagnostics::DiagnosticsConfig,
+    RtcUdpIoBackend, VideoAdaptationTuning, VideoBitrateLimits, diagnostics::DiagnosticsConfig,
     feature_flags::RuntimeFeatureFlags, telemetry::TelemetryConfig,
 };
 
@@ -60,6 +60,7 @@ pub struct TransportConfig {
     pub rtc_media_worker_count: usize,
     pub room_worker_policy: RoomWorkerPolicy,
     pub room_media_limits: RoomMediaLimits,
+    pub video_adaptation_tuning: VideoAdaptationTuning,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -3,7 +3,8 @@ use std::{net::IpAddr, num::NonZeroUsize, thread};
 use anyhow::{Result, anyhow, ensure};
 use o_sfu_core::prelude::{
     Bitrate, LocalSpilloverPolicy, LocalSpilloverPolicyError, LocalSpilloverPolicyParts,
-    RoomMediaLimits, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend, VideoBitrateLimits,
+    RoomMediaLimits, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend, VideoAdaptationTuning,
+    VideoAdaptationTuningError, VideoBitrateLimits,
 };
 
 use super::{
@@ -89,6 +90,7 @@ impl TransportConfig {
         let room_spillover_mode = env.var("ROOM_SPILLOVER_MODE").optional()?;
         let local_spillover_policy = local_spillover_policy_from_env(env)?;
         let room_media_limits = room_media_limits_from_env(env)?;
+        let video_adaptation_tuning = video_adaptation_tuning_from_env(env)?;
         let rtc_port_range = RtcPortRange::new(rtc_min_port, rtc_max_port);
         ensure!(
             rtc_port_range.min() <= rtc_port_range.max(),
@@ -125,6 +127,7 @@ impl TransportConfig {
             rtc_media_worker_count,
             room_worker_policy,
             room_media_limits,
+            video_adaptation_tuning,
         })
     }
 }
@@ -182,6 +185,40 @@ fn room_media_limits_from_env(env: &Env<'_>) -> Result<RoomMediaLimits> {
     )?)
 }
 
+fn video_adaptation_tuning_from_env(env: &Env<'_>) -> Result<VideoAdaptationTuning> {
+    let multiparty_scalable_video_threshold = env
+        .var("ROOM_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD")
+        .check(positive)
+        .default(VideoAdaptationTuning::DEFAULT_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD)?;
+    let thumbnail_budget_divisor = env
+        .var("ROOM_THUMBNAIL_BUDGET_DIVISOR")
+        .check(positive)
+        .default(VideoAdaptationTuning::DEFAULT_THUMBNAIL_BUDGET_DIVISOR)?;
+    let downswitch_pressure_observations = env
+        .var("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS")
+        .check(positive)
+        .default(VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS)?;
+    let upswitch_stable_observations = env
+        .var("ROOM_UPSWITCH_STABLE_OBSERVATIONS")
+        .check(positive)
+        .default(VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS)?;
+    let receiver_budget_headroom_percent = env
+        .var("ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT")
+        .default(VideoAdaptationTuning::DEFAULT_RECEIVER_BUDGET_HEADROOM_PERCENT)?;
+    let audio_reserve_per_speaker_bps = env
+        .var("ROOM_AUDIO_RESERVE_PER_SPEAKER_BPS")
+        .default(VideoAdaptationTuning::DEFAULT_AUDIO_RESERVE_PER_SPEAKER.as_bps())?;
+    VideoAdaptationTuning::try_new(
+        multiparty_scalable_video_threshold,
+        thumbnail_budget_divisor,
+        downswitch_pressure_observations,
+        upswitch_stable_observations,
+        receiver_budget_headroom_percent,
+        Bitrate::from_bps(audio_reserve_per_speaker_bps),
+    )
+    .map_err(video_adaptation_tuning_error)
+}
+
 pub fn default_rtc_media_worker_count() -> usize {
     thread::available_parallelism().map_or(1, NonZeroUsize::get)
 }
@@ -208,6 +245,26 @@ fn select_room_worker_policy(
         }
         (_, RoomSpilloverSetting::Bounded) => {
             RoomWorkerPolicy::bounded_local_spillover(room_max_local_routers)
+        }
+    }
+}
+
+fn video_adaptation_tuning_error(error: VideoAdaptationTuningError) -> anyhow::Error {
+    match error {
+        VideoAdaptationTuningError::MultipartyScalableVideoThresholdZero => {
+            anyhow!("ROOM_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD must be greater than zero")
+        }
+        VideoAdaptationTuningError::ThumbnailBudgetDivisorZero => {
+            anyhow!("ROOM_THUMBNAIL_BUDGET_DIVISOR must be greater than zero")
+        }
+        VideoAdaptationTuningError::DownswitchPressureObservationsZero => {
+            anyhow!("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS must be greater than zero")
+        }
+        VideoAdaptationTuningError::UpswitchStableObservationsZero => {
+            anyhow!("ROOM_UPSWITCH_STABLE_OBSERVATIONS must be greater than zero")
+        }
+        VideoAdaptationTuningError::ReceiverBudgetHeadroomPercentTooHigh => {
+            anyhow!("ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT must not exceed 100")
         }
     }
 }

--- a/src/runtime/TESTS/support.rs
+++ b/src/runtime/TESTS/support.rs
@@ -10,7 +10,8 @@ use crate::{
     config::{
         AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config, DiagnosticsConfig, HttpConfig,
         MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend,
-        RuntimeFeatureFlags, TelemetryConfig, TransportConfig, UserConfig, VideoBitrateLimits,
+        RuntimeFeatureFlags, TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning,
+        VideoBitrateLimits,
     },
     runtime::{
         MediaTransport, RuntimeServices, RuntimeState, build_media_transport, build_room_manager,
@@ -69,6 +70,7 @@ impl RuntimeTestBuilder {
                     rtc_media_worker_count: 1,
                     room_worker_policy: RoomWorkerPolicy::strict_single_router(),
                     room_media_limits: RoomMediaLimits::default(),
+                    video_adaptation_tuning: VideoAdaptationTuning::default(),
                     rtc_udp_io_backend: RtcUdpIoBackend::Tokio,
                 },
                 codecs: CodecConfig {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -342,6 +342,7 @@ fn build_room_runtime_policy(
     )
     .with_room_worker_policy(config.transport.room_worker_policy)
     .with_media_limits(config.transport.room_media_limits)
+    .with_video_adaptation_tuning(config.transport.video_adaptation_tuning)
 }
 
 fn build_room_manager(

--- a/tests/src/support/harness.rs
+++ b/tests/src/support/harness.rs
@@ -20,7 +20,8 @@ use o_sfu::{
     config::{
         AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config, DiagnosticsConfig, HttpConfig,
         MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend,
-        RuntimeFeatureFlags, TelemetryConfig, TransportConfig, UserConfig, VideoBitrateLimits,
+        RuntimeFeatureFlags, TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning,
+        VideoBitrateLimits,
     },
     core::server::room::{
         DEFAULT_USER_OUTBOUND_QUEUE_BYTE_CAPACITY, DEFAULT_USER_OUTBOUND_QUEUE_CAPACITY,
@@ -426,6 +427,7 @@ pub fn test_config(authentication_timeout_ms: u64, room_size: usize) -> Config {
             rtc_media_worker_count: 1,
             room_worker_policy: RoomWorkerPolicy::strict_single_router(),
             room_media_limits: RoomMediaLimits::default(),
+            video_adaptation_tuning: VideoAdaptationTuning::default(),
         },
         codecs: CodecConfig {
             flags: MediaCodecFlags::default(),


### PR DESCRIPTION
The video source-policy solver hard-coded its adaptation knobs and
budgeted video against the raw receiver estimate, ignoring audio and
degrading thumbnails straight to their lowest layer under pressure.

Promote the knobs into a validated `VideoAdaptationTuning` options
struct threaded through the room runtime policy / state / source-policy
pipeline (same path as `RoomMediaLimits`), and improve the budget:

- tuning: multiparty threshold, thumbnail budget divisor, down/up-switch
  observation counts -- previously constants, now per-deployment.
- overload: step the highest-consuming downgradable route down one layer
  at a time until within budget, instead of dropping every downgradable
  route to the cheapest layer, so mid-tier quality survives.
- budget: reserve a configurable headroom percent, and hold back
  bandwidth for admitted audio speakers using the per-media transport
  bitrate snapshot (per-speaker floor covers DTX silence), smoothed with
  an EWMA carried between policy turns in per-room state.

All new behaviour is off by default (zero headroom, zero audio floor),
so the effective video budget still equals the raw estimate until a
deployment opts in; existing behaviour and tests are unchanged.

Adds unit tests for the tuning validation and the budget/smoothing
helpers.


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [x] AI was used to write substantial segments of the code
