### PR TITLE
[FIX] client: avoid blocking ICE answers

### DIFF
--- a/crates/client/playwright/live_server.spec.js
+++ b/crates/client/playwright/live_server.spec.js
@@ -1,3 +1,6 @@
+import { createSocket } from "node:dgram";
+import { once } from "node:events";
+
 import { expect, test } from "@playwright/test";
 
 import {
@@ -35,6 +38,47 @@ import {
 
 const PUBLISHER_SESSION_ID = 41;
 const SUBSCRIBER_SESSION_ID = 42;
+const STUN_MAGIC_COOKIE = 0x2112a442;
+
+test("unresponsive STUN does not block the initial answer", async ({ browserName, context }) => {
+    test.skip(browserName !== "chromium", "Chromium-specific ICE gathering regression");
+    test.setTimeout(15_000);
+    const stun = createSocket("udp4");
+    let listening = false;
+    let stunRequests = 0;
+    stun.on("message", (message) => {
+        if (message.length >= 20 && message.readUInt32BE(4) === STUN_MAGIC_COOKIE) {
+            stunRequests += 1;
+        }
+    });
+
+    try {
+        stun.bind(0, "127.0.0.1");
+        await once(stun, "listening");
+        listening = true;
+        const channelUuid = await createChannel();
+        const peer = await createPeerPage(context);
+
+        await connectPeer(peer, {
+            channelUuid,
+            iceServers: [{ urls: `stun:127.0.0.1:${stun.address().port}` }],
+            jwt: createConnectToken(channelUuid, PUBLISHER_SESSION_ID)
+        });
+
+        await expect.poll(() => stunRequests).toBeGreaterThan(0);
+        await expect
+            .poll(async () => (await peerSnapshot(peer)).peerConnectionState, { timeout: 8_000 })
+            .toBe("connected");
+        const snapshot = await peerSnapshot(peer);
+        expect(snapshot.state).toBe("connected");
+    } finally {
+        if (listening) {
+            const closed = once(stun, "close");
+            stun.close();
+            await closed;
+        }
+    }
+});
 
 test("default VP8 camera pauses and resumes without renegotiation", async ({
     browserName,

--- a/crates/client/playwright/live_server_helpers.mjs
+++ b/crates/client/playwright/live_server_helpers.mjs
@@ -151,9 +151,9 @@ export async function observeNegotiationNeeded(page) {
         });
 }
 
-export async function connectPeer(page, { channelUuid, jwt, url = TEST_SFU_WS_URL }) {
+export async function connectPeer(page, { channelUuid, iceServers, jwt, url = TEST_SFU_WS_URL }) {
     await page.evaluate(
-        async ({ channelUuid, jwt, url }) => {
+        async ({ channelUuid, iceServers, jwt, url }) => {
             const serializeTrack = (track) =>
                 track
                     ? {
@@ -195,11 +195,9 @@ export async function connectPeer(page, { channelUuid, jwt, url = TEST_SFU_WS_UR
             client.addEventListener("update", (event) => {
                 harness.updates.push(serializeUpdate(event.detail));
             });
-            client.connect(url, jwt, {
-                channelUUID: channelUuid
-            });
+            client.connect(url, jwt, { channelUUID: channelUuid, iceServers });
         },
-        { channelUuid, jwt, url }
+        { channelUuid, iceServers, jwt, url }
     );
 }
 
@@ -406,9 +404,11 @@ export async function peerSnapshot(page) {
             );
         const harness = globalThis.__liveHarness;
         const client = harness.client;
+        const peerConnection = client?._runtime?._peerSession?._activePeer;
         return {
             consumers: client ? serializeConsumers(client._consumers) : {},
             errors: [...harness.errors],
+            peerConnectionState: peerConnection?.connectionState ?? null,
             state: client?.state ?? null,
             stateChanges: [...harness.stateChanges],
             updates: [...harness.updates]

--- a/crates/client/playwright/sfu_client.spec.js
+++ b/crates/client/playwright/sfu_client.spec.js
@@ -94,10 +94,8 @@ test.beforeEach(async ({ page }) => {
             constructor(config) {
                 this.closed = false;
                 this.config = config;
-                this.iceGatheringState = "new";
                 this.localDescription = null;
-                this.onicecandidate = null;
-                this.onicegatheringstatechange = null;
+                this.onicecandidateerror = null;
                 this.ontrack = null;
                 this.transceivers = [
                     { mid: "0", sender: new FakeSender() },
@@ -127,7 +125,6 @@ test.beforeEach(async ({ page }) => {
 
             async setLocalDescription(description) {
                 this.localDescription = description;
-                this.iceGatheringState = "complete";
             }
 
             async setRemoteDescription() {}

--- a/crates/client/src/internals/browser_types.ts
+++ b/crates/client/src/internals/browser_types.ts
@@ -57,8 +57,6 @@ export interface PeerConnectionTrackEvent {
     };
 }
 
-export type ClientIceGatheringState = "new" | "gathering" | "complete";
-
 export type ClientPeerConnectionState =
     "new" | "connecting" | "connected" | "disconnected" | "failed" | "closed";
 
@@ -68,11 +66,9 @@ export interface ClientPeerConnection {
     createAnswer(): Promise<{ sdp: string; type: "answer" }>;
     getStats?(): Promise<RTCStatsReport>;
     getTransceivers(): PeerConnectionTransceiver[];
-    iceGatheringState?: ClientIceGatheringState;
     localDescription?: { sdp: string; type: "answer" } | null;
-    onicecandidate: ((event: { candidate: { candidate: string } | null }) => void) | null;
-    onicegatheringstatechange: (() => void) | null;
     onconnectionstatechange: (() => void) | null;
+    onicecandidateerror: ((event: RTCPeerConnectionIceErrorEvent) => void) | null;
     ontrack: ((event: PeerConnectionTrackEvent) => void) | null;
     setLocalDescription(description: { sdp: string; type: "answer" }): Promise<void>;
     setRemoteDescription(description: { sdp: string; type: "offer" }): Promise<void>;

--- a/crates/client/src/internals/peer_session.ts
+++ b/crates/client/src/internals/peer_session.ts
@@ -102,6 +102,7 @@ export class PeerSession {
         });
         this._log(CLIENT_LOG_LEVEL.DEBUG, "created RTCPeerConnection");
         peer.onconnectionstatechange = () => this.handleConnectionState(peer);
+        peer.onicecandidateerror = (event) => this.handleIceCandidateError(peer, event);
         peer.ontrack = (event) => {
             if (this._activePeer !== peer) {
                 return;
@@ -183,9 +184,11 @@ export class PeerSession {
         if (!this.isActive(peer)) {
             return null;
         }
-        const answerSdp = await this.awaitStableLocalDescription(peer);
-        if (!this.isActive(peer)) {
-            return null;
+        const answerSdp = peer.localDescription?.sdp;
+        if (!answerSdp) {
+            throw new Error(
+                "peer connection local description is missing after setLocalDescription"
+            );
         }
         this._log(
             CLIENT_LOG_LEVEL.DEBUG,
@@ -214,6 +217,16 @@ export class PeerSession {
         };
     }
 
+    private handleIceCandidateError(
+        peer: ClientPeerConnection,
+        event: RTCPeerConnectionIceErrorEvent
+    ): void {
+        if (!this.isActive(peer)) {
+            return;
+        }
+        this._log(CLIENT_LOG_LEVEL.WARN, `ice candidate error: ${event.errorText}`);
+    }
+
     private handleConnectionState(peer: ClientPeerConnection): void {
         if (!this.isActive(peer)) {
             return;
@@ -228,47 +241,6 @@ export class PeerSession {
         } else if (state === "failed") {
             this._closeSocketForTransportFailure();
         }
-    }
-
-    private async awaitStableLocalDescription(peer: ClientPeerConnection): Promise<string> {
-        const initialSdp = peer.localDescription?.sdp;
-        if (!initialSdp) {
-            throw new Error("peer connection local description is missing after createAnswer");
-        }
-        if (peer.iceGatheringState === "complete") {
-            return initialSdp;
-        }
-
-        return new Promise((resolve) => {
-            const previousIceCandidate = peer.onicecandidate;
-            const previousIceGatheringStateChange = peer.onicegatheringstatechange;
-            const finishIfReady = (candidate: { candidate: string } | null | undefined) => {
-                const localSdp = peer.localDescription?.sdp;
-                if (!localSdp) {
-                    return;
-                }
-                if (candidate !== null && peer.iceGatheringState !== "complete") {
-                    return;
-                }
-                peer.onicecandidate = previousIceCandidate;
-                peer.onicegatheringstatechange = previousIceGatheringStateChange;
-                resolve(localSdp);
-            };
-
-            peer.onicecandidate = (event) => {
-                previousIceCandidate?.(event);
-                finishIfReady(event.candidate);
-            };
-            peer.onicegatheringstatechange = () => {
-                previousIceGatheringStateChange?.();
-                if (peer.iceGatheringState === "complete") {
-                    finishIfReady(undefined);
-                }
-            };
-            if (peer.iceGatheringState === "complete") {
-                finishIfReady(undefined);
-            }
-        });
     }
 
     private isActive(peer: ClientPeerConnection): boolean {

--- a/crates/client/test/sfu_client.test.mjs
+++ b/crates/client/test/sfu_client.test.mjs
@@ -713,28 +713,6 @@ test("negotiation creates a peer connection and emits lowercase track updates", 
     assert.equal(client._consumers.get(42).camera.track, track);
 });
 
-test("offer waits for the ICE-complete local description before replying", async () => {
-    const { core, emitMessage, peerConnections, connectWithWelcome } = createSfuClientHarness({
-        peerConnectionOptions: {
-            answerSdp: "answer-sdp",
-            gatheredAnswerSdp:
-                "answer-sdp\r\na=candidate:1 1 udp 2113937151 127.0.0.1 54400 typ host"
-        }
-    });
-
-    await connectWithWelcome();
-    await emitMessage("offer");
-
-    assert.equal(peerConnections.length, 1);
-    assert.deepEqual(core.submittedAnswers, [
-        {
-            negotiationKind: "offer",
-            requestId: "7",
-            sdp: "answer-sdp\r\na=candidate:1 1 udp 2113937151 127.0.0.1 54400 typ host"
-        }
-    ]);
-});
-
 test("protocol inputs wait for an in-flight negotiation to finish", async () => {
     const { promise: answerGate, resolve: releaseAnswer } = Promise.withResolvers();
     const callOrder = [];
@@ -1394,6 +1372,32 @@ test("peer connection disconnected does not tear down the websocket session", as
     assert.equal(client.state, "connected");
 });
 
+test("ICE candidate errors emit a warning without tearing down the session", async () => {
+    const { client, connectWithWelcome, emitMessage, handledErrors, peerConnections, sockets } =
+        createSfuClientHarness();
+    const logs = [];
+    client.addEventListener("log", (event) => logs.push(event.detail));
+
+    await connectWithWelcome();
+    await emitMessage("offer");
+
+    peerConnections[0].emitIceCandidateError({
+        errorCode: 701,
+        errorText: "STUN binding request timed out.",
+        url: "stun:stun.example.test:3478"
+    });
+    await tick();
+
+    assert.deepEqual(logs.at(-1), {
+        id: "browser_runtime",
+        level: "warn",
+        message: "ice candidate error: STUN binding request timed out."
+    });
+    assert.deepEqual(handledErrors, []);
+    assert.equal(sockets[0].closeCode, null);
+    assert.equal(client.state, "connected");
+});
+
 test("stale peer connection callbacks cannot affect the active session", async () => {
     const core = new FakeProtocolCore();
     core.transportFailureState = "recovering";
@@ -1401,6 +1405,8 @@ test("stale peer connection callbacks cannot affect the active session", async (
         createSfuClientHarness({
             protocolCore: core
         });
+    const logs = [];
+    client.addEventListener("log", (event) => logs.push(event.detail));
 
     await connect();
     await open();
@@ -1416,10 +1422,16 @@ test("stale peer connection callbacks cannot affect the active session", async (
     assert.equal(peerConnections.length, 2);
     assert.equal(stalePeerConnection.closed, true);
     const transportReadyCalls = core.transportReadyCalls;
+    const logCount = logs.length;
 
     stalePeerConnection.emitTrack(createCameraTrack("stale-camera"), "0");
     stalePeerConnection.emitConnectionState("connected");
     stalePeerConnection.emitConnectionState("failed");
+    stalePeerConnection.emitIceCandidateError({
+        errorCode: 701,
+        errorText: "STUN binding request timed out.",
+        url: "stun:stale.example.test:3478"
+    });
     await tick();
 
     assert.deepEqual(updates, []);
@@ -1428,6 +1440,7 @@ test("stale peer connection callbacks cannot affect the active session", async (
     assert.equal(sockets[0].closeCode, null);
     assert.equal(client.state, "connected");
     assert.equal(client._consumers.size, 0);
+    assert.equal(logs.length, logCount);
 });
 
 test("peer teardown clears bindings before the next peer can emit tracks", async () => {
@@ -2223,25 +2236,41 @@ test("initial offer binds a pending local track before answering", async () => {
     );
 });
 
-test("offer waits for ice gathering completion before submitting the final answer", async () => {
-    const { core, emitMessage, connectWithWelcome } = createSfuClientHarness({
-        peerConnectionOptions: {
-            autoConnect: false,
-            gatheredAnswerSdp: "gathered-answer-sdp",
-            preCompleteAnswerSdp: "candidate-answer-sdp"
+test("offer submits its local description while ice gathering continues", async () => {
+    class GatheringPeerConnection extends FakePeerConnection {
+        async setLocalDescription(description) {
+            await super.setLocalDescription(description);
+            this.iceGatheringState = "gathering";
         }
+
+        completeIceGathering() {
+            this.iceGatheringState = "complete";
+            this.onicegatheringstatechange?.();
+        }
+    }
+    const { core, emitMessage, connectWithWelcome, peerConnections } = createSfuClientHarness({
+        createPeerConnection: (config) =>
+            new GatheringPeerConnection(config, {
+                answerSdp: "answer-with-ice-credentials",
+                autoConnect: false
+            })
     });
 
     await connectWithWelcome();
     await emitMessage("offer");
 
-    assert.deepEqual(core.submittedAnswers, [
-        {
-            negotiationKind: "offer",
-            requestId: "7",
-            sdp: "gathered-answer-sdp"
-        }
-    ]);
+    try {
+        assert.deepEqual(core.submittedAnswers, [
+            {
+                negotiationKind: "offer",
+                requestId: "7",
+                sdp: "answer-with-ice-credentials"
+            }
+        ]);
+    } finally {
+        peerConnections[0].completeIceGathering();
+        await tick();
+    }
 });
 
 test("renegotiation binds pending camera and screen tracks to distinct offer-ordered mids", async () => {

--- a/crates/client/test/support/browser_fakes.mjs
+++ b/crates/client/test/support/browser_fakes.mjs
@@ -78,8 +78,6 @@ export class FakePeerConnection {
         {
             answerSdp = "answer-sdp",
             autoConnect = true,
-            gatheredAnswerSdp = null,
-            preCompleteAnswerSdp = null,
             peerConnectionStats = undefined,
             senderOptionsByMid = {}
         } = {}
@@ -89,15 +87,11 @@ export class FakePeerConnection {
         this.answerSnapshots = [];
         this.connectionState = "new";
         this.config = config;
-        this.gatheredAnswerSdp = gatheredAnswerSdp;
-        this.iceGatheringState = "new";
         this.localDescription = null;
         this.onconnectionstatechange = null;
-        this.onicecandidate = null;
-        this.onicegatheringstatechange = null;
+        this.onicecandidateerror = null;
         this.ontrack = null;
         this.peerConnectionStats = peerConnectionStats;
-        this.preCompleteAnswerSdp = preCompleteAnswerSdp;
         this.senderOptionsByMid = senderOptionsByMid;
         this.transceivers = [this._transceiver("0", "audio"), this._transceiver("1", "video")];
     }
@@ -124,18 +118,6 @@ export class FakePeerConnection {
                 transceiver.currentDirection = "inactive";
             }
         });
-        if (this.gatheredAnswerSdp) {
-            this.iceGatheringState = "gathering";
-            queueMicrotask(() => {
-                if (this.preCompleteAnswerSdp) {
-                    this._completeCandidateGathering(description);
-                    return;
-                }
-                this._completeIceGathering(description, true);
-            });
-        } else {
-            this.iceGatheringState = "complete";
-        }
         if (this.autoConnect) {
             this.emitConnectionState("connected");
         }
@@ -180,42 +162,14 @@ export class FakePeerConnection {
         this.onconnectionstatechange?.();
     }
 
+    emitIceCandidateError({ errorCode, errorText, url }) {
+        this.onicecandidateerror?.({ errorCode, errorText, url });
+    }
+
     _addRemoteTransceiver(description, mid, kind) {
         if (description.sdp.includes(`a=mid:${mid}`) && !this._hasTransceiver(mid)) {
             this.transceivers.push(this._transceiver(mid, kind));
         }
-    }
-
-    _completeCandidateGathering(description) {
-        this.localDescription = {
-            ...description,
-            sdp: this.preCompleteAnswerSdp
-        };
-        this.onicecandidate?.({
-            candidate: {
-                candidate: "candidate:1 1 udp 2113937151 127.0.0.1 54400 typ host"
-            }
-        });
-        queueMicrotask(() => {
-            this._completeIceGathering(description);
-        });
-    }
-
-    _completeIceGathering(description, emitCandidate = false) {
-        this.localDescription = {
-            ...description,
-            sdp: this.gatheredAnswerSdp
-        };
-        this.iceGatheringState = "complete";
-        if (emitCandidate) {
-            this.onicecandidate?.({
-                candidate: {
-                    candidate: "candidate:1 1 udp 2113937151 127.0.0.1 54400 typ host"
-                }
-            });
-        }
-        this.onicegatheringstatechange?.();
-        this.onicecandidate?.({ candidate: null });
     }
 
     _hasTransceiver(mid) {

--- a/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
+++ b/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
@@ -22,7 +22,7 @@ const FIREFOX_OFFER_AUDIO_ONLY: &str = include_str!("testdata/firefox_offer_audi
 const SAFARI_DATA_CHANNEL_OFFER: &str = include_str!("testdata/safari_datachannel_offer.sdp");
 
 #[tokio::test]
-async fn rtc_initial_session_offer_round_trips_through_str0m_answer() {
+async fn rtc_initial_session_offer_accepts_answer_without_candidates() {
     let adapter = RtcWorker::default();
     let session_key = transport_key(1, 34, UserId::Integer(34));
 
@@ -33,25 +33,19 @@ async fn rtc_initial_session_offer_round_trips_through_str0m_answer() {
     assert!(offer_sdp.contains("a=recvonly"));
 
     let mut remote = Rtc::new(Instant::now());
-    assert!(
-        remote
-            .add_local_candidate(
-                Candidate::host(SocketAddr::from(([127, 0, 0, 1], 55_000)), "udp")
-                    .expect("test host candidate should build"),
-            )
-            .is_some()
-    );
-    let answer = remote
+    let answer_sdp = remote
         .sdp_api()
         .accept_offer(
             SdpOffer::from_sdp_string(&offer_sdp)
                 .expect("adapter should return parseable SDP offer"),
         )
-        .expect("remote RTC should accept the adapter offer");
+        .expect("remote RTC should accept the adapter offer")
+        .to_sdp_string();
+    assert!(!answer_sdp.contains("a=candidate:"));
 
     assert!(
         adapter
-            .apply_session_answer(&session_key, &answer.to_sdp_string())
+            .apply_session_answer(&session_key, &answer_sdp)
             .await
             .is_ok()
     );
@@ -1432,12 +1426,12 @@ async fn apply_offer_answer(
     remote: &mut Rtc,
     offer_sdp: String,
 ) {
+    let offer =
+        SdpOffer::from_sdp_string(&offer_sdp).expect("adapter should return parseable SDP offer");
+    assert!(offer.session.end_of_candidates());
     let answer = remote
         .sdp_api()
-        .accept_offer(
-            SdpOffer::from_sdp_string(&offer_sdp)
-                .expect("adapter should return parseable SDP offer"),
-        )
+        .accept_offer(offer)
         .expect("remote answer should build");
     assert!(
         adapter

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/negotiation.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/negotiation.rs
@@ -14,7 +14,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use o_sfu_rfc::webrtc::MediaKind as ProtocolMediaKind;
+use o_sfu_rfc::webrtc::{self, MediaKind as ProtocolMediaKind};
 use str0m::{
     change::{SdpAnswer, SdpApi},
     media::{Direction, Media, MediaKind, Mid},
@@ -111,11 +111,12 @@ pub(super) fn worker_create_initial_session_offer(
         .staged_offer_upload_slots
         .clear();
     Ok(
-        SessionOffer::new(offer.to_sdp_string()).with_upload_slots(initial_upload_slots(
-            bootstrap_mids,
-            config.profile,
-            config.video_bitrate_limits,
-        )),
+        SessionOffer::new(offer_sdp_with_end_of_candidates(offer.to_sdp_string()))
+            .with_upload_slots(initial_upload_slots(
+                bootstrap_mids,
+                config.profile,
+                config.video_bitrate_limits,
+            )),
     )
 }
 
@@ -139,7 +140,10 @@ pub(super) fn worker_create_session_renegotiation_offer(
         .sdp_negotiation
         .staged_offer_upload_slots
         .clone();
-    Ok(SessionOffer::new(offer_sdp).with_upload_slots(upload_slots))
+    Ok(
+        SessionOffer::new(offer_sdp_with_end_of_candidates(offer_sdp))
+            .with_upload_slots(upload_slots),
+    )
 }
 
 /// Accept the currently pending local offer and reconcile every worker-local
@@ -367,6 +371,14 @@ fn stage_queued_removal_offer(session_state: &mut super::super::super::state::Rt
         .sdp_negotiation
         .staged_offer_upload_slots
         .clear();
+}
+
+fn offer_sdp_with_end_of_candidates(mut offer_sdp: String) -> String {
+    let media_line_start = offer_sdp
+        .find("\r\nm=")
+        .map_or(offer_sdp.len(), |index| index + 2);
+    offer_sdp.insert_str(media_line_start, webrtc::sdp::END_OF_CANDIDATES_LINE);
+    offer_sdp
 }
 
 fn ensure_initial_negotiation_media(

--- a/crates/rfc/src/webrtc.rs
+++ b/crates/rfc/src/webrtc.rs
@@ -251,6 +251,10 @@ pub mod rtcp_feedback {
 
 pub mod sdp {
     pub const ATTRIBUTE_PREFIX: &str = "a=";
+    /// Session-level end-of-candidates indication.
+    ///
+    /// Reference: RFC 8840 section 8.
+    pub const END_OF_CANDIDATES_LINE: &str = "a=end-of-candidates\r\n";
     pub const MEDIA_PREFIX: &str = "m=";
 
     pub mod group_semantics {

--- a/tests/integration/server_smoke.rs
+++ b/tests/integration/server_smoke.rs
@@ -17,6 +17,7 @@ use o_sfu_tests::support::{
     read_close_code, require_some, signed_connect_claims, spawn_test_server, test_config,
 };
 use reqwest::StatusCode;
+use str0m::change::SdpOffer;
 use tokio::time::{Duration, timeout};
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 
@@ -131,6 +132,13 @@ async fn websocket_welcome_and_initial_offer_expose_real_rtc_transport_details()
         panic!("expected offer request");
     };
     assert!(payload.sdp.contains("a=ice-lite"));
+    assert!(payload.sdp.contains("a=ice-options:trickle"));
+    let parsed_offer = require_some(
+        SdpOffer::from_sdp_string(&payload.sdp).ok(),
+        "offer should contain parseable SDP",
+    )?;
+    assert!(parsed_offer.session.end_of_candidates());
+    assert_eq!(payload.sdp.matches("a=end-of-candidates").count(), 1);
     assert!(payload.sdp.contains("a=fingerprint:sha-256"));
     assert!(payload.sdp.contains("a=candidate:"));
     assert!(payload.sdp.contains("127.0.0.1"));
@@ -150,6 +158,23 @@ async fn websocket_welcome_and_initial_offer_expose_real_rtc_transport_details()
         "candidate should expose an RTC port",
     )?;
     assert!(rtc_port_range.ports().any(|candidate| candidate == port));
+    Ok(())
+}
+
+#[tokio::test]
+async fn websocket_candidate_free_answer_establishes_rtc_transport() -> TestResult {
+    let (server, room) = server_with_room("issuer-candidate-free-answer").await?;
+    let mut client = client_in_room(&server, &room, UserId::Integer(703)).await?;
+
+    require_some(client.read_welcome().await, "welcome should be sent")?;
+    require_some(
+        client.finish_initial_negotiation_without_candidates().await,
+        "candidate-free answer should be accepted",
+    )?;
+    require_some(
+        client.wait_until_connected(Duration::from_secs(5)).await,
+        "candidate-free answer should establish ICE and DTLS",
+    )?;
     Ok(())
 }
 

--- a/tests/src/support/fake_rtc_peer.rs
+++ b/tests/src/support/fake_rtc_peer.rs
@@ -88,22 +88,36 @@ impl FakeRtcPeer {
         })
     }
 
+    pub fn answer_offer_without_candidates(
+        &mut self,
+        offer_sdp: &str,
+    ) -> Option<SessionDescriptionPayload> {
+        let mut answer = self.answer_offer(offer_sdp)?;
+        answer.sdp = answer
+            .sdp
+            .split_inclusive("\r\n")
+            .filter(|line| {
+                !line
+                    .strip_prefix(webrtc::sdp::ATTRIBUTE_PREFIX)
+                    .is_some_and(|attribute| {
+                        attribute.starts_with(webrtc::ice::candidate_attribute::PREFIX)
+                    })
+            })
+            .collect();
+        Some(answer)
+    }
+
     pub async fn wait_until_connected(&mut self, timeout_window: Duration) -> Option<()> {
-        let deadline = Instant::now() + timeout_window;
-        if pump_until(
+        pump_until(
             &mut self.rtc,
             &self.socket,
             self.local_addr,
             &mut self.connected,
-            deadline,
+            Instant::now() + timeout_window,
             true,
         )
         .await?
-        {
-            Some(())
-        } else {
-            None
-        }
+        .then_some(())
     }
 
     pub async fn send_rtp_packets(
@@ -249,16 +263,9 @@ async fn pump_until(
                     return Some(true);
                 }
             }
-            Output::Event(Event::IceConnectionStateChange(state)) => match state {
-                IceConnectionState::Connected | IceConnectionState::Completed => {
-                    *connected = true;
-                    if stop_on_connected {
-                        return Some(true);
-                    }
-                }
-                IceConnectionState::Disconnected => return None,
-                _ => {}
-            },
+            Output::Event(Event::IceConnectionStateChange(IceConnectionState::Disconnected)) => {
+                return None;
+            }
             Output::Event(_) => {}
             Output::Timeout(timeout_at) => {
                 if timeout_at <= now {
@@ -324,13 +331,9 @@ async fn pump_until_rtp(
             Output::Event(Event::Connected) => {
                 *connected = true;
             }
-            Output::Event(Event::IceConnectionStateChange(state)) => match state {
-                IceConnectionState::Connected | IceConnectionState::Completed => {
-                    *connected = true;
-                }
-                IceConnectionState::Disconnected => return None,
-                _ => {}
-            },
+            Output::Event(Event::IceConnectionStateChange(IceConnectionState::Disconnected)) => {
+                return None;
+            }
             Output::Event(_) => {}
             Output::Timeout(timeout_at) => {
                 if timeout_at <= now {

--- a/tests/src/support/protocol_harness.rs
+++ b/tests/src/support/protocol_harness.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use futures_util::SinkExt;
 use o_sfu_protocol::wire::{
-    AuthPayload, ClientBroadcastPayload, ClientEnvelope, ClientMessage, EnvelopeBatch, RequestId,
-    ServerEnvelope, ServerMessage, ServerRequest, UserId, WelcomePayload,
+    AuthPayload, ClientBroadcastPayload, ClientEnvelope, ClientMessage, ClientResponse,
+    EnvelopeBatch, RequestId, ServerEnvelope, ServerMessage, ServerRequest, UserId, WelcomePayload,
 };
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::{self, protocol::frame::coding::CloseCode};
@@ -83,8 +83,32 @@ impl ProtocolWebSocketClient {
         let ServerRequest::Offer(_) = request else {
             return None;
         };
-        self.respond_to_negotiation_request(request_id, request)
+        send_server_request_response(&mut self.websocket, &mut self.rtc_peer, request_id, request)
             .await
+    }
+
+    pub async fn finish_initial_negotiation_without_candidates(&mut self) -> Option<()> {
+        let (response_to, request) = self.read_server_request().await?;
+        let ServerRequest::Offer(payload) = request else {
+            return None;
+        };
+        let answer = self
+            .rtc_peer
+            .answer_offer_without_candidates(&payload.sdp)?;
+        self.websocket
+            .send(tungstenite::Message::Text(
+                encode_client_batch(vec![ClientEnvelope::Response {
+                    response_to,
+                    response: ClientResponse::Offer(answer),
+                }])?
+                .into(),
+            ))
+            .await
+            .ok()
+    }
+
+    pub async fn wait_until_connected(&mut self, timeout_window: Duration) -> Option<()> {
+        self.rtc_peer.wait_until_connected(timeout_window).await
     }
 
     pub async fn send_message(&mut self, message: ClientMessage) -> Option<()> {
@@ -133,20 +157,6 @@ impl ProtocolWebSocketClient {
         duration: Duration,
     ) -> Option<ServerMessage> {
         timeout(duration, self.read_server_message()).await.ok()?
-    }
-
-    pub async fn respond_to_negotiation_request(
-        &mut self,
-        response_to: RequestId,
-        request: ServerRequest,
-    ) -> Option<()> {
-        send_server_request_response(
-            &mut self.websocket,
-            &mut self.rtc_peer,
-            response_to,
-            request,
-        )
-        .await
     }
 
     pub async fn read_close_code(&mut self) -> Option<CloseCode> {


### PR DESCRIPTION
ICE gathering can outlast Odoo's connection deadline when an optional STUN server does not respond.

Submit the local description after setLocalDescription. The ICE-lite server learns the nominated source from connectivity checks

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
