### PR TITLE
[FIX] core: exclude paused cameras from featuring

### DIFF
--- a/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
@@ -2,11 +2,15 @@ use std::time::Duration;
 
 use super::support::*;
 use crate::engine::{
+    UserInfo,
     media_transport::{
         ActiveSpeakerSource, ReceiverBandwidthSnapshot, TransportMediaId, TransportTeardown,
     },
-    room::source_policy::SourcePolicyTransaction,
-    source_model::{ConsumerSourceSelection, PublishedSourceId, SourcePolicy, SourcePublishIntent},
+    room::{DeactivateIntentOutcome, source_policy::SourcePolicyTransaction},
+    source_model::{
+        ConsumerSourceSelection, PublishedSourceId, SourceDeactivateIntent, SourcePolicy,
+        SourcePublishIntent,
+    },
 };
 
 #[tokio::test]
@@ -239,7 +243,6 @@ async fn source_policy_resets_receiver_bwe_target_after_publication_deactivation
 #[tokio::test]
 async fn source_policy_stale_featured_update_does_not_mark_replacement_user() {
     let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
-    let featured_user_id = UserId::Integer(1);
     scenario.publish_audio_and_camera(1).await;
     let audio_media_id = scenario.audio_media_id(1).await;
     scenario.mark_active_speaker(audio_media_id).await;
@@ -249,21 +252,13 @@ async fn source_policy_stale_featured_update_does_not_mark_replacement_user() {
     join_user_without_transport_teardown(
         &scenario.room,
         &scenario.adapter,
-        featured_user_id.clone(),
+        UserId::Integer(1),
         replacement_tx,
     )
     .await;
     tx.execute(&scenario.room, &scenario.adapter).await;
 
-    let info = scenario
-        .room
-        .test_api()
-        .inspect()
-        .user_info_snapshot(&featured_user_id)
-        .await
-        .expect("replacement user should still be present")
-        .1;
-    assert_eq!(info.is_featured, Some(false));
+    assert_featured(&scenario, 1, false).await;
 }
 
 #[tokio::test]
@@ -337,6 +332,77 @@ async fn active_speaker_camera_policy_selects_the_observed_speaker() {
 }
 
 #[tokio::test]
+async fn active_speaker_camera_policy_tracks_camera_activity() {
+    let (room, adapter, _owner_rx, mut observer_rx) = setup_two_ready_users().await;
+    let scenario = SourcePolicyScenario { room, adapter };
+    let owner_id = UserId::Integer(1);
+    publish_track(
+        &scenario.room,
+        &owner_id,
+        TestSourceKind::AudioDetector,
+        MediaKind::Audio,
+        test_audio_rtp_parameters(),
+        &scenario.adapter,
+    )
+    .await;
+    let audio_media_id = scenario.audio_media_id(1).await;
+
+    scenario.mark_active_speaker(audio_media_id).await;
+    scenario.refresh_policy().await;
+    assert_featured(&scenario, 1, false).await;
+    drain_outbound(&mut observer_rx);
+
+    let camera = source_publish_intent_for_source(TestSourceKind::ScalableVideo).with_presence(
+        Some(UserInfo {
+            is_camera_on: Some(true),
+            ..UserInfo::default()
+        }),
+    );
+    scenario
+        .room
+        .test_api()
+        .media()
+        .publish_intent(
+            &owner_id,
+            &camera,
+            MediaKind::Video,
+            test_simulcast_video_rtp_parameters(),
+            &scenario.adapter,
+        )
+        .await
+        .expect("camera publication should succeed");
+    assert_camera_feature_fanout(&mut observer_rx, &owner_id, true);
+
+    let connection_id = user_connection_id(&scenario.room, &owner_id).await;
+    let stream_id = stream_id_for_source(TestSourceKind::ScalableVideo);
+    let pause = SourceDeactivateIntent::new(stream_id).with_presence(Some(UserInfo {
+        is_camera_on: Some(false),
+        ..UserInfo::default()
+    }));
+    assert_eq!(
+        scenario
+            .room
+            .user_operation(&owner_id, connection_id, &scenario.adapter)
+            .deactivate_publication(&pause)
+            .await,
+        DeactivateIntentOutcome::Deactivated
+    );
+
+    assert_eq!(scenario.room.test_api().inspect().producer_count().await, 2);
+    assert_camera_feature_fanout(&mut observer_rx, &owner_id, false);
+    assert!(matches!(
+        scenario
+            .room
+            .user_operation(&owner_id, connection_id, &scenario.adapter)
+            .start_publish(&camera, true)
+            .await,
+        Ok(PublishIntentOutcome::Activated)
+    ));
+
+    assert_camera_feature_fanout(&mut observer_rx, &owner_id, true);
+}
+
+#[tokio::test]
 async fn active_speaker_camera_policy_prefers_louder_same_observation_speaker() {
     let scenario = SourcePolicyScenario::with_ready_users_and_media_limits(
         &[1, 2, 3],
@@ -355,24 +421,8 @@ async fn active_speaker_camera_policy_prefers_louder_same_observation_speaker() 
         .await;
     scenario.refresh_policy_until_upgrades_settle().await;
 
-    let first_info = scenario
-        .room
-        .test_api()
-        .inspect()
-        .user_info_snapshot(&UserId::Integer(1))
-        .await
-        .unwrap()
-        .1;
-    let third_info = scenario
-        .room
-        .test_api()
-        .inspect()
-        .user_info_snapshot(&UserId::Integer(3))
-        .await
-        .unwrap()
-        .1;
-    assert_eq!(first_info.is_featured, Some(false));
-    assert_eq!(third_info.is_featured, Some(true));
+    assert_featured(&scenario, 1, false).await;
+    assert_featured(&scenario, 3, true).await;
 
     assert_subscription_policy_pause_reason(
         &scenario.room,
@@ -701,6 +751,35 @@ async fn source_policy_transaction_from_transport_snapshot(
         &receiver_bandwidth_snapshot,
     )
     .expect("source policy transaction should contain work before execution")
+}
+
+async fn assert_featured(scenario: &SourcePolicyScenario, user_id: i64, expected: bool) {
+    let info = scenario
+        .room
+        .test_api()
+        .inspect()
+        .user_info_snapshot(&UserId::Integer(user_id))
+        .await
+        .expect("user should still be present")
+        .1;
+    assert_eq!(info.is_featured, Some(expected));
+}
+
+fn assert_camera_feature_fanout(rx: &mut UserOutboundReceiver, user: &UserId, expected: bool) {
+    let info = drain_outbound(rx)
+        .into_iter()
+        .rev()
+        .find_map(|message| match message {
+            UserOutbound::Message(RoomEventMessage::UserInfoChanged(mut snapshot)) => {
+                snapshot.remove(user)
+            }
+            UserOutbound::Message(_) | UserOutbound::RemoteSources(_) | UserOutbound::Close(_) => {
+                None
+            }
+        })
+        .expect("user info fanout should contain the target user");
+    assert_eq!(info.is_camera_on, Some(expected));
+    assert_eq!(info.is_featured, Some(expected));
 }
 
 async fn reset_subscription_selection_to_open(

--- a/crates/core/src/engine/room/TESTS/producer_tests/staged_negotiation.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/staged_negotiation.rs
@@ -1,3 +1,7 @@
+use std::time::Duration;
+
+use tokio::time::timeout;
+
 use super::support::*;
 
 #[tokio::test]
@@ -52,6 +56,19 @@ async fn staged_negotiated_publish_commit_moves_through_room_owned_transaction()
         .staged_media_id(TestSourceKind::ScalableVideo)
         .await;
 
+    {
+        let source_policy_guard = scenario.room.source_policy_turn.lock().await;
+        let mut commit = Box::pin(scenario.commit());
+        assert!(
+            timeout(Duration::from_millis(10), commit.as_mut())
+                .await
+                .is_err()
+        );
+        assert_eq!(scenario.room.test_api().inspect().producer_count().await, 0);
+        assert_eq!(scenario.staged_count().await, 1);
+        drop(commit);
+        drop(source_policy_guard);
+    }
     scenario.commit().await;
 
     assert_eq!(scenario.staged_count().await, 0);

--- a/crates/core/src/engine/room/effects/batch.rs
+++ b/crates/core/src/engine/room/effects/batch.rs
@@ -119,7 +119,8 @@ impl RoomEffects {
 
     pub(in crate::engine::room) fn from_presence(commit: PresenceCommit) -> Self {
         let mut batch = Self::default();
-        batch.push_presence(Some(commit));
+        batch.output.push_user_info(commit.fanout);
+        batch.source_policy.receiver_intent_changed();
         batch
     }
 
@@ -136,7 +137,7 @@ impl RoomEffects {
         batch
             .transport
             .push_receiver_work(commit.receiver_route_work, ConsumerSetupOrigin::Publish);
-        batch.push_presence(commit.presence);
+        batch.push_presence_before_policy(commit.presence);
         batch.source_policy.route_graph_changed();
         batch
     }
@@ -161,7 +162,7 @@ impl RoomEffects {
             .extend_remote_source_activity(remote_activity_effects);
         batch.transport.push_producer(source, stream_id, update);
         batch.output.push_source_snapshots(source_snapshots);
-        batch.push_presence(presence);
+        batch.push_presence_before_policy(presence);
         batch.source_policy.route_graph_changed();
         batch
     }
@@ -183,9 +184,9 @@ impl RoomEffects {
         batch
     }
 
-    fn push_presence(&mut self, presence: Option<PresenceCommit>) {
+    fn push_presence_before_policy(&mut self, presence: Option<PresenceCommit>) {
         if let Some(presence) = presence {
-            self.output.push_user_info(presence.fanout);
+            self.output.push_user_info_before_policy(presence.fanout);
             self.source_policy.receiver_intent_changed();
         }
     }
@@ -226,6 +227,7 @@ impl RoomEffects {
         let mut source_policy = self.source_policy;
         record_gauges(&mut gauges, room);
         if self.policy_before_transport {
+            output.emit_user_info_before_policy();
             source_policy
                 .execute_guarded(room, context.media_transport(), None)
                 .await;

--- a/crates/core/src/engine/room/effects/output.rs
+++ b/crates/core/src/engine/room/effects/output.rs
@@ -7,6 +7,7 @@ use crate::engine::room::{
 #[derive(Debug, Default)]
 pub(super) struct RoomOutputPlan {
     source_snapshots: Vec<(OutboundSender, RemoteSourceSnapshot)>,
+    user_info_before_policy: Vec<MessageFanout>,
     user_info: Vec<MessageFanout>,
     lifecycle: Vec<LifecycleEffects>,
 }
@@ -23,6 +24,10 @@ impl RoomOutputPlan {
         self.user_info.push(fanout);
     }
 
+    pub(super) fn push_user_info_before_policy(&mut self, fanout: MessageFanout) {
+        self.user_info_before_policy.push(fanout);
+    }
+
     pub(super) fn push_lifecycle(&mut self, effects: LifecycleEffects) {
         self.lifecycle.push(effects);
     }
@@ -30,6 +35,13 @@ impl RoomOutputPlan {
     pub(super) fn emit_before_policy(&mut self) {
         for (recipient, snapshot) in self.source_snapshots.drain(..) {
             let _ = recipient.send(UserOutbound::RemoteSources(snapshot));
+        }
+        self.emit_user_info_before_policy();
+    }
+
+    pub(super) fn emit_user_info_before_policy(&mut self) {
+        for fanout in self.user_info_before_policy.drain(..) {
+            fanout.emit();
         }
     }
 

--- a/crates/core/src/engine/room/media_graph/source_index.rs
+++ b/crates/core/src/engine/room/media_graph/source_index.rs
@@ -98,7 +98,9 @@ impl PublishedSources {
         group: ActiveSpeakerGroup,
     ) -> bool {
         self.ids_for_owner(owner)
-            .filter_map(|id| self.source(id).map(|source| &source.descriptor))
+            .filter_map(|id| self.source(id))
+            .filter(|source| source.active)
+            .map(|source| &source.descriptor)
             .any(|source| {
                 source.policy().active_speaker().is_some_and(|policy| {
                     policy.group() == group && policy.role() == ActiveSpeakerSourceRole::Promotable

--- a/crates/core/src/engine/room/transition/TESTS/publication_support.rs
+++ b/crates/core/src/engine/room/transition/TESTS/publication_support.rs
@@ -15,8 +15,8 @@ impl StagedPublish {
         operation: RoomUserOperation<'_>,
         rtp: RouterRtpParameters,
     ) -> Option<UserStreamId> {
-        self.commit_with_negotiated_parameters(operation, rtp, &[])
-            .await
+        let _source_policy_guard = operation.room.source_policy_turn.lock().await;
+        self.commit_rtp_guarded(operation, rtp, &[]).await
     }
 }
 

--- a/crates/core/src/engine/room/transition/publication.rs
+++ b/crates/core/src/engine/room/transition/publication.rs
@@ -219,6 +219,7 @@ impl RoomUserOperation<'_> {
     }
 
     pub(crate) async fn commit_staged_publishes(self, applied_answer: &AppliedSessionAnswer) {
+        let _source_policy_guard = self.room.source_policy_turn.lock().await;
         let staged = {
             let mut state = self.room.state.write().await;
             state
@@ -226,7 +227,7 @@ impl RoomUserOperation<'_> {
                 .take_for_connection(self.user_id, self.connection_id)
         };
         for publish in staged {
-            publish.commit_from_answer(self, applied_answer).await;
+            publish.commit_answer_guarded(self, applied_answer).await;
         }
     }
 

--- a/crates/core/src/engine/room/transition/publication/staging.rs
+++ b/crates/core/src/engine/room/transition/publication/staging.rs
@@ -137,7 +137,7 @@ impl StagedPublish {
         )
     }
 
-    pub(super) async fn commit_from_answer(
+    pub(super) async fn commit_answer_guarded(
         self,
         operation: RoomUserOperation<'_>,
         applied_answer: &AppliedSessionAnswer,
@@ -161,11 +161,10 @@ impl StagedPublish {
             return None;
         };
         let encodings = applied_answer.negotiated_producer_upload_encodings(media);
-        self.commit_with_negotiated_parameters(operation, rtp, encodings)
-            .await
+        self.commit_rtp_guarded(operation, rtp, encodings).await
     }
 
-    pub(super) async fn commit_with_negotiated_parameters(
+    pub(super) async fn commit_rtp_guarded(
         self,
         operation: RoomUserOperation<'_>,
         rtp: RouterRtpParameters,
@@ -193,8 +192,9 @@ impl StagedPublish {
             return None;
         };
         self.commit_reservation();
+        let context = RoomEffectContext::runtime(operation.media_transport);
         RoomEffects::from_publish(commit)
-            .execute(room, RoomEffectContext::runtime(operation.media_transport))
+            .execute_with_source_policy_guard(room, context)
             .await;
         info!(
             event = telemetry_event::PUBLISH_COMMITTED,


### PR DESCRIPTION
Camera pause retains the publication so source policy must reject inactive promotable sources. Otherwise an active microphone keeps the user featured after the camera pauses.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
