### PR TITLE
[IMP] core: stop forwarding audio to deafened receivers

### DIFF
--- a/crates/core/src/engine/room/TESTS/fixtures.rs
+++ b/crates/core/src/engine/room/TESTS/fixtures.rs
@@ -18,7 +18,7 @@ pub(super) use super::super::{
 pub(super) use crate::{
     RoomMediaLimits, VideoAdaptationTuning,
     engine::{
-        ConnectionId, TestSourceKind, UserId, UserPermissions, VideoLayoutIntent,
+        ConnectionId, TestSourceKind, UserId, UserInfo, UserPermissions, VideoLayoutIntent,
         media_transport::{
             AppliedSessionAnswer, MediaTransport, TransportMediaId, TransportSessionHealth,
             test_support::{
@@ -549,6 +549,89 @@ impl SourcePolicyScenario {
         for _ in 0..3 {
             self.refresh_policy().await;
         }
+    }
+
+    pub(super) async fn set_deaf(&self, raw_user_id: i64, is_deaf: bool) {
+        let user_id = UserId::Integer(raw_user_id);
+        let connection_id = user_connection_id(&self.room, &user_id).await;
+        self.set_deaf_for_connection(&user_id, connection_id, is_deaf)
+            .await;
+    }
+
+    /// Sends a deafen presence update on an explicit connection.
+    ///
+    /// Tests use this to replay a presence update from a connection that is no
+    /// longer current, which room state must reject.
+    pub(super) async fn set_deaf_for_connection(
+        &self,
+        user_id: &UserId,
+        connection_id: ConnectionId,
+        is_deaf: bool,
+    ) {
+        self.room
+            .update_user_info(
+                user_id,
+                connection_id,
+                &self.adapter,
+                UserInfo {
+                    is_deaf: Some(is_deaf),
+                    ..UserInfo::default()
+                },
+            )
+            .await;
+    }
+
+    /// Replays a receiver audio subscribe intent, as a reconnecting client does.
+    pub(super) async fn subscribe_audio(
+        &self,
+        receiver_user_id: i64,
+        source_user_id: i64,
+        active: bool,
+    ) {
+        self.subscribe(
+            receiver_user_id,
+            source_user_id,
+            TestSubscriptionStates {
+                audio_detector: Some(active),
+                ..TestSubscriptionStates::default()
+            },
+        )
+        .await;
+    }
+
+    pub(super) async fn subscribe_scalable_video(
+        &self,
+        receiver_user_id: i64,
+        source_user_id: i64,
+        active: bool,
+    ) {
+        self.subscribe(
+            receiver_user_id,
+            source_user_id,
+            TestSubscriptionStates {
+                scalable_video: Some(active),
+                ..TestSubscriptionStates::default()
+            },
+        )
+        .await;
+    }
+
+    async fn subscribe(
+        &self,
+        receiver_user_id: i64,
+        source_user_id: i64,
+        states: TestSubscriptionStates,
+    ) {
+        let receiver_user_id = UserId::Integer(receiver_user_id);
+        let source_user_id = UserId::Integer(source_user_id);
+        let intents = subscription_intents_from_test_states(&states);
+        assert!(
+            self.room
+                .test_api()
+                .media()
+                .update_subscription(&receiver_user_id, &source_user_id, &intents, &self.adapter)
+                .await
+        );
     }
 
     pub(super) async fn set_scalable_video_layout(

--- a/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
@@ -6,7 +6,10 @@ use crate::engine::{
     media_transport::{
         ActiveSpeakerSource, ReceiverBandwidthSnapshot, TransportMediaId, TransportTeardown,
     },
-    room::{DeactivateIntentOutcome, source_policy::SourcePolicyTransaction},
+    room::{
+        DeactivateIntentOutcome, media_graph::ReceiverRouteActivity,
+        source_policy::SourcePolicyTransaction,
+    },
     source_model::{
         ConsumerSourceSelection, PublishedSourceId, SourceDeactivateIntent, SourcePolicy,
         SourcePublishIntent,
@@ -534,6 +537,438 @@ async fn audio_speaker_limit_ignores_foreign_and_inactive_sources() {
 }
 
 #[tokio::test]
+async fn deafening_a_receiver_pauses_its_audio_and_keeps_video() {
+    let scenario = SourcePolicyScenario::three_ready_users().await;
+    scenario
+        .publish_audio_and_camera_for_users(&[1, 2, 3])
+        .await;
+    let first_audio = scenario.audio_media_id(1).await;
+    scenario.refresh_policy().await;
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        vec![UserId::Integer(2), UserId::Integer(3)]
+    );
+
+    scenario.set_deaf(2, true).await;
+
+    // User 1's audio now reaches user 3 only, so the deafened receiver is the
+    // single route that stopped being forwarded.
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        vec![UserId::Integer(3)]
+    );
+    for publisher_user_id in [UserId::Integer(1), UserId::Integer(3)] {
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &UserId::Integer(2),
+            &publisher_user_id,
+            TestSourceKind::AudioDetector,
+            Some(DiagnosticsPolicyPauseReason::ReceiverDeafened),
+        )
+        .await;
+    }
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(3),
+        &UserId::Integer(1),
+        TestSourceKind::AudioDetector,
+        None,
+    )
+    .await;
+    // A receiver-side audio decision must not touch video delivery.
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn undeafening_restores_audio_on_the_negotiated_route() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    scenario.publish_audio_and_camera(1).await;
+    let first_audio = scenario.audio_media_id(1).await;
+    scenario.refresh_policy().await;
+    let destination_before =
+        consumer_destination_identity(&scenario.adapter, first_audio, &UserId::Integer(2)).await;
+
+    scenario.set_deaf(2, true).await;
+    scenario.set_deaf(2, false).await;
+
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        vec![UserId::Integer(2)]
+    );
+    assert_eq!(
+        consumer_destination_identity(&scenario.adapter, first_audio, &UserId::Integer(2)).await,
+        destination_before
+    );
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(1),
+        TestSourceKind::AudioDetector,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn undeafening_recomputes_the_audio_speaker_limit() {
+    let scenario = SourcePolicyScenario::with_ready_users_and_media_limits(
+        &[1, 2, 3],
+        RoomMediaLimits::try_new(1, 10).unwrap(),
+    )
+    .await;
+    for user_id in [UserId::Integer(1), UserId::Integer(3)] {
+        publish_track(
+            &scenario.room,
+            &user_id,
+            TestSourceKind::AudioDetector,
+            MediaKind::Audio,
+            test_audio_rtp_parameters(),
+            &scenario.adapter,
+        )
+        .await;
+    }
+    let first_audio = scenario.audio_media_id(1).await;
+    let third_audio = scenario.audio_media_id(3).await;
+    // User 1 is the louder, more recent speaker, so it wins the single slot and
+    // user 3 is the route the speaker cap withholds.
+    scenario
+        .mark_active_speakers_with_levels([(third_audio, -30), (first_audio, -20)])
+        .await;
+    scenario.refresh_policy().await;
+    scenario.set_deaf(2, true).await;
+    for publisher_user_id in [UserId::Integer(1), UserId::Integer(3)] {
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &UserId::Integer(2),
+            &publisher_user_id,
+            TestSourceKind::AudioDetector,
+            Some(DiagnosticsPolicyPauseReason::ReceiverDeafened),
+        )
+        .await;
+    }
+
+    scenario.set_deaf(2, false).await;
+
+    // Undeafening restores only the admitted speaker; the capped route keeps its
+    // own pause reason instead of being blindly resumed. User 3 receives the
+    // admitted speaker throughout because it never deafened.
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        vec![UserId::Integer(2), UserId::Integer(3)]
+    );
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [third_audio]).await,
+        Vec::<UserId>::new()
+    );
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(1),
+        TestSourceKind::AudioDetector,
+        None,
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(3),
+        TestSourceKind::AudioDetector,
+        Some(DiagnosticsPolicyPauseReason::AudioSpeakerLimit),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn audio_published_while_the_receiver_is_deaf_starts_paused() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    scenario.set_deaf(2, true).await;
+
+    scenario.publish_audio_and_camera(1).await;
+
+    let first_audio = scenario.audio_media_id(1).await;
+    // The route is set up but never forwarded, so no audio leaks between the
+    // publish and the next policy turn.
+    let destination_at_publish =
+        consumer_destination_identity(&scenario.adapter, first_audio, &UserId::Integer(2)).await;
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        Vec::<UserId>::new()
+    );
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(1),
+        TestSourceKind::AudioDetector,
+        Some(DiagnosticsPolicyPauseReason::ReceiverDeafened),
+    )
+    .await;
+
+    scenario.set_deaf(2, false).await;
+
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        vec![UserId::Integer(2)]
+    );
+    assert_eq!(
+        consumer_destination_identity(&scenario.adapter, first_audio, &UserId::Integer(2)).await,
+        destination_at_publish
+    );
+}
+
+#[tokio::test]
+async fn resubscribing_while_deaf_keeps_transport_and_diagnostics_agreed() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    scenario.publish_audio_and_camera(1).await;
+    let first_audio = scenario.audio_media_id(1).await;
+    scenario.set_deaf(2, true).await;
+
+    // Receiver intent only moves the subscription flag. It must not reopen the
+    // transport destination behind a policy pause, or delivery and diagnostics
+    // would disagree until some later turn happened to change the pause reason.
+    scenario.subscribe_audio(2, 1, true).await;
+
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        Vec::<UserId>::new()
+    );
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(1),
+        TestSourceKind::AudioDetector,
+        Some(DiagnosticsPolicyPauseReason::ReceiverDeafened),
+    )
+    .await;
+
+    scenario.set_deaf(2, false).await;
+
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        vec![UserId::Integer(2)]
+    );
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(1),
+        TestSourceKind::AudioDetector,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn a_deaf_receiver_keeps_its_video_subscription_deliverable() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    scenario.publish_audio_and_camera(1).await;
+    let first_camera = source_media_id(
+        &scenario.room,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+    )
+    .await;
+    scenario.set_deaf(2, true).await;
+
+    // Deafening is audio only. Stamping ReceiverDeafened onto a video route would
+    // freeze it permanently, because audio policy iterates audio routes and so
+    // could never clear it again.
+    scenario.subscribe_scalable_video(2, 1, true).await;
+
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_camera]).await,
+        vec![UserId::Integer(2)]
+    );
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn deafening_releases_the_receivers_audio_budget_reserve() {
+    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 0, Bitrate::from_kbps(40))
+        .expect("valid tuning should build");
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
+    for user_id in [UserId::Integer(1), UserId::Integer(3)] {
+        publish_track(
+            &scenario.room,
+            &user_id,
+            TestSourceKind::AudioDetector,
+            MediaKind::Audio,
+            test_audio_rtp_parameters(),
+            &scenario.adapter,
+        )
+        .await;
+    }
+    let first_audio = scenario.audio_media_id(1).await;
+    let third_audio = scenario.audio_media_id(3).await;
+    scenario
+        .mark_active_speakers([first_audio, third_audio])
+        .await;
+    scenario.refresh_policy().await;
+
+    // Receiver 2 has no video, so its whole BWE demand is the audio reserve for
+    // the two admitted speakers it consumes.
+    let receiver_user_id = UserId::Integer(2);
+    assert_receiver_bwe_target(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        Bitrate::from_kbps(80),
+    )
+    .await;
+
+    scenario.set_deaf(2, true).await;
+
+    // A deafened receiver consumes no audio, so it must stop reserving video
+    // budget for audio it will never get.
+    assert_receiver_bwe_target(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        Bitrate::zero(),
+    )
+    .await;
+
+    scenario.set_deaf(2, false).await;
+
+    assert_receiver_bwe_target(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        Bitrate::from_kbps(80),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn reactivating_an_inactive_subscription_while_deaf_plans_no_active_destination() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    scenario.publish_audio_and_camera(1).await;
+    let receiver_user_id = UserId::Integer(2);
+    let publisher_user_id = UserId::Integer(1);
+    // The route is inactive when the deafen turn runs, so the policy snapshot
+    // skips it and it never gets stamped with a pause reason.
+    scenario.subscribe_audio(2, 1, false).await;
+    scenario.set_deaf(2, true).await;
+
+    // Transport applies before the policy turn that would correct it, so the
+    // planned activity itself must already be inactive; otherwise the
+    // destination opens and queued RTP reaches a deafened receiver.
+    let connection_id = user_connection_id(&scenario.room, &receiver_user_id).await;
+    let intents = subscription_intents_from_test_states(&TestSubscriptionStates {
+        audio_detector: Some(true),
+        ..TestSubscriptionStates::default()
+    });
+    let work = {
+        let mut state = scenario.room.state.write().await;
+        state.plan_receiver_route_work(
+            &receiver_user_id,
+            connection_id,
+            &publisher_user_id,
+            &intents,
+        )
+    };
+
+    assert_eq!(
+        work.activities
+            .iter()
+            .map(ReceiverRouteActivity::active)
+            .collect::<Vec<_>>(),
+        vec![false]
+    );
+}
+
+#[tokio::test]
+async fn each_deafen_toggle_moves_audio_delivery() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    scenario.publish_audio_and_camera(1).await;
+    let first_audio = scenario.audio_media_id(1).await;
+    let receiver_user_id = UserId::Integer(2);
+
+    for (toggle, is_deaf) in [true, false, true, false, true].into_iter().enumerate() {
+        scenario.set_deaf(2, is_deaf).await;
+
+        let expected_receivers = if is_deaf {
+            Vec::new()
+        } else {
+            vec![receiver_user_id.clone()]
+        };
+        assert_eq!(
+            active_destination_receivers(&scenario.adapter, [first_audio]).await,
+            expected_receivers,
+            "toggle {toggle} to is_deaf={is_deaf} should move audio delivery"
+        );
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &receiver_user_id,
+            &UserId::Integer(1),
+            TestSourceKind::AudioDetector,
+            is_deaf.then_some(DiagnosticsPolicyPauseReason::ReceiverDeafened),
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn deafen_from_a_stale_connection_keeps_audio_flowing() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    scenario.publish_audio_and_camera(1).await;
+    let first_audio = scenario.audio_media_id(1).await;
+    let receiver_user_id = UserId::Integer(2);
+    let current_connection_id = user_connection_id(&scenario.room, &receiver_user_id).await;
+
+    scenario
+        .set_deaf_for_connection(&receiver_user_id, test_connection_id(u64::MAX), true)
+        .await;
+
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        vec![receiver_user_id.clone()]
+    );
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_user_id,
+        &UserId::Integer(1),
+        TestSourceKind::AudioDetector,
+        None,
+    )
+    .await;
+
+    scenario
+        .set_deaf_for_connection(&receiver_user_id, current_connection_id, true)
+        .await;
+
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [first_audio]).await,
+        Vec::<UserId>::new()
+    );
+}
+
+#[tokio::test]
 async fn per_receiver_audio_reserve_excludes_own_and_counts_only_consumed_audio() {
     // Reserve 40 kbps of video budget per admitted audio speaker the receiver
     // actually consumes; no headroom so the arithmetic is exact.
@@ -741,14 +1176,15 @@ async fn video_download_limit_pauses_lowest_ranked_receiver_routes() {
         None,
     )
     .await;
+    // Receiver 2 is over its one-video cap, so it keeps user 3's camera and drops
+    // user 1's, while receivers 1 and 3 stay within the cap and keep theirs.
     assert_eq!(
-        active_destination_count_for_receiver(
-            &scenario.adapter,
-            [first_camera_media_id, third_camera_media_id],
-            &UserId::Integer(2),
-        )
-        .await,
-        1
+        active_destination_receivers(&scenario.adapter, [first_camera_media_id]).await,
+        vec![UserId::Integer(3)]
+    );
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [third_camera_media_id]).await,
+        vec![UserId::Integer(1), UserId::Integer(2)]
     );
 }
 

--- a/crates/core/src/engine/room/TESTS/producer_tests/support.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/support.rs
@@ -9,7 +9,7 @@ pub(super) use o_sfu_telemetry::diagnostics::{
     DiagnosticsSourceSelector, DiagnosticsUserView, DiagnosticsVideoLayoutRole,
     DiagnosticsVideoRoutePriority,
 };
-pub(super) use str0m::{Candidate, Rtc, change::SdpOffer};
+pub(super) use str0m::{Candidate, Rtc, change::SdpOffer, media::Mid};
 
 pub(super) use super::super::{api::NegotiatedPublish, fixtures::*};
 pub(super) use crate::{
@@ -241,12 +241,39 @@ pub(super) async fn assert_subscription_policy_pause_reason(
     );
 }
 
-pub(super) async fn active_destination_count_for_receiver(
+/// Transport identity of one receiver's destination on a source route.
+///
+/// A policy pause keeps this pair stable, so comparing it across a pause and a
+/// resume proves delivery came back on the already negotiated route instead of
+/// through a fresh SDP exchange.
+pub(super) async fn consumer_destination_identity(
+    adapter: &MediaTransport,
+    source_media_id: TransportMediaId,
+    receiver_user_id: &UserId,
+) -> (TransportMediaId, Mid) {
+    let entry = adapter
+        .test_api()
+        .route_entry_by_media_id(source_media_id)
+        .await
+        .expect("source route should exist");
+    let destination = entry
+        .destinations
+        .iter()
+        .find(|destination| destination.dest_session.user_id() == receiver_user_id)
+        .expect("receiver should keep its consumer destination");
+    (destination.dest_transport_media_id, destination.dest_mid)
+}
+
+/// Every receiver that currently has an active transport destination for the
+/// given sources, sorted and one entry per destination.
+///
+/// Assertions name the exact delivery set with this, so a route that stops or
+/// starts being forwarded fails loudly instead of being proven by an absence.
+pub(super) async fn active_destination_receivers(
     adapter: &MediaTransport,
     source_media_ids: impl IntoIterator<Item = TransportMediaId>,
-    receiver_user_id: &UserId,
-) -> usize {
-    let mut count = 0;
+) -> Vec<UserId> {
+    let mut receivers = Vec::new();
     for source_media_id in source_media_ids {
         let Some(entry) = adapter
             .test_api()
@@ -255,15 +282,16 @@ pub(super) async fn active_destination_count_for_receiver(
         else {
             continue;
         };
-        count += entry
-            .destinations
-            .iter()
-            .filter(|destination| {
-                destination.active && destination.dest_session.user_id() == receiver_user_id
-            })
-            .count();
+        receivers.extend(
+            entry
+                .destinations
+                .iter()
+                .filter(|destination| destination.active)
+                .map(|destination| destination.dest_session.user_id().clone()),
+        );
     }
-    count
+    receivers.sort();
+    receivers
 }
 
 pub(super) async fn assert_receiver_bwe_target(

--- a/crates/core/src/engine/room/media_graph/TESTS/route_graph.rs
+++ b/crates/core/src/engine/room/media_graph/TESTS/route_graph.rs
@@ -330,7 +330,7 @@ fn stale_source_or_route_cannot_commit_after_reattach() {
     );
     assert!(
         graph
-            .set_activity(&key, SOURCE_TWO, ConnectionId::from_raw(20), false,)
+            .set_activity(&key, SOURCE_TWO, ConnectionId::from_raw(20), false, None)
             .is_none()
     );
     assert_eq!(
@@ -344,6 +344,60 @@ fn stale_source_or_route_cannot_commit_after_reattach() {
             selection.set_active(false);
         })
     );
+}
+
+#[test]
+fn policy_pause_stamps_the_selection_but_leaves_the_relay_on_intent() {
+    let mut graph = RouteGraph::default();
+    let key = key(2);
+    let target = target(2, 20, SOURCE_ONE);
+    let reservation = reserve(
+        &mut graph,
+        &key,
+        SOURCE_ONE,
+        ConsumerSourceSelection::open(false),
+    );
+    let worker = MediaWorkerId::from_raw(1);
+    assert_eq!(
+        actions(graph.reserve_relay(&reservation, &target, worker, false)),
+        [TransportRelayRouteAction::Install]
+    );
+    let _ = commit_route(
+        &mut graph,
+        reservation,
+        &target,
+        101,
+        ConsumerSourceSelection::open(false),
+    );
+
+    // Reactivating while the receiver is deaf stamps the pause so the consumer
+    // destination stays closed, and still raises the relay: source policy resumes
+    // the destination only, so a relay left inactive here could never come back.
+    assert_eq!(
+        actions(
+            graph
+                .set_activity(
+                    &key,
+                    SOURCE_ONE,
+                    ConnectionId::from_raw(20),
+                    true,
+                    Some(PolicyPauseReason::ReceiverDeafened),
+                )
+                .expect("activity update should apply to the committed route")
+        ),
+        [TransportRelayRouteAction::SetActivity(
+            RelayRouteActivity::Active
+        )]
+    );
+    let selection = graph
+        .selection(&key, SOURCE_ONE)
+        .expect("committed route should expose its selection");
+    assert!(selection.active());
+    assert_eq!(
+        selection.policy_pause_reason(),
+        Some(PolicyPauseReason::ReceiverDeafened)
+    );
+    assert!(!selection.delivery_active());
 }
 
 #[test]

--- a/crates/core/src/engine/room/media_graph/route_graph.rs
+++ b/crates/core/src/engine/room/media_graph/route_graph.rs
@@ -13,7 +13,7 @@ use crate::engine::{
         RelayRouteActivity, TransportConsumerRoute, TransportMediaId, TransportRelayRouteAction,
         TransportSourceKey,
     },
-    source_model::{PublishedSourceId, SourceSubscriptionIntent},
+    source_model::{PolicyPauseReason, PublishedSourceId, SourceSubscriptionIntent},
 };
 
 #[derive(Debug, Default)]
@@ -158,6 +158,7 @@ impl RouteGraph {
         source_id: PublishedSourceId,
         connection_id: ConnectionId,
         active: bool,
+        policy_pause_reason: Option<PolicyPauseReason>,
     ) -> Option<Vec<RelayRouteEffect>> {
         let relay = {
             let current = self
@@ -171,6 +172,9 @@ impl RouteGraph {
                 return None;
             }
             current.selection.set_active(active);
+            if let Some(reason) = policy_pause_reason {
+                current.selection.set_policy_pause_reason(Some(reason));
+            }
             current
                 .realization
                 .set_relay_activity(RelayRouteActivity::from_active(active))

--- a/crates/core/src/engine/room/media_graph/subscription.rs
+++ b/crates/core/src/engine/room/media_graph/subscription.rs
@@ -3,7 +3,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use o_sfu_router::{MediaKind as RouterMediaKind, negotiation::negotiate_consumer_rtp_parameters};
 
 use super::{
-    super::{effects::RoomGaugeDelta, state::RoomState},
+    super::{
+        effects::RoomGaugeDelta,
+        state::{ActiveUser, RoomState},
+    },
     ConsumerId, ConsumerRouteTarget, SubscriptionKey,
     consumer_setup::{ConsumerSetupTarget, PendingConsumerSetup},
 };
@@ -219,6 +222,9 @@ impl RoomState {
     ) -> (Vec<ReceiverRouteActivity>, Vec<TransportRelayRouteEffect>) {
         let mut updates = Vec::new();
         let mut relays = Vec::new();
+        let receiver_deafened = self
+            .user_for_connection(user_id, connection_id)
+            .is_some_and(ActiveUser::is_deaf);
         for (stream_id, intent) in intents {
             let Some(active) = intent.active() else {
                 continue;
@@ -229,6 +235,7 @@ impl RoomState {
                 target_user_id,
                 stream_id,
                 active,
+                active && receiver_deafened,
             ) else {
                 continue;
             };
@@ -304,7 +311,24 @@ impl RoomState {
                         .unwrap_or(true),
                 )
             });
-        self.apply_initial_video_download_cap(target, source_active, selection)
+        let selection = self.apply_initial_video_download_cap(target, source_active, selection);
+        self.apply_initial_receiver_deafened(target, selection)
+    }
+
+    fn apply_initial_receiver_deafened(
+        &self,
+        target: &ConsumerSetupTarget,
+        mut selection: ConsumerSourceSelection,
+    ) -> ConsumerSourceSelection {
+        if target.kind == RouterMediaKind::Audio
+            && selection.delivery_active()
+            && self
+                .user_for_connection(target.session.user_id(), target.session.connection_id())
+                .is_some_and(ActiveUser::is_deaf)
+        {
+            selection.set_policy_pause_reason(Some(PolicyPauseReason::ReceiverDeafened));
+        }
+        selection
     }
 
     fn apply_initial_video_download_cap(

--- a/crates/core/src/engine/room/media_graph/topology.rs
+++ b/crates/core/src/engine/room/media_graph/topology.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use o_sfu_router::{
-    ProducerId, Router, RouterError,
+    MediaKind, ProducerId, Router, RouterError,
     rtp::{MediaCapabilities, MediaStream as RouterRtpParameters},
 };
 use tracing::{error, warn};
@@ -30,8 +30,8 @@ use crate::engine::{
         placement::WorkerLoadIndex,
     },
     source_model::{
-        ActiveSpeakerSourceRole, ConsumerSourceSelection, PublishedSourceDescriptor,
-        PublishedSourceId, SourceSubscriptionIntent, UserStreamId,
+        ActiveSpeakerSourceRole, ConsumerSourceSelection, PolicyPauseReason,
+        PublishedSourceDescriptor, PublishedSourceId, SourceSubscriptionIntent, UserStreamId,
     },
 };
 
@@ -787,7 +787,7 @@ impl RoomTopology {
         rtp: RouterRtpParameters,
     ) -> Option<PendingConsumerSetup> {
         let key = target.subscription_key();
-        let active = selection.delivery_active();
+        let relay_active = selection.active();
         let reservation =
             self.route_graph
                 .reserve_consumer_setup(key, target.source_id, selection)?;
@@ -798,7 +798,7 @@ impl RoomTopology {
         } else {
             let relays =
                 self.route_graph
-                    .reserve_relay(&reservation, &target, target_worker, active);
+                    .reserve_relay(&reservation, &target, target_worker, relay_active);
             self.resolve_relay_effects(relays)
         };
         Some(PendingConsumerSetup {
@@ -826,17 +826,29 @@ impl RoomTopology {
         target_user_id: &UserId,
         stream_id: &UserStreamId,
         active: bool,
+        receiver_deafened: bool,
     ) -> Option<ConsumerActivityCommit> {
         let key = SubscriptionKey::new(user_id, target_user_id, stream_id);
         let source_id = self.source_id_for_owner_stream(target_user_id, stream_id)?;
-        let relay_effects =
-            self.route_graph
-                .set_activity(&key, source_id, connection_id, active)?;
+        let policy_pause_reason = (receiver_deafened
+            && self
+                .source_descriptor(source_id)
+                .is_some_and(|source| source.media_kind() == MediaKind::Audio))
+        .then_some(PolicyPauseReason::ReceiverDeafened);
+        let relay_effects = self.route_graph.set_activity(
+            &key,
+            source_id,
+            connection_id,
+            active,
+            policy_pause_reason,
+        )?;
         let relay_effects = self.resolve_relay_effects(relay_effects);
         let update = self
             .committed_consumer_route_for_key(&key)
             .filter(|route| route.route.consumer_session_key().connection_id() == connection_id)
-            .map(|route| ReceiverRouteActivity::new(route.target(), active));
+            .map(|route| {
+                ReceiverRouteActivity::new(route.target(), route.selection.delivery_active())
+            });
         Some(ConsumerActivityCommit {
             update,
             relay_effects,

--- a/crates/core/src/engine/room/read_model.rs
+++ b/crates/core/src/engine/room/read_model.rs
@@ -792,6 +792,7 @@ impl From<PolicyPauseReason> for DiagnosticsPolicyPauseReason {
             PolicyPauseReason::OverflowTile => Self::OverflowTile,
             PolicyPauseReason::MissingUsableLayer => Self::MissingUsableLayer,
             PolicyPauseReason::AudioSpeakerLimit => Self::AudioSpeakerLimit,
+            PolicyPauseReason::ReceiverDeafened => Self::ReceiverDeafened,
             PolicyPauseReason::VideoDownloadLimit => Self::VideoDownloadLimit,
             PolicyPauseReason::SourceBitrateLimit => Self::SourceBitrateLimit,
         }

--- a/crates/core/src/engine/room/source_policy/audio.rs
+++ b/crates/core/src/engine/room/source_policy/audio.rs
@@ -4,7 +4,12 @@ use super::{
     action::ConsumerPacketSelectionUpdate, input::SourcePolicySnapshot,
     turn::SourcePolicyTransaction,
 };
-use crate::engine::source_model::PolicyPauseReason;
+use crate::engine::{room::media_graph::ConsumerRouteView, source_model::PolicyPauseReason};
+
+const AUDIO_PAUSE_REASONS: [PolicyPauseReason; 2] = [
+    PolicyPauseReason::AudioSpeakerLimit,
+    PolicyPauseReason::ReceiverDeafened,
+];
 
 pub(super) fn append_audio_route_activity(
     tx: &mut SourcePolicyTransaction,
@@ -14,17 +19,8 @@ pub(super) fn append_audio_route_activity(
         if route.source.descriptor.media_kind() != MediaKind::Audio {
             continue;
         }
-        let active_speaker = input
-            .active_speaker_media_ids
-            .contains(&route.route.source_transport_media_id());
-        let admitted = input
-            .admitted_audio_media_ids
-            .contains(&route.route.source_transport_media_id());
-        let next_reason =
-            (active_speaker && !admitted).then_some(PolicyPauseReason::AudioSpeakerLimit);
-        if next_reason.is_none()
-            && route.selection.policy_pause_reason() != Some(PolicyPauseReason::AudioSpeakerLimit)
-        {
+        let next_reason = audio_pause_reason(input, route);
+        if next_reason.is_none() && !owns_pause_reason(route.selection.policy_pause_reason()) {
             continue;
         }
         if let Some(update) = ConsumerPacketSelectionUpdate::route_activity(
@@ -37,4 +33,24 @@ pub(super) fn append_audio_route_activity(
             tx.push_route_update(update);
         }
     }
+}
+
+fn audio_pause_reason(
+    input: &SourcePolicySnapshot<'_>,
+    route: &ConsumerRouteView<'_>,
+) -> Option<PolicyPauseReason> {
+    if input
+        .deaf_receiver_connection_ids
+        .contains(&route.route.consumer_session_key().connection_id())
+    {
+        return Some(PolicyPauseReason::ReceiverDeafened);
+    }
+    let source_media_id = route.route.source_transport_media_id();
+    let active_speaker = input.active_speaker_media_ids.contains(&source_media_id);
+    let admitted = input.admitted_audio_media_ids.contains(&source_media_id);
+    (active_speaker && !admitted).then_some(PolicyPauseReason::AudioSpeakerLimit)
+}
+
+fn owns_pause_reason(current_reason: Option<PolicyPauseReason>) -> bool {
+    current_reason.is_some_and(|reason| AUDIO_PAUSE_REASONS.contains(&reason))
 }

--- a/crates/core/src/engine/room/source_policy/input.rs
+++ b/crates/core/src/engine/room/source_policy/input.rs
@@ -27,6 +27,7 @@ pub(super) struct SourcePolicySnapshot<'a> {
     pub(super) receiver_bandwidth_by_connection: BTreeMap<ConnectionId, Bitrate>,
     pub(super) active_speaker_media_ids: BTreeSet<TransportMediaId>,
     pub(super) admitted_audio_media_ids: BTreeSet<TransportMediaId>,
+    pub(super) deaf_receiver_connection_ids: BTreeSet<ConnectionId>,
     pub(super) featured_source_user_ids: BTreeSet<UserId>,
     pub(super) active_speaker_rank_by_user: BTreeMap<UserId, usize>,
     pub(super) featured_user_updates: Vec<FeaturedUserUpdate>,
@@ -48,6 +49,7 @@ impl<'a> SourcePolicySnapshot<'a> {
         let active_speakers = active_speaker_media_ids(&ranked_sources);
         let admitted_audio_speakers =
             admitted_audio_media_ids(&ranked_sources, media_limits.max_active_audio_speakers());
+        let deaf_receiver_connection_ids = deaf_receiver_connection_ids(state);
         let featured_source_user_ids = featured_source_user_ids(state, &ranked_sources);
         let active_speaker_rank_by_user = active_speaker_rank_by_user(state, &ranked_sources);
         let desired_featured_user_id = ranked_sources.iter().find_map(|source| {
@@ -61,6 +63,7 @@ impl<'a> SourcePolicySnapshot<'a> {
         let audio_reserve_by_connection = audio_reserve_by_connection(
             &routes,
             &admitted_audio_speakers,
+            &deaf_receiver_connection_ids,
             tuning.audio_reserve_per_speaker,
         );
         Self {
@@ -71,6 +74,7 @@ impl<'a> SourcePolicySnapshot<'a> {
             ),
             active_speaker_media_ids: active_speakers,
             admitted_audio_media_ids: admitted_audio_speakers,
+            deaf_receiver_connection_ids,
             featured_source_user_ids,
             active_speaker_rank_by_user,
             featured_user_updates,
@@ -86,14 +90,15 @@ impl<'a> SourcePolicySnapshot<'a> {
 /// connection.
 ///
 /// Each receiver reserves `per_speaker` for every admitted audio route it
-/// actually consumes, so a receiver that disabled audio (or a publisher with no
-/// consumer routes) reserves nothing and keeps its full video budget. The
-/// reserve is fixed per route, so it is deterministic and independent of
-/// policy-turn cadence. A zero per-speaker rate disables the reservation and
-/// returns an empty map.
+/// actually consumes, so a receiver that disabled audio, deafened itself (or a
+/// publisher with no consumer routes) reserves nothing and keeps its full video
+/// budget. The reserve is fixed per route, so it is deterministic and
+/// independent of policy-turn cadence. A zero per-speaker rate disables the
+/// reservation and returns an empty map.
 fn audio_reserve_by_connection(
     routes: &[ConsumerRouteView<'_>],
     admitted_audio_media_ids: &BTreeSet<TransportMediaId>,
+    deaf_receiver_connection_ids: &BTreeSet<ConnectionId>,
     per_speaker: Bitrate,
 ) -> BTreeMap<ConnectionId, Bitrate> {
     if per_speaker.as_bps() == 0 {
@@ -107,6 +112,9 @@ fn audio_reserve_by_connection(
             continue;
         }
         let connection_id = route.route.consumer_session_key().connection_id();
+        if deaf_receiver_connection_ids.contains(&connection_id) {
+            continue;
+        }
         let reserve = reserve_by_connection
             .entry(connection_id)
             .or_insert_with(Bitrate::zero);
@@ -181,6 +189,15 @@ fn admitted_audio_media_ids(
         .iter()
         .take(limit)
         .map(|source| source.transport_media_id())
+        .collect()
+}
+
+fn deaf_receiver_connection_ids(state: &RoomState) -> BTreeSet<ConnectionId> {
+    state
+        .users
+        .values()
+        .filter(|user| user.is_deaf())
+        .map(|user| user.connection_id)
         .collect()
 }
 

--- a/crates/core/src/engine/room/state/mod.rs
+++ b/crates/core/src/engine/room/state/mod.rs
@@ -8,7 +8,7 @@ pub use self::{
     membership::{
         ConnectionCloseCommit, DisconnectCommit, JoinCommit, LifecycleEffects, PresenceCommit,
     },
-    shared::RoomState,
+    shared::{ActiveUser, RoomState},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/engine/room/state/shared.rs
+++ b/crates/core/src/engine/room/state/shared.rs
@@ -59,6 +59,10 @@ impl ActiveUser {
         self.server_featured
     }
 
+    pub(in crate::engine::room) const fn is_deaf(&self) -> bool {
+        matches!(self.info.is_deaf, Some(true))
+    }
+
     pub(in crate::engine::room) fn set_featured(&mut self, featured: Option<bool>) {
         self.server_featured = featured;
     }

--- a/crates/core/src/engine/source_model/policy.rs
+++ b/crates/core/src/engine/source_model/policy.rs
@@ -299,6 +299,8 @@ pub enum PolicyPauseReason {
     MissingUsableLayer,
     /// the active-audio-speaker cap withheld this route
     AudioSpeakerLimit,
+    /// the receiver deafened itself so no audio is delivered to it
+    ReceiverDeafened,
     /// the per-receiver live-video cap withheld this route
     VideoDownloadLimit,
     /// the source bitrate cap withheld this route

--- a/crates/telemetry/src/diagnostics/types.rs
+++ b/crates/telemetry/src/diagnostics/types.rs
@@ -59,6 +59,7 @@ pub enum DiagnosticsPolicyPauseReason {
     OverflowTile,
     MissingUsableLayer,
     AudioSpeakerLimit,
+    ReceiverDeafened,
     VideoDownloadLimit,
     SourceBitrateLimit,
 }


### PR DESCRIPTION
Odoo broadcasts `is_deaf` and o-sfu already stored it on `UserInfo`, but receiver audio policy never read it, so a deafened participant kept receiving every audio RTP packet and only muted its local audio elements. The bandwidth was spent and diagnostics had no record of why delivery should have stopped.

Treat deafening as a receiver-side audio policy instead: a new `PolicyPauseReason::ReceiverDeafened` pauses every committed audio route whose receiver is deaf, while subscription intent, consumer routes and negotiated media stay untouched so undeafening needs no SDP exchange.

- `SourcePolicySnapshot` carries the deafened receivers as a set of `ConnectionId` rather than `UserId`, so a replacement connection never inherits the deafened state of the connection it replaced
- `audio_pause_reason` derives the reason from scratch every turn, so undeafening falls back to `AudioSpeakerLimit` for a route the speaker cap still withholds instead of blindly resuming delivery
- the resume guard checks a two-entry `AUDIO_PAUSE_REASONS` list rather than one hardcoded variant, so audio policy still cannot clear a pause another planner installed
- `setup_selection` pauses an audio route at consumer setup when its receiver is already deaf, so media published during deafening never bursts before the next policy turn
- deafened connections no longer reserve video budget for audio they do not receive, matching what `audio_reserve_by_connection` documents

Presence updates already trigger a source-policy pass, so no new invalidation path was needed. Video delivery and other receivers are unaffected.


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [x] AI was used to write substantial segments of the code

Fixes #560
