### PR TITLE
[IMP] prioritize screen sharers when determining admitted audio

### DIFF
--- a/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
@@ -537,6 +537,88 @@ async fn audio_speaker_limit_ignores_foreign_and_inactive_sources() {
 }
 
 #[tokio::test]
+async fn audio_speaker_limit_prioritizes_screen_sharers() {
+    let scenario = SourcePolicyScenario::with_ready_users_and_media_limits(
+        &[1, 2, 3],
+        // Restrict to 1 active speaker so that all sources are dropped except the highest-priority one.
+        RoomMediaLimits::try_new(1, 10).unwrap(),
+    )
+    .await;
+    let screen_sharer_id = UserId::Integer(1);
+    let receiver_id = UserId::Integer(2);
+    let non_screen_sharer_id = UserId::Integer(3);
+    for user_id in [&screen_sharer_id, &non_screen_sharer_id] {
+        publish_track(
+            &scenario.room,
+            user_id,
+            TestSourceKind::AudioDetector,
+            MediaKind::Audio,
+            test_audio_rtp_parameters(),
+            &scenario.adapter,
+        )
+        .await;
+    }
+    let screen_sharing_intent = source_publish_intent_for_source(TestSourceKind::ReadableVideo)
+        .with_presence(Some(UserInfo {
+            is_screen_sharing_on: Some(true),
+            ..UserInfo::default()
+        }));
+    scenario
+        .room
+        .test_api()
+        .media()
+        .publish_intent(
+            &screen_sharer_id,
+            &screen_sharing_intent,
+            MediaKind::Video,
+            test_video_rtp_parameters(),
+            &scenario.adapter,
+        )
+        .await
+        .expect("screen share publication should succeed");
+    let screen_sharer_audio = source_media_id(
+        &scenario.room,
+        &screen_sharer_id,
+        TestSourceKind::AudioDetector,
+    )
+    .await;
+    let non_screen_sharer_audio = source_media_id(
+        &scenario.room,
+        &non_screen_sharer_id,
+        TestSourceKind::AudioDetector,
+    )
+    .await;
+    // Make the non-screen sharer louder so they rank higher.
+    // This verifies that the screen sharer's audio is preserved despite having a lower volume ranking.
+    scenario
+        .mark_active_speakers_with_levels([
+            (non_screen_sharer_audio, -10), // loudest
+            (screen_sharer_audio, -30),     // quietest
+        ])
+        .await;
+    scenario.refresh_policy().await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_id,
+        &screen_sharer_id,
+        TestSourceKind::AudioDetector,
+        // No pause reason means the subscription remains active and the screen sharer's source is preserved.
+        None,
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver_id,
+        &non_screen_sharer_id,
+        TestSourceKind::AudioDetector,
+        Some(DiagnosticsPolicyPauseReason::AudioSpeakerLimit),
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn deafening_a_receiver_pauses_its_audio_and_keeps_video() {
     let scenario = SourcePolicyScenario::three_ready_users().await;
     scenario

--- a/crates/core/src/engine/room/source_policy/input.rs
+++ b/crates/core/src/engine/room/source_policy/input.rs
@@ -14,7 +14,10 @@ use crate::{
             ActiveSpeakerSource, ReceiverBandwidthSnapshot, ReceiverBweTargetUpdate,
             TransportMediaId,
         },
-        room::{media_graph::ConsumerRouteView, state::RoomState},
+        room::{
+            media_graph::ConsumerRouteView,
+            state::{ActiveUser, RoomState},
+        },
     },
 };
 
@@ -47,8 +50,11 @@ impl<'a> SourcePolicySnapshot<'a> {
         let media_limits = room.media_limits;
         let tuning = room.video_adaptation_tuning;
         let active_speakers = active_speaker_media_ids(&ranked_sources);
-        let admitted_audio_speakers =
-            admitted_audio_media_ids(&ranked_sources, media_limits.max_active_audio_speakers());
+        let admitted_audio_speakers = admitted_audio_media_ids(
+            room,
+            &ranked_sources,
+            media_limits.max_active_audio_speakers(),
+        );
         let deaf_receiver_connection_ids = deaf_receiver_connection_ids(room);
         let featured_source_user_ids = featured_source_user_ids(room, &ranked_sources);
         let active_speaker_rank_by_user = active_speaker_rank_by_user(room, &ranked_sources);
@@ -187,15 +193,41 @@ fn active_speaker_media_ids(sources: &[ActiveSpeakerSource]) -> BTreeSet<Transpo
         .collect()
 }
 
+fn user_for_source<'a>(
+    room: &'a RoomState,
+    source: &ActiveSpeakerSource,
+) -> Option<&'a ActiveUser> {
+    room.topology
+        .source_for_transport_media(source.transport_media_id())
+        .and_then(|published_source| {
+            room.users
+                .get(published_source.descriptor.owner().user_id())
+        })
+}
+
+/// Takes audio media IDs from `sources` up to the provided `limit`,
+/// prioritizing participants who are currently screen sharing.
 fn admitted_audio_media_ids(
+    room: &RoomState,
     sources: &[ActiveSpeakerSource],
     limit: usize,
 ) -> BTreeSet<TransportMediaId> {
-    sources
-        .iter()
-        .take(limit)
-        .map(|source| source.transport_media_id())
-        .collect()
+    let mut admitted = BTreeSet::new();
+    let mut deferred = Vec::with_capacity(limit);
+    for source in sources {
+        if admitted.len() == limit {
+            break;
+        }
+        let media_id = source.transport_media_id();
+        // prioritize participants who are currently screen sharing
+        if user_for_source(room, source).is_some_and(ActiveUser::is_screensharing) {
+            admitted.insert(media_id);
+        } else if deferred.len() < limit - admitted.len() {
+            deferred.push(media_id);
+        }
+    }
+    admitted.extend(deferred.into_iter().take(limit - admitted.len()));
+    admitted
 }
 
 fn deaf_receiver_connection_ids(room: &RoomState) -> BTreeSet<ConnectionId> {

--- a/crates/core/src/engine/room/source_policy/input.rs
+++ b/crates/core/src/engine/room/source_policy/input.rs
@@ -39,24 +39,24 @@ pub(super) struct SourcePolicySnapshot<'a> {
 
 impl<'a> SourcePolicySnapshot<'a> {
     pub(super) fn from_state(
-        state: &'a RoomState,
+        room: &'a RoomState,
         active_speaker_sources: &[ActiveSpeakerSource],
         receiver_bandwidth_snapshot: &ReceiverBandwidthSnapshot,
     ) -> Self {
-        let ranked_sources = rank_room_active_speakers(state, active_speaker_sources);
-        let media_limits = state.media_limits;
-        let tuning = state.video_adaptation_tuning;
+        let ranked_sources = rank_room_active_speakers(room, active_speaker_sources);
+        let media_limits = room.media_limits;
+        let tuning = room.video_adaptation_tuning;
         let active_speakers = active_speaker_media_ids(&ranked_sources);
         let admitted_audio_speakers =
             admitted_audio_media_ids(&ranked_sources, media_limits.max_active_audio_speakers());
-        let deaf_receiver_connection_ids = deaf_receiver_connection_ids(state);
-        let featured_source_user_ids = featured_source_user_ids(state, &ranked_sources);
-        let active_speaker_rank_by_user = active_speaker_rank_by_user(state, &ranked_sources);
+        let deaf_receiver_connection_ids = deaf_receiver_connection_ids(room);
+        let featured_source_user_ids = featured_source_user_ids(room, &ranked_sources);
+        let active_speaker_rank_by_user = active_speaker_rank_by_user(room, &ranked_sources);
         let desired_featured_user_id = ranked_sources.iter().find_map(|source| {
-            featured_source_owner_for_active_speaker_source(state, source.transport_media_id())
+            featured_source_owner_for_active_speaker_source(room, source.transport_media_id())
         });
-        let featured_user_updates = featured_user_updates(state, desired_featured_user_id.as_ref());
-        let routes = state
+        let featured_user_updates = featured_user_updates(room, desired_featured_user_id.as_ref());
+        let routes = room
             .committed_consumer_routes()
             .filter(|route| route.source.active && route.selection.active())
             .collect::<Vec<_>>();
@@ -68,7 +68,7 @@ impl<'a> SourcePolicySnapshot<'a> {
         );
         Self {
             routes,
-            receiver_bwe_targets: receiver_bwe_targets(state, &audio_reserve_by_connection),
+            receiver_bwe_targets: receiver_bwe_targets(room, &audio_reserve_by_connection),
             receiver_bandwidth_by_connection: receiver_bandwidth_by_connection(
                 receiver_bandwidth_snapshot,
             ),
@@ -78,7 +78,7 @@ impl<'a> SourcePolicySnapshot<'a> {
             featured_source_user_ids,
             active_speaker_rank_by_user,
             featured_user_updates,
-            user_count: state.user_count(),
+            user_count: room.user_count(),
             media_limits,
             video_adaptation_tuning: tuning,
             audio_reserve_by_connection,
@@ -124,13 +124,12 @@ fn audio_reserve_by_connection(
 }
 
 fn receiver_bwe_targets(
-    state: &RoomState,
+    room: &RoomState,
     audio_reserve_by_connection: &BTreeMap<ConnectionId, Bitrate>,
 ) -> BTreeMap<UserId, ReceiverBweTargetUpdate> {
-    state
-        .transport_user_entries()
+    room.transport_user_entries()
         .map(|(user_id, connection_id)| {
-            let session = state.transport_user_key(user_id, connection_id);
+            let session = room.transport_user_key(user_id, connection_id);
             let audio_reserve = audio_reserve_by_connection
                 .get(&connection_id)
                 .copied()
@@ -162,13 +161,12 @@ fn receiver_bandwidth_by_connection(
 ///
 /// Only retains sources that are active and present in the current room topology.
 fn rank_room_active_speakers(
-    state: &RoomState,
+    room: &RoomState,
     sources: &[ActiveSpeakerSource],
 ) -> Vec<ActiveSpeakerSource> {
     let mut sources = sources.to_vec();
     sources.retain(|source| {
-        state
-            .topology
+        room.topology
             .source_for_transport_media(source.transport_media_id())
             .is_some_and(|source| source.active)
     });
@@ -200,36 +198,32 @@ fn admitted_audio_media_ids(
         .collect()
 }
 
-fn deaf_receiver_connection_ids(state: &RoomState) -> BTreeSet<ConnectionId> {
-    state
-        .users
+fn deaf_receiver_connection_ids(room: &RoomState) -> BTreeSet<ConnectionId> {
+    room.users
         .values()
         .filter(|user| user.is_deaf())
         .map(|user| user.connection_id)
         .collect()
 }
 
-fn featured_source_user_ids(
-    state: &RoomState,
-    sources: &[ActiveSpeakerSource],
-) -> BTreeSet<UserId> {
+fn featured_source_user_ids(room: &RoomState, sources: &[ActiveSpeakerSource]) -> BTreeSet<UserId> {
     sources
         .iter()
         .filter_map(|source| {
-            featured_source_owner_for_active_speaker_source(state, source.transport_media_id())
+            featured_source_owner_for_active_speaker_source(room, source.transport_media_id())
         })
         .take(ACTIVE_SPEAKER_FEATURED_CLEAR_LIMIT)
         .collect()
 }
 
 fn active_speaker_rank_by_user(
-    state: &RoomState,
+    room: &RoomState,
     sources: &[ActiveSpeakerSource],
 ) -> BTreeMap<UserId, usize> {
     let mut ranks = BTreeMap::new();
     for source in sources {
         let Some(user_id) =
-            featured_source_owner_for_active_speaker_source(state, source.transport_media_id())
+            featured_source_owner_for_active_speaker_source(room, source.transport_media_id())
         else {
             continue;
         };
@@ -240,25 +234,23 @@ fn active_speaker_rank_by_user(
 }
 
 fn featured_source_owner_for_active_speaker_source(
-    state: &RoomState,
+    room: &RoomState,
     transport_media_id: TransportMediaId,
 ) -> Option<UserId> {
-    state
-        .topology
+    room.topology
         .active_speaker_detector_owner(transport_media_id)
 }
 
 fn featured_user_updates(
-    state: &RoomState,
+    room: &RoomState,
     desired_featured_user_id: Option<&UserId>,
 ) -> Vec<FeaturedUserUpdate> {
     if desired_featured_user_id.is_none()
-        && !state.users.values().any(|user| user.featured().is_some())
+        && !room.users.values().any(|user| user.featured().is_some())
     {
         return Vec::new();
     }
-    state
-        .users
+    room.users
         .iter()
         .filter_map(|(user_id, user)| {
             let current_featured = user.featured();

--- a/crates/core/src/engine/room/source_policy/input.rs
+++ b/crates/core/src/engine/room/source_policy/input.rs
@@ -153,6 +153,14 @@ fn receiver_bandwidth_by_connection(
         .collect()
 }
 
+/// Filters and ranks a list of active speaker sources for a room.
+///
+/// **Ranking Criteria:**
+/// 1. **Recency:** Most recently active first (highest `observed_at`).
+/// 2. **Loudness:** Highest audio level first (`last_audio_level_dbov`).
+/// 3. **Tie-breaker:** Transport media ID.
+///
+/// Only retains sources that are active and present in the current room topology.
 fn rank_room_active_speakers(
     state: &RoomState,
     sources: &[ActiveSpeakerSource],

--- a/crates/core/src/engine/room/state/shared.rs
+++ b/crates/core/src/engine/room/state/shared.rs
@@ -63,6 +63,10 @@ impl ActiveUser {
         matches!(self.info.is_deaf, Some(true))
     }
 
+    pub(in crate::engine::room) const fn is_screensharing(&self) -> bool {
+        matches!(self.info.is_screen_sharing_on, Some(true))
+    }
+
     pub(in crate::engine::room) fn set_featured(&mut self, featured: Option<bool>) {
         self.server_featured = featured;
     }


### PR DESCRIPTION
This commit updates the source policy to prioritize the audio of screen-sharing users.

#### Context

The SFU currently ranks active audio sources by observation time, audio level, and transport media ID, then admits the first sources up to the configured limit. The default limit is 4 active audio sources.

This means that under pressure, the audio of someone presenting may be dropped. To mitigate this risk, this commit updates the source policy to prioritize the audio of screen-sharing users.

#### Note

This solution is not perfect, as a presentation itself may be silent, holding an admitted audio "slot" unnecessarily. However, we cannot currently distinguish between a user's microphone audio and their screen-share audio, as the client sends both mixed into a single track. This is a known limitation that could be improved in the future.

#### See also

Related issue: #562

#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [x] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
