### PR TITLE
[FIX] core: prevent RTC test port races

### DIFF
--- a/crates/core/src/engine/media_transport/TESTS/mod.rs
+++ b/crates/core/src/engine/media_transport/TESTS/mod.rs
@@ -233,15 +233,8 @@ async fn assert_remote_route_activity(
 }
 
 fn test_media_transport(worker_count: usize, rtc_port_range: RtcPortRange) -> MediaTransport {
-    match build_test_media_transport(worker_count, rtc_port_range) {
-        Ok(transport) => transport,
-        Err(error) => panic!("fixed RTC transport test config should be valid: {error}"),
-    }
-}
-
-fn test_rtc_range(worker_count: usize) -> RtcPortRange {
-    test_rtc_port_range(worker_count)
-        .unwrap_or_else(|| panic!("test RTC port range should be available"))
+    build_test_media_transport(worker_count, rtc_port_range)
+        .unwrap_or_else(|error| panic!("RTC transport test config should be valid: {error}"))
 }
 
 fn expect_first_candidate_port(offer_sdp: &str) -> u16 {
@@ -336,7 +329,7 @@ async fn assert_media_control_batch_bound(
 #[tokio::test]
 #[allow(clippy::too_many_lines, reason = "one phase-order scenario")]
 async fn media_transport_plan_updates_source_route() {
-    let adapter = test_media_transport(3, test_rtc_range(3));
+    let adapter = test_media_transport(3, test_rtc_port_range());
     let source_session = test_session_key(60, 1, 1, UserId::Integer(1));
     let consumer_session = test_session_key(60, 1, 2, UserId::Integer(2));
     let peer_source_session = test_session_key(60, 2, 3, UserId::Integer(3));
@@ -583,77 +576,59 @@ fn media_transport_build_rejects_invalid_port_split() {
 }
 
 #[test]
-fn media_transport_ready_workers_bind_and_release_ports() {
-    let range = test_rtc_range(2);
-    let mut ports = range.ports();
-    let first_port = ports
-        .next()
-        .unwrap_or_else(|| panic!("test RTC range should contain a first port"));
-    let second_port = ports
-        .next()
-        .unwrap_or_else(|| panic!("test RTC range should contain a second port"));
-    let blocker = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, first_port))
+fn media_transport_build_rejects_occupied_port_range() {
+    let blocker = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
         .unwrap_or_else(|error| panic!("test RTC port should bind: {error}"));
-    let result = MediaTransport::build(
-        test_media_transport_config(1, RtcPortRange::new(first_port, first_port)),
-        test_media_transport_deps(),
-    );
+    let port = blocker
+        .local_addr()
+        .unwrap_or_else(|error| panic!("test RTC port should expose its address: {error}"))
+        .port();
     assert_eq!(
-        result.err(),
+        MediaTransport::build(
+            test_media_transport_config(1, RtcPortRange::new(port, port)),
+            test_media_transport_deps(),
+        )
+        .err(),
         Some(MediaTransportBuildError::WorkerStartup { worker_index: 0 })
     );
-    drop(blocker);
+}
 
-    let adapter = MediaTransport::build(
-        test_media_transport_config(2, range),
-        test_media_transport_deps(),
-    )
-    .unwrap_or_else(|error| panic!("test media transport should start: {error}"));
-
-    assert!(
-        range.ports().all(|port| {
-            UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_err()
-        })
-    );
-    drop(adapter);
-    assert!(
-        range.ports().all(|port| {
-            UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_ok()
-        })
-    );
-
-    let _blocker = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, second_port))
-        .unwrap_or_else(|error| panic!("second test RTC port should bind: {error}"));
-
-    let result = MediaTransport::build(
-        test_media_transport_config(2, range),
-        test_media_transport_deps(),
-    );
-
-    assert_eq!(
-        result.err(),
-        Some(MediaTransportBuildError::WorkerStartup { worker_index: 1 })
-    );
-    assert!(UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, first_port)).is_ok());
+#[test]
+fn media_transport_overlapping_ranges_skip_bound_ports() {
+    let range = test_rtc_port_range();
+    let _first = test_media_transport(2, range);
+    let _second = test_media_transport(2, range);
 }
 
 #[cfg(target_os = "linux")]
 #[tokio::test]
 async fn media_transport_io_uring_worker_binds_before_first_offer() {
-    let range = test_rtc_range(1);
-    let port = range.min();
+    let blocker = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
+        .unwrap_or_else(|error| panic!("test RTC port should bind: {error}"));
+    let blocked_port = blocker
+        .local_addr()
+        .unwrap_or_else(|error| panic!("test RTC port should expose its address: {error}"))
+        .port();
+    let mut blocked_config =
+        test_media_transport_config(1, RtcPortRange::new(blocked_port, blocked_port));
+    blocked_config.rtc_udp_io_backend = RtcUdpIoBackend::IoUring;
+    assert_eq!(
+        MediaTransport::build(blocked_config, test_media_transport_deps()).err(),
+        Some(MediaTransportBuildError::WorkerStartup { worker_index: 0 })
+    );
+    drop(blocker);
+
+    let range = test_rtc_port_range();
     let mut config = test_media_transport_config(1, range);
     config.rtc_udp_io_backend = RtcUdpIoBackend::IoUring;
     let adapter = MediaTransport::build(config, test_media_transport_deps())
         .unwrap_or_else(|error| panic!("io_uring media transport should start: {error}"));
 
-    assert!(UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_err());
     let session = test_session_key(1, 0, 1, UserId::Integer(1));
     let offer = expect_initial_offer(&adapter, &session).await;
-    assert_eq!(expect_first_candidate_port(&offer.sdp), port);
-
-    drop(adapter);
-    assert!(UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_ok());
+    let port = expect_first_candidate_port(&offer.sdp);
+    assert!(range.ports().any(|candidate| candidate == port));
+    assert!(UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_err());
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -682,7 +657,7 @@ fn rtc_rejects_answers_without_projectable_client_capabilities() {
 
 #[tokio::test]
 async fn rtc_workers_room_bootstrap_by_explicit_media_worker() {
-    let rtc_port_range = test_rtc_range(2);
+    let rtc_port_range = test_rtc_port_range();
     let adapter = test_media_transport(2, rtc_port_range);
     let first_room_session = test_session_key(10, 0, 1, UserId::Integer(1));
     let second_room_session = test_session_key(11, 1, 1, UserId::Integer(2));
@@ -708,12 +683,14 @@ async fn rtc_workers_room_bootstrap_by_explicit_media_worker() {
         .unwrap_or_else(|| panic!("second worker range should exist"));
     assert!(first_worker_range.ports().any(|port| port == first_port));
     assert!(second_worker_range.ports().any(|port| port == second_port));
+    assert!(UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, first_port)).is_err());
+    assert!(UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, second_port)).is_err());
     assert_eq!(same_worker_port, first_port);
 }
 
 #[tokio::test]
 async fn rtc_rejects_noncanonical_media_worker_id() {
-    let adapter = test_media_transport(2, test_rtc_range(2));
+    let adapter = test_media_transport(2, test_rtc_port_range());
     let session = test_session_key(13, 2, 1, UserId::Integer(4));
 
     let offer = adapter
@@ -728,7 +705,7 @@ async fn rtc_rejects_noncanonical_media_worker_id() {
 
 #[tokio::test]
 async fn rtc_diagnostics_group_workers_and_preserve_media_ids() {
-    let adapter = test_media_transport(2, test_rtc_range(2));
+    let adapter = test_media_transport(2, test_rtc_port_range());
     let first_session = test_session_key(50, 0, 1, UserId::Integer(1));
     let second_session = test_session_key(50, 1, 2, UserId::Integer(2));
     let first_rtp = sample_rtp_parameters("first", 71_000);
@@ -805,7 +782,7 @@ async fn rtc_diagnostics_group_workers_and_preserve_media_ids() {
 
 #[tokio::test]
 async fn rtc_rejects_stale_session_removal_without_dropping_consumer_handle() {
-    let adapter = test_media_transport(1, test_rtc_range(1));
+    let adapter = test_media_transport(1, test_rtc_port_range());
     let source_session = test_session_key(35, 0, 1, UserId::Integer(1));
     let consumer_session = test_session_key(35, 0, 2, UserId::Integer(2));
     let producer_rtp_parameters = sample_rtp_parameters("aud-up", 54_000);
@@ -864,7 +841,7 @@ async fn rtc_rejects_stale_session_removal_without_dropping_consumer_handle() {
 
 #[tokio::test]
 async fn media_transport_terminal_teardown_falls_back_and_continues_batch() {
-    let adapter = test_media_transport(1, test_rtc_range(1));
+    let adapter = test_media_transport(1, test_rtc_port_range());
     let source_session = test_session_key(36, 0, 1, UserId::Integer(1));
     let wrong_owner = test_session_key(36, 0, 2, UserId::Integer(2));
     let later_session = test_session_key(36, 0, 3, UserId::Integer(3));
@@ -910,7 +887,7 @@ async fn media_transport_terminal_teardown_falls_back_and_continues_batch() {
 
 #[tokio::test]
 async fn rtc_gates_remote_relay_mailboxes_without_touching_local_routes() -> TransportResult<()> {
-    let adapter = test_media_transport(2, test_rtc_range(2));
+    let adapter = test_media_transport(2, test_rtc_port_range());
     let source_session = test_session_key(40, 0, 1, UserId::Integer(1));
     let local_consumer_session = test_session_key(40, 0, 2, UserId::Integer(2));
     let remote_consumer_session = test_session_key(40, 1, 3, UserId::Integer(3));

--- a/crates/core/src/engine/media_transport/TESTS/test_support/mod.rs
+++ b/crates/core/src/engine/media_transport/TESTS/test_support/mod.rs
@@ -4,22 +4,19 @@ use {
         MediaTransport, TransportMediaId, TransportQualitySample, TransportSessionHealth,
         TransportSessionKey, TransportSourceKey,
     },
-    crate::engine::sync::lock_unpoisoned,
+    o_sfu_rfc::port as rfc_port,
     std::{
-        collections::BTreeSet,
-        env, fs,
-        io::ErrorKind,
-        net::{SocketAddrV4, UdpSocket},
-        path::{Path, PathBuf},
-        sync::{Mutex, OnceLock, atomic::Ordering, mpsc},
-        time::{Duration, Instant, SystemTime},
+        sync::{atomic::Ordering, mpsc},
+        time::Instant,
     },
     str0m::media::Mid,
 };
 #[cfg(test)]
 use {
     super::{MediaTransportBuildError, TransportAdapterError, rtc::WorkerMediaControlBatch},
+    crate::engine::sync::lock_unpoisoned,
     o_sfu_router::rtp::MediaStream as RouterRtpParameters,
+    std::sync::Mutex,
 };
 #[cfg(any(test, feature = "internal-benchmarks"))]
 use {
@@ -29,22 +26,16 @@ use {
         VideoBitrateLimits,
         engine::{metrics::RuntimeMetrics, packet_sink_registry::RoomPacketSinkRegistry},
     },
-    std::{net::IpAddr, sync::Arc},
+    std::{
+        net::{IpAddr, Ipv4Addr},
+        sync::Arc,
+    },
 };
-#[cfg(any(test, feature = "internal-benchmarks", feature = "testing-transport"))]
-use {crate::RtcPortRange, std::net::Ipv4Addr};
 
 #[cfg(any(test, feature = "testing-transport"))]
 pub use super::rtc::{ForwardedPacket, test_support::*};
-
-#[cfg(any(test, feature = "testing-transport"))]
-static RESERVED_RTC_TEST_PORTS: OnceLock<Mutex<BTreeSet<u16>>> = OnceLock::new();
-#[cfg(any(test, feature = "testing-transport"))]
-const RTC_PORT_RESERVATION_ATTEMPTS: usize = 256;
-#[cfg(any(test, feature = "testing-transport"))]
-const RTC_PORT_LOCK_DIR: &str = "o-sfu-rtc-test-ports";
-#[cfg(any(test, feature = "testing-transport"))]
-const RTC_PORT_LOCK_STALE_AFTER: Duration = Duration::from_hours(1);
+#[cfg(any(test, feature = "internal-benchmarks", feature = "testing-transport"))]
+use crate::RtcPortRange;
 
 #[cfg(test)]
 pub(super) type MediaControlBatchLog = Arc<Mutex<Vec<(usize, &'static str, Vec<usize>)>>>;
@@ -247,118 +238,13 @@ impl MediaTransportTestApi<'_> {
     }
 }
 
-/// returns a process-unique contiguous UDP port range for RTC integration tests
+/// returns the RFC 6335 dynamic UDP port range for RTC tests and benchmarks
 ///
-/// asks the operating system for an ephemeral starting port and keeps selected
-/// ranges out of later test transports in the same process. sockets are
-/// released before the transport starts so the real RTC worker still owns the
-/// final bind path
+/// each RTC worker binds the first available port in its assigned subrange
 #[cfg(any(test, feature = "testing-transport"))]
 #[must_use]
-pub fn test_rtc_port_range(worker_count: usize) -> Option<RtcPortRange> {
-    let worker_count = u16::try_from(worker_count).ok()?;
-    if worker_count == 0 {
-        return None;
-    }
-    let ports = RESERVED_RTC_TEST_PORTS.get_or_init(|| Mutex::new(BTreeSet::new()));
-    for _ in 0..RTC_PORT_RESERVATION_ATTEMPTS {
-        let used_ports = {
-            let ports = lock_unpoisoned(ports);
-            ports.clone()
-        };
-        let Some((range, _sockets)) = reserve_contiguous_rtc_ports(worker_count, &used_ports)
-        else {
-            continue;
-        };
-        let Some(port_locks) = reserve_rtc_port_locks(range) else {
-            continue;
-        };
-        let inserted = {
-            let mut ports = lock_unpoisoned(ports);
-            if range.ports().any(|port| ports.contains(&port)) {
-                false
-            } else {
-                ports.extend(range.ports());
-                true
-            }
-        };
-        if !inserted {
-            release_rtc_port_locks(&port_locks);
-            continue;
-        }
-        return Some(range);
-    }
-    None
-}
-
-#[cfg(any(test, feature = "testing-transport"))]
-fn reserve_contiguous_rtc_ports(
-    worker_count: u16,
-    used_ports: &BTreeSet<u16>,
-) -> Option<(RtcPortRange, Vec<UdpSocket>)> {
-    let first_socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).ok()?;
-    let first_port = first_socket.local_addr().ok()?.port();
-    let last_port = first_port.checked_add(worker_count.checked_sub(1)?)?;
-    let range = RtcPortRange::new(first_port, last_port);
-    if range.ports().any(|port| used_ports.contains(&port)) {
-        return None;
-    }
-    let mut sockets = Vec::with_capacity(usize::from(worker_count));
-    sockets.push(first_socket);
-    for port in (first_port.saturating_add(1))..=last_port {
-        sockets.push(UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).ok()?);
-    }
-    Some((range, sockets))
-}
-
-#[cfg(any(test, feature = "testing-transport"))]
-fn reserve_rtc_port_locks(range: RtcPortRange) -> Option<Vec<PathBuf>> {
-    let lock_root = env::temp_dir().join(RTC_PORT_LOCK_DIR);
-    fs::create_dir_all(&lock_root).ok()?;
-    let mut locked_paths = Vec::with_capacity(usize::from(range.port_count()));
-    for port in range.ports() {
-        let lock_path = lock_root.join(port.to_string());
-        if !reserve_rtc_port_lock(&lock_path) {
-            release_rtc_port_locks(&locked_paths);
-            return None;
-        }
-        locked_paths.push(lock_path);
-    }
-    Some(locked_paths)
-}
-
-#[cfg(any(test, feature = "testing-transport"))]
-fn reserve_rtc_port_lock(path: &Path) -> bool {
-    match fs::create_dir(path) {
-        Ok(()) => true,
-        Err(error)
-            if error.kind() == ErrorKind::AlreadyExists && remove_stale_rtc_port_lock(path) =>
-        {
-            fs::create_dir(path).is_ok()
-        }
-        Err(_) => false,
-    }
-}
-
-#[cfg(any(test, feature = "testing-transport"))]
-fn remove_stale_rtc_port_lock(path: &Path) -> bool {
-    let Ok(metadata) = fs::metadata(path) else {
-        return false;
-    };
-    let Ok(modified_at) = metadata.modified() else {
-        return false;
-    };
-    let Ok(age) = SystemTime::now().duration_since(modified_at) else {
-        return false;
-    };
-    age > RTC_PORT_LOCK_STALE_AFTER && fs::remove_dir(path).is_ok()
-}
-
-#[cfg(any(test, feature = "testing-transport"))]
-fn release_rtc_port_locks(paths: &[PathBuf]) {
-    for path in paths {
-        let _ = fs::remove_dir(path);
-    }
+pub const fn test_rtc_port_range() -> RtcPortRange {
+    RtcPortRange::new(rfc_port::DYNAMIC_RANGE_START, rfc_port::DYNAMIC_RANGE_END)
 }
 
 #[cfg(test)]

--- a/crates/core/src/engine/media_transport/rtc/bootstrap.rs
+++ b/crates/core/src/engine/media_transport/rtc/bootstrap.rs
@@ -9,6 +9,7 @@
 //! contracts
 
 use std::{
+    io::ErrorKind,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket as StdUdpSocket},
     sync::Arc,
     time::{Duration, Instant},
@@ -16,7 +17,7 @@ use std::{
 
 use o_sfu_rfc::webrtc;
 use str0m::{Candidate, bwe::Bitrate as Str0mBitrate};
-use tracing::info;
+use tracing::{info, warn};
 
 use super::{
     RtpProfile,
@@ -41,15 +42,13 @@ use crate::{CodecPreferences, MediaCodecFlags};
 /// the advertised candidate keeps the configured public IP with the
 /// bound port because that is what browsers must see in SDP
 ///
-/// ports are tried in configured order
-/// a port that cannot be bound, switched to
-/// nonblocking mode or converted into an RTC UDP socket is skipped so startup can
-/// continue with the next candidate
+/// tries configured ports in order and skips only [`ErrorKind::AddrInUse`]
+/// any other bind, nonblocking or backend initialization error aborts startup
 ///
 /// # errors
 ///
-/// returns `TransportUnavailable` when no port in the configured range produces
-/// a usable shared socket
+/// returns [`TransportAdapterError::TransportUnavailable`] when every port is
+/// occupied or another socket operation fails
 pub(super) fn bind_shared_rtc_socket(
     announced_ip: IpAddr,
     rtc_port_range: RtcPortRange,
@@ -58,15 +57,27 @@ pub(super) fn bind_shared_rtc_socket(
     let bind_ip = bind_ip_for_announced_ip(announced_ip);
     for port in rtc_port_range.ports() {
         let bind_addr = SocketAddr::new(bind_ip, port);
-        let Ok(socket) = StdUdpSocket::bind(bind_addr) else {
-            continue;
+        let socket = match StdUdpSocket::bind(bind_addr) {
+            Ok(socket) => socket,
+            Err(error) if error.kind() == ErrorKind::AddrInUse => continue,
+            Err(error) => {
+                warn!(%bind_addr, ?error, "failed to bind shared rtc UDP socket");
+                return Err(TransportAdapterError::TransportUnavailable);
+            }
         };
-        if socket.set_nonblocking(true).is_err() {
-            continue;
-        }
-        let Ok(socket) = RtcUdpSocket::from_std(socket, rtc_udp_io_backend) else {
-            continue;
-        };
+        socket.set_nonblocking(true).map_err(|error| {
+            warn!(%bind_addr, ?error, "failed to configure shared rtc UDP socket");
+            TransportAdapterError::TransportUnavailable
+        })?;
+        let socket = RtcUdpSocket::from_std(socket, rtc_udp_io_backend).map_err(|error| {
+            warn!(
+                %bind_addr,
+                backend = rtc_udp_io_backend.wire_name(),
+                ?error,
+                "failed to initialize shared rtc UDP socket"
+            );
+            TransportAdapterError::TransportUnavailable
+        })?;
         let candidate_addr = SocketAddr::new(announced_ip, port);
         let ingress = UdpIngress::new(socket.clone(), bind_addr, candidate_addr);
         info!(
@@ -80,6 +91,12 @@ pub(super) fn bind_shared_rtc_socket(
             candidate_addr,
         });
     }
+    warn!(
+        %bind_ip,
+        port_min = rtc_port_range.min(),
+        port_max = rtc_port_range.max(),
+        "rtc UDP port range is unavailable"
+    );
     Err(TransportAdapterError::TransportUnavailable)
 }
 

--- a/crates/core/src/engine/media_transport/rtc/worker/TESTS/support.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/TESTS/support.rs
@@ -44,19 +44,12 @@ use super::{
     },
     RtcWorker,
 };
-use crate::Bitrate;
-
-#[cfg(test)]
-#[allow(
-    clippy::panic,
-    reason = "test worker defaults cannot return Result and must fail loudly when no RTC ports are available"
-)]
-fn default_test_rtc_port_range() -> RtcPortRange {
-    test_rtc_port_range(1).unwrap_or_else(|| panic!("test RTC port range should be available"))
-}
 #[cfg(any(test, feature = "testing-transport"))]
 use crate::engine::media_transport::{TransportMediaId, TransportQualitySample};
-use crate::engine::{media_transport::TransportSessionKey, metrics};
+use crate::{
+    Bitrate,
+    engine::{media_transport::TransportSessionKey, metrics},
+};
 
 impl RtcWorker {
     #[cfg(test)]
@@ -441,7 +434,7 @@ impl Default for RtcWorkerTestBuilder {
         Self {
             max_bitrate_in: Bitrate::from_mbps(8),
             max_bitrate_out: Bitrate::from_mbps(10),
-            rtc_port_range: default_test_rtc_port_range(),
+            rtc_port_range: test_rtc_port_range(),
             codec_flags: MediaCodecFlags::default(),
             codec_preferences: CodecPreferences::default(),
         }

--- a/crates/core/src/engine/room/TESTS/fixtures.rs
+++ b/crates/core/src/engine/room/TESTS/fixtures.rs
@@ -67,7 +67,7 @@ pub(super) fn test_sender() -> (UserOutboundSender, UserOutboundReceiver) {
 
 #[allow(
     clippy::panic,
-    reason = "the room test fixture uses a fixed-valid RTC config and should fail loudly if it stops being valid"
+    reason = "the room test fixture uses a valid RTC config and should fail loudly if it stops being valid"
 )]
 pub(super) fn real_adapter() -> MediaTransport {
     real_adapter_with_metrics(Arc::new(RuntimeMetrics::default()))
@@ -76,12 +76,10 @@ pub(super) fn real_adapter() -> MediaTransport {
 fn real_adapter_with_metrics(metrics: Arc<RuntimeMetrics>) -> MediaTransport {
     let mut deps = test_media_transport_deps();
     deps.metrics = metrics;
-    let rtc_port_range =
-        test_rtc_port_range(4).unwrap_or_else(|| panic!("RTC room test ports should be available"));
-    match MediaTransport::build(test_media_transport_config(4, rtc_port_range), deps) {
-        Ok(transport) => transport,
-        Err(error) => panic!("constant RTC room test transport config should be valid: {error}"),
-    }
+    MediaTransport::build(test_media_transport_config(4, test_rtc_port_range()), deps)
+        .unwrap_or_else(|error| {
+            panic!("constant RTC room test transport config should be valid: {error}")
+        })
 }
 
 pub(super) fn test_connection_id(raw: u64) -> ConnectionId {

--- a/crates/core/src/engine/room/TESTS/producer_tests/support.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/support.rs
@@ -13,11 +13,13 @@ pub(super) use str0m::{Candidate, Rtc, change::SdpOffer, media::Mid};
 
 pub(super) use super::super::{api::NegotiatedPublish, fixtures::*};
 pub(super) use crate::{
-    Bitrate, RoomMediaLimits, RtcPortRange,
+    Bitrate, RoomMediaLimits,
     engine::{
         media_transport::{
             SessionOffer, TransportMediaId, TransportSessionKey,
-            test_support::{test_media_transport_config, test_media_transport_deps},
+            test_support::{
+                test_media_transport_config, test_media_transport_deps, test_rtc_port_range,
+            },
         },
         room::{PublishIntentOutcome, RemoteSourceSnapshot, Room},
     },
@@ -441,18 +443,15 @@ pub(super) fn build_real_rtc_media_transport() -> MediaTransport {
 
 #[allow(
     clippy::panic,
-    reason = "the RTC room test fixture uses a fixed valid configuration and should fail loudly if it stops being valid"
+    reason = "the RTC room test fixture uses a valid test configuration and should fail loudly if it stops being valid"
 )]
 fn build_real_rtc_media_transport_with_metrics(metrics: Arc<RuntimeMetrics>) -> MediaTransport {
     let mut deps = test_media_transport_deps();
     deps.metrics = metrics;
-    match MediaTransport::build(
-        test_media_transport_config(1, RtcPortRange::new(46_200, 46_299)),
-        deps,
-    ) {
-        Ok(transport) => transport,
-        Err(error) => panic!("constant RTC room test transport config should be valid: {error}"),
-    }
+    MediaTransport::build(test_media_transport_config(1, test_rtc_port_range()), deps)
+        .unwrap_or_else(|error| {
+            panic!("constant RTC room test transport config should be valid: {error}")
+        })
 }
 
 pub(super) async fn bootstrap_real_rtc_user(

--- a/crates/core/src/engine/room/effects/TESTS/route.rs
+++ b/crates/core/src/engine/room/effects/TESTS/route.rs
@@ -186,13 +186,11 @@ struct RouteFixture {
 
 impl RouteFixture {
     async fn new() -> Result<Self, Box<dyn Error>> {
-        let port_range =
-            test_rtc_port_range(1).ok_or_else(|| io::Error::other("rtc test ports unavailable"))?;
         let metrics = Arc::new(RuntimeMetrics::default());
         let mut deps = test_media_transport_deps();
         deps.metrics = Arc::clone(&metrics);
         let media_transport =
-            MediaTransport::build(test_media_transport_config(1, port_range), deps)?;
+            MediaTransport::build(test_media_transport_config(1, test_rtc_port_range()), deps)?;
         let source_session = session_key(1, UserId::Integer(1));
         let consumer_session = session_key(2, UserId::Integer(2));
         media_transport

--- a/crates/core/src/engine/room/transition/TESTS/publication.rs
+++ b/crates/core/src/engine/room/transition/TESTS/publication.rs
@@ -23,8 +23,8 @@ use crate::engine::{
 };
 
 fn media_transport() -> MediaTransport {
-    let rtc_port_range = test_rtc_port_range(4).expect("test ports should be available");
-    test_media_transport(4, rtc_port_range).expect("test media transport config should be valid")
+    test_media_transport(4, test_rtc_port_range())
+        .expect("test media transport config should be valid")
 }
 
 fn test_sender() -> UserOutboundSender {

--- a/crates/core/src/engine/room/transition/TESTS/subscription.rs
+++ b/crates/core/src/engine/room/transition/TESTS/subscription.rs
@@ -40,8 +40,8 @@ use crate::{
 };
 
 fn media_transport() -> MediaTransport {
-    let rtc_port_range = test_rtc_port_range(4).expect("test ports should be available");
-    test_media_transport(4, rtc_port_range).expect("test media transport config should be valid")
+    test_media_transport(4, test_rtc_port_range())
+        .expect("test media transport config should be valid")
 }
 
 fn test_sender() -> UserOutboundSender {

--- a/crates/rfc/src/lib.rs
+++ b/crates/rfc/src/lib.rs
@@ -4,5 +4,6 @@
 //! spelling, constrained numeric ranges or spec-defined parsing behavior
 
 pub mod jwt;
+pub mod port;
 pub mod rtp;
 pub mod webrtc;

--- a/crates/rfc/src/port.rs
+++ b/crates/rfc/src/port.rs
@@ -1,0 +1,7 @@
+//! Transport protocol port ranges from RFC 6335.
+
+/// First port in the dynamic port range from RFC 6335 section 6.
+pub const DYNAMIC_RANGE_START: u16 = 49_152;
+
+/// Last port in the dynamic port range from RFC 6335 section 6.
+pub const DYNAMIC_RANGE_END: u16 = u16::MAX;

--- a/src/runtime/TESTS/support.rs
+++ b/src/runtime/TESTS/support.rs
@@ -9,9 +9,8 @@ pub(super) use crate::runtime::metrics::test_support::RuntimeMetricsSnapshotTest
 use crate::{
     config::{
         AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config, DiagnosticsConfig, HttpConfig,
-        MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend,
-        RuntimeFeatureFlags, TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning,
-        VideoBitrateLimits,
+        MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcUdpIoBackend, RuntimeFeatureFlags,
+        TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning, VideoBitrateLimits,
     },
     runtime::{
         MediaTransport, RuntimeServices, RuntimeState, build_media_transport, build_room_manager,
@@ -40,7 +39,6 @@ pub(super) struct RuntimeTestBuilder {
 
 impl RuntimeTestBuilder {
     pub(super) fn new() -> Self {
-        let rtc_port_range = next_runtime_test_rtc_port_range();
         Self {
             config: Config {
                 auth: AuthConfig {
@@ -63,7 +61,7 @@ impl RuntimeTestBuilder {
                 },
                 transport: TransportConfig {
                     announced_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    rtc_port_range,
+                    rtc_port_range: test_rtc_port_range(),
                     max_bitrate_in: Bitrate::from_mbps(8),
                     max_bitrate_out: Bitrate::from_mbps(10),
                     video_bitrate_limits: VideoBitrateLimits::default(),
@@ -157,14 +155,6 @@ impl RuntimeTestBuilder {
     pub(super) fn build_runtime_state(self) -> RuntimeState {
         self.build_state().state
     }
-}
-
-#[allow(
-    clippy::panic,
-    reason = "runtime test fixtures need a real UDP range and should fail loudly when the host cannot provide one"
-)]
-fn next_runtime_test_rtc_port_range() -> RtcPortRange {
-    test_rtc_port_range(1).unwrap_or_else(|| panic!("runtime test RTC ports should be available"))
 }
 
 pub(super) fn test_outbound_sender(

--- a/tests/benchmarks/general_call/mod.rs
+++ b/tests/benchmarks/general_call/mod.rs
@@ -636,14 +636,12 @@ impl GeneralCallScenario {
 }
 
 fn media_transport() -> Result<MediaTransport> {
-    let rtc_port_range = test_rtc_port_range(WORKER_COUNT)
-        .ok_or_else(|| anyhow!("benchmark RTC port range was not available"))?;
     let config = MediaTransportConfig {
         worker_count: WORKER_COUNT,
         announced_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
         bitrate_limits: SessionBitrateLimits::new(Bitrate::from_mbps(8), Bitrate::from_mbps(10)),
         video_bitrate_limits: VideoBitrateLimits::default(),
-        rtc_port_range,
+        rtc_port_range: test_rtc_port_range(),
         rtc_udp_io_backend: RtcUdpIoBackend::Tokio,
         codec_flags: MediaCodecFlags::default(),
         codec_preferences: CodecPreferences::default(),

--- a/tests/core-room/tests/support/mod.rs
+++ b/tests/core-room/tests/support/mod.rs
@@ -50,8 +50,6 @@ pub fn test_sender() -> (UserOutboundSender, UserOutboundReceiver) {
 }
 
 pub fn media_transport() -> Result<MediaTransport> {
-    let rtc_port_range =
-        test_rtc_port_range(4).ok_or_else(|| anyhow!("RTC test ports should be available"))?;
     MediaTransport::build(
         MediaTransportConfig {
             worker_count: 4,
@@ -61,7 +59,7 @@ pub fn media_transport() -> Result<MediaTransport> {
                 Bitrate::from_mbps(10),
             ),
             video_bitrate_limits: VideoBitrateLimits::default(),
-            rtc_port_range,
+            rtc_port_range: test_rtc_port_range(),
             rtc_udp_io_backend: RtcUdpIoBackend::Tokio,
             codec_flags: MediaCodecFlags::default(),
             codec_preferences: CodecPreferences::default(),

--- a/tests/integration/full_stack/support.rs
+++ b/tests/integration/full_stack/support.rs
@@ -38,8 +38,7 @@ pub(super) use o_sfu_tests::support::{
         ProtocolFakePeer, connect_fake_peer, connect_two_fake_peers,
         connect_two_rtc_ready_fake_peers,
     },
-    require_some, set_rtc_media_worker_count, spawn_room_server_with_config, spawn_test_server,
-    stats, test_config,
+    require_some, spawn_room_server_with_config, spawn_test_server, stats, test_config,
 };
 pub(super) use tokio::{
     sync::{Mutex, MutexGuard},

--- a/tests/integration/full_stack/support/setup.rs
+++ b/tests/integration/full_stack/support/setup.rs
@@ -147,7 +147,7 @@ pub(crate) async fn room_parts_with_config(
 
 pub(crate) fn cross_worker_test_config() -> Config {
     let mut config = test_config(1_000, 10);
-    set_rtc_media_worker_count(&mut config, 2);
+    config.transport.rtc_media_worker_count = 2;
     config.transport.room_worker_policy = spillover_policy(2);
     config
 }

--- a/tests/integration/full_stack/support/spillover.rs
+++ b/tests/integration/full_stack/support/spillover.rs
@@ -95,14 +95,14 @@ pub(crate) async fn large_room_spillover_fake_peers(
 
 fn overload_spillover_test_config() -> Config {
     let mut config = super::test_config(1_000, 10);
-    set_rtc_media_worker_count(&mut config, 2);
+    config.transport.rtc_media_worker_count = 2;
     config.transport.room_worker_policy = spillover_policy(2);
     config
 }
 
 fn large_room_spillover_test_config() -> Config {
     let mut config = super::test_config(1_000, LARGE_ROOM_SIZE);
-    set_rtc_media_worker_count(&mut config, LARGE_ROOM_LOCAL_ROUTER_CAP);
+    config.transport.rtc_media_worker_count = LARGE_ROOM_LOCAL_ROUTER_CAP;
     config.transport.room_worker_policy = spillover_policy(LARGE_ROOM_LOCAL_ROUTER_CAP);
     config.transport.room_media_limits =
         match RoomMediaLimits::try_new(LARGE_ROOM_MEDIA_LIMIT, LARGE_ROOM_MEDIA_LIMIT) {

--- a/tests/src/support/harness.rs
+++ b/tests/src/support/harness.rs
@@ -19,9 +19,8 @@ use o_sfu::{
     },
     config::{
         AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config, DiagnosticsConfig, HttpConfig,
-        MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcPortRange, RtcUdpIoBackend,
-        RuntimeFeatureFlags, TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning,
-        VideoBitrateLimits,
+        MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcUdpIoBackend, RuntimeFeatureFlags,
+        TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning, VideoBitrateLimits,
     },
     core::server::room::{
         DEFAULT_USER_OUTBOUND_QUEUE_BYTE_CAPACITY, DEFAULT_USER_OUTBOUND_QUEUE_CAPACITY,
@@ -428,7 +427,7 @@ pub fn test_config(authentication_timeout_ms: u64, room_size: usize) -> Config {
         },
         transport: TransportConfig {
             announced_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            rtc_port_range: unique_rtc_port_range(1),
+            rtc_port_range: test_rtc_port_range(),
             max_bitrate_in: Bitrate::from_mbps(8),
             max_bitrate_out: Bitrate::from_mbps(10),
             video_bitrate_limits: VideoBitrateLimits::default(),
@@ -446,21 +445,6 @@ pub fn test_config(authentication_timeout_ms: u64, room_size: usize) -> Config {
         telemetry: TelemetryConfig::default(),
         diagnostics: DiagnosticsConfig::default(),
     }
-}
-
-pub fn set_rtc_media_worker_count(config: &mut Config, worker_count: usize) {
-    config.transport.rtc_media_worker_count = worker_count;
-    config.transport.rtc_port_range = unique_rtc_port_range(worker_count);
-}
-
-fn unique_rtc_port_range(worker_count: usize) -> RtcPortRange {
-    #![allow(
-        clippy::panic,
-        reason = "test configs cannot return Result and must fail loudly when no RTC ports are available"
-    )]
-
-    test_rtc_port_range(worker_count)
-        .unwrap_or_else(|| panic!("test RTC port allocator could not reserve a contiguous range"))
 }
 
 #[must_use]


### PR DESCRIPTION
RTC tests released probed ports before workers bound them. Parallel startup could then lose a selected port to another process.

Use the RFC 6335 dynamic range for every test transport. Let each worker claim an available port through the existing bind loop. Remove the process catalog, filesystem locks and stale-lock cleanup.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
