### PR TITLE
[IMP] core, config, runtime: expire room reservations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,5 +175,6 @@ o-sfu-protocol = { workspace = true, features = ["test-support"] }
 o-sfu-telemetry = { workspace = true, features = ["test-support"] }
 o-sfu-router = { workspace = true, features = ["test-support"] }
 str0m.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tokio-tungstenite.workspace = true
 tower = { version = "0.5", features = ["util"] }

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -484,6 +484,7 @@ room and user limits:
 | `PING_INTERVAL_MS` | `60000` | signaling ping interval in milliseconds |
 | `USER_OUTBOUND_QUEUE_CAPACITY` | `128` | per-user WebSocket room-event queue depth |
 | `USER_OUTBOUND_QUEUE_BYTE_CAPACITY` | `2097152` | per-user WebSocket queued-byte budget |
+| `ROOM_RESERVATION_TTL` | `60` | time-to-live for unjoined rooms in seconds |
 
 RTC transport:
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,4 +40,5 @@ workspace = true
 [dev-dependencies]
 o-sfu-telemetry = { workspace = true, features = ["test-support"] }
 o-sfu-router = { workspace = true, features = ["test-support"] }
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { version = "0.3", features = ["json"] }

--- a/crates/core/src/engine/room/TESTS/api/lifecycle.rs
+++ b/crates/core/src/engine/room/TESTS/api/lifecycle.rs
@@ -4,7 +4,7 @@ use o_sfu_router::{
 
 use super::super::super::{
     JoinUserRequest, Room, RoomEffectContext, RoomJoinError, UserOutboundSender,
-    placement::JoinAdmissionTurn,
+    media_graph::CommittedTransportReceipt, placement::JoinAdmissionTurn,
 };
 use crate::engine::{
     ConnectionId, UserId, UserPermissions,
@@ -55,13 +55,12 @@ impl RoomTestLifecycle<'_> {
             permissions,
             sender,
         };
-        self.room
-            .admit_session(
-                JoinAdmissionTurn::for_test(request, delays_ms, spillover_router_id),
-                RoomEffectContext::state_only(None),
-            )
-            .await
-            .map(|receipt| receipt.connection_id)
+        self.admit_session(
+            JoinAdmissionTurn::for_test(request, delays_ms, spillover_router_id),
+            RoomEffectContext::state_only(None),
+        )
+        .await
+        .map(|receipt| receipt.connection_id)
     }
 
     /// # Errors
@@ -82,17 +81,25 @@ impl RoomTestLifecycle<'_> {
             permissions,
             sender,
         };
-        self.room
-            .admit_session(
-                JoinAdmissionTurn::for_test(
-                    request,
-                    media_transport.packet_loop_delays_ms(),
-                    spillover_router_id,
-                ),
-                RoomEffectContext::state_only(Some(media_transport)),
-            )
-            .await
-            .map(|receipt| receipt.connection_id)
+        self.admit_session(
+            JoinAdmissionTurn::for_test(
+                request,
+                media_transport.packet_loop_delays_ms(),
+                spillover_router_id,
+            ),
+            RoomEffectContext::state_only(Some(media_transport)),
+        )
+        .await
+        .map(|receipt| receipt.connection_id)
+    }
+
+    async fn admit_session(
+        self,
+        admission: JoinAdmissionTurn<'_, impl FnOnce() -> o_sfu_router::RouterId>,
+        context: RoomEffectContext<'_>,
+    ) -> Result<CommittedTransportReceipt, RoomJoinError> {
+        let commit = self.room.commit_admission(admission, context).await?;
+        Ok(self.room.finalize_admission(commit, context).await)
     }
 
     /// # Errors

--- a/crates/core/src/engine/room/TESTS/manager_tests.rs
+++ b/crates/core/src/engine/room/TESTS/manager_tests.rs
@@ -10,14 +10,17 @@ use serde_json::Value;
 use tokio::{sync::Notify, task::yield_now, time::timeout};
 
 use super::{
-    super::manager::JoinPlacementTestGate,
+    super::{RoomManagerJoinError, manager::JoinPlacementTestGate},
     api::NegotiatedPublish,
     fixtures::*,
     tracing::{assert_exact, assert_user_exact, capture},
 };
-use crate::{RoomWorkerPolicy, RuntimeFeatureFlags};
+use crate::{RoomWorkerPolicy, RuntimeFeatureFlags, engine::metrics::RoomGaugeValues};
 
 type TestRoom = super::super::Room;
+
+/// reservation window that no test can reach, so expiry only happens on demand
+const LONG_EXPIRATION: Duration = Duration::from_hours(1);
 
 async fn manager_join_user(
     manager: &RoomManager,
@@ -40,6 +43,28 @@ async fn manager_join_user(
         .await
         .expect("user should join through manager");
     admission.connection_id
+}
+
+async fn try_manager_join_user(
+    manager: &RoomManager,
+    room_id: &str,
+    raw_user_id: i64,
+    media_transport: &MediaTransport,
+) -> Result<ConnectionId, RoomManagerJoinError> {
+    let (sender, _receiver) = test_sender();
+    manager
+        .join_user(
+            room_id,
+            JoinUserRequest {
+                user_id: UserId::Integer(raw_user_id),
+                label: None,
+                permissions: UserPermissions::default(),
+                sender,
+            },
+            media_transport,
+        )
+        .await
+        .map(|admission| admission.connection_id)
 }
 
 fn manager_with_room_worker_policy(room_worker_policy: RoomWorkerPolicy) -> RoomManager {
@@ -450,5 +475,294 @@ async fn spillover_media_diagnostics_use_connection_worker() {
             ("active", Value::from(false)),
             ("stream_id", Value::from(stream_id.to_string())),
         ],
+    );
+}
+
+#[tokio::test]
+async fn expired_reservation_is_reaped_and_frees_the_issuer_alias() {
+    const ISSUER: &str = "issuer-reservation-expiry";
+
+    let manager = RoomManager::for_test_with_reservation_ttl(Duration::ZERO);
+    let room = serve_test_room(&manager, ISSUER).await;
+    let room_id = room.uuid().to_owned();
+
+    // a room is available until it is reaped, so `/v1/channel` keeps serving a
+    // uuid whose deadline has passed. that uuid is still joinable.
+    assert_eq!(serve_test_room(&manager, ISSUER).await.uuid(), room_id);
+
+    manager.check_expired_room_reservations().await;
+
+    assert!(
+        manager.get_by_uuid(&room_id).await.is_none(),
+        "an expired reservation should leave the directory"
+    );
+    assert_eq!(
+        manager.room_gauges().await,
+        RoomGaugeValues::default(),
+        "the reaped room should stop counting towards the active-room gauge"
+    );
+    assert_ne!(
+        serve_test_room(&manager, ISSUER).await.uuid(),
+        room_id,
+        "the issuer alias should be free for a fresh room"
+    );
+}
+
+#[tokio::test]
+async fn serving_an_existing_room_renews_its_reservation() {
+    const ISSUER: &str = "issuer-serve-renews-reservation";
+
+    let manager = RoomManager::for_test_with_reservation_ttl(LONG_EXPIRATION);
+    let room = serve_test_room(&manager, ISSUER).await;
+
+    assert!(
+        manager
+            .expire_room_reservation_now_for_test(room.uuid())
+            .await
+    );
+
+    assert_eq!(
+        serve_test_room(&manager, ISSUER).await.uuid(),
+        room.uuid(),
+        "a second serve for the same issuer should return the same room"
+    );
+
+    // if the second serve had not renewed the reservation, this pass would
+    // reap the room since it was force expired
+    manager.check_expired_room_reservations().await;
+
+    assert!(
+        manager.get_by_uuid(room.uuid()).await.is_some(),
+        "serving the room again should renew its reservation before the reaper runs"
+    );
+}
+
+#[tokio::test]
+async fn serving_a_joined_room_does_not_rearm_its_reservation() {
+    const ISSUER: &str = "issuer-serve-after-join";
+
+    let manager = RoomManager::for_test_with_reservation_ttl(Duration::ZERO);
+    let media_transport = real_adapter();
+    let room = serve_test_room(&manager, ISSUER).await;
+    manager_join_user(&manager, &room, 1, &media_transport).await;
+
+    // `/v1/channel` keeps serving a room its users are already in, and the
+    // reaper does not check membership, so a deadline re-armed here would reap
+    // an occupied room
+    assert_eq!(serve_test_room(&manager, ISSUER).await.uuid(), room.uuid());
+    assert!(
+        !manager
+            .has_room_reservation_deadline_for_test(room.uuid())
+            .await,
+        "serving a joined room must not rearm the reservation its join retired"
+    );
+
+    manager.check_expired_room_reservations().await;
+
+    assert!(
+        manager.get_by_uuid(room.uuid()).await.is_some(),
+        "an occupied room must survive the reaper"
+    );
+    assert_eq!(
+        manager.room_gauges().await,
+        RoomGaugeValues {
+            rooms: 1,
+            users: 1,
+            ..RoomGaugeValues::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn a_joined_room_has_no_reservation_deadline() {
+    let manager = RoomManager::for_test_with_reservation_ttl(LONG_EXPIRATION);
+    let media_transport = real_adapter();
+    let room = serve_test_room(&manager, "issuer-joined-reservation").await;
+    assert!(
+        manager
+            .has_room_reservation_deadline_for_test(room.uuid())
+            .await,
+        "an unjoined room should carry a reservation deadline"
+    );
+
+    let connection_id = manager_join_user(&manager, &room, 1, &media_transport).await;
+
+    assert!(
+        !manager
+            .has_room_reservation_deadline_for_test(room.uuid())
+            .await,
+        "a successful first join should retire the reservation"
+    );
+    manager.check_expired_room_reservations().await;
+    assert_eq!(
+        manager.room_gauges().await,
+        RoomGaugeValues {
+            rooms: 1,
+            users: 1,
+            ..RoomGaugeValues::default()
+        }
+    );
+
+    assert!(
+        manager
+            .close_session(
+                room.uuid(),
+                &UserId::Integer(1),
+                connection_id,
+                &media_transport,
+            )
+            .await
+    );
+    assert!(
+        manager.get_by_uuid(room.uuid()).await.is_none(),
+        "last-user cleanup should stay unchanged by reservations"
+    );
+}
+
+#[tokio::test]
+async fn expiry_loses_to_an_in_flight_first_join() {
+    let manager = Arc::new(RoomManager::for_test_with_reservation_ttl(LONG_EXPIRATION));
+    let media_transport = real_adapter();
+    let room = serve_test_room(&manager, "issuer-join-outruns-expiry").await;
+    let gate = Arc::new(JoinPlacementTestGate::new(1));
+    manager.set_join_placement_gate_for_test(Arc::clone(&gate));
+    let pending_join = {
+        let manager = Arc::clone(&manager);
+        let room = Arc::clone(&room);
+        let media_transport = media_transport.clone();
+        tokio::spawn(async move { manager_join_user(&manager, &room, 1, &media_transport).await })
+    };
+
+    timeout(Duration::from_secs(5), gate.hold_all_ready())
+        .await
+        .expect("the join should reach the placement gate");
+    assert!(
+        manager
+            .expire_room_reservation_now_for_test(room.uuid())
+            .await
+    );
+    manager.check_expired_room_reservations().await;
+
+    assert!(
+        manager.get_by_uuid(room.uuid()).await.is_some(),
+        "expiry must not reap a room whose first join already holds a lease"
+    );
+
+    gate.release_all().await;
+    pending_join.await.expect("join task should not panic");
+
+    assert!(
+        !manager
+            .has_room_reservation_deadline_for_test(room.uuid())
+            .await,
+        "the join that outran expiry should retire the reservation"
+    );
+    manager.check_expired_room_reservations().await;
+    assert_eq!(
+        manager.room_gauges().await,
+        RoomGaugeValues {
+            rooms: 1,
+            users: 1,
+            ..RoomGaugeValues::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn a_join_between_the_deadline_and_the_reaper_keeps_the_room() {
+    const ISSUER: &str = "issuer-join-outruns-reaper";
+
+    let manager = RoomManager::for_test_with_reservation_ttl(Duration::ZERO);
+    let media_transport = real_adapter();
+    let room = serve_test_room(&manager, ISSUER).await;
+    let room_id = room.uuid().to_owned();
+
+    // the deadline has already passed, but no reaper pass has claimed the row,
+    // so the room is still in the directory and still joinable
+    assert!(
+        try_manager_join_user(&manager, &room_id, 1, &media_transport)
+            .await
+            .is_ok(),
+        "a room past its deadline stays joinable until the reaper claims it"
+    );
+
+    assert!(
+        manager
+            .test_api()
+            .has_session(&room_id, &UserId::Integer(1))
+            .await,
+        "the accepted join should leave a room session behind"
+    );
+    assert!(
+        !manager
+            .has_room_reservation_deadline_for_test(&room_id)
+            .await,
+        "the join that outran the reaper should retire the reservation"
+    );
+
+    manager.check_expired_room_reservations().await;
+
+    assert!(
+        manager.get_by_uuid(&room_id).await.is_some(),
+        "a reaper pass after the join must leave the occupied room alone"
+    );
+    assert_eq!(
+        manager.room_gauges().await,
+        RoomGaugeValues {
+            rooms: 1,
+            users: 1,
+            ..RoomGaugeValues::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn a_failed_first_join_does_not_extend_the_reservation() {
+    let manager = RoomManager::for_test_with_runtime_policy_and_reservation_ttl(
+        super::super::RoomRuntimePolicy::new(
+            RoomAdmissionPolicy::new(0),
+            RuntimeFeatureFlags::default(),
+            test_client_rtp_capabilities(),
+        ),
+        LONG_EXPIRATION,
+    );
+    let media_transport = real_adapter();
+    let room = serve_test_room(&manager, "issuer-failed-join-reservation").await;
+
+    assert!(matches!(
+        try_manager_join_user(&manager, room.uuid(), 1, &media_transport).await,
+        Err(RoomManagerJoinError::RoomFull)
+    ));
+
+    assert!(
+        manager
+            .has_room_reservation_deadline_for_test(room.uuid())
+            .await,
+        "only a successful join may retire the reservation"
+    );
+    assert!(
+        manager
+            .expire_room_reservation_now_for_test(room.uuid())
+            .await
+    );
+    manager.check_expired_room_reservations().await;
+
+    assert!(manager.get_by_uuid(room.uuid()).await.is_none());
+    assert_eq!(manager.room_gauges().await, RoomGaugeValues::default());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn room_reservation_expired_event_preserves_contract_fields() {
+    let _guard = capture().await;
+    let manager = RoomManager::for_test_with_reservation_ttl(Duration::ZERO);
+    let room = serve_test_room(&manager, "issuer-reservation-expiry-events").await;
+
+    // `assert_exact` requires exactly one matching event, so a reaper that re-logged every tick would fail here
+    manager.check_expired_room_reservations().await;
+    manager.check_expired_room_reservations().await;
+
+    assert_exact(
+        telemetry_event::ROOM_RESERVATION_EXPIRED,
+        &[("room_id", Value::from(room.uuid()))],
     );
 }

--- a/crates/core/src/engine/room/TESTS/mod.rs
+++ b/crates/core/src/engine/room/TESTS/mod.rs
@@ -24,5 +24,8 @@ mod outbound_tests;
 #[path = "producer_tests.rs"]
 mod producer_tests;
 #[cfg(test)]
+#[path = "reservation_tests.rs"]
+mod reservation_tests;
+#[cfg(test)]
 #[path = "tracing.rs"]
 pub(crate) mod tracing;

--- a/crates/core/src/engine/room/TESTS/reservation_tests.rs
+++ b/crates/core/src/engine/room/TESTS/reservation_tests.rs
@@ -1,0 +1,158 @@
+//! room reservation expiry coordination
+//!
+//! a room published by `/v1/channel` carries a reservation deadline until a
+//! user successfully joins it. these tests pin the orderings that decide
+//! whether expiry or room work wins, and the directory indexes an expiry is
+//! allowed to touch
+//!
+//! the deadline is a [`tokio::time::Instant`], so these tests move the clock
+//! explicitly instead of sleeping. they spawn no tasks, which keeps paused-time
+//! auto-advance from reaching any other timer
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::time::advance;
+
+use super::{
+    super::{
+        RoomAdmissionPolicy, RoomConfig, RoomRuntimePolicy,
+        directory::{RoomDirectory, RoomLifecycle},
+        factory::RoomFactory,
+    },
+    fixtures::{TEST_ROOM_KEY, test_client_rtp_capabilities},
+};
+use crate::{RuntimeFeatureFlags, engine::metrics::RuntimeMetrics};
+
+const TEST_RESERVATION_TTL: Duration = Duration::from_mins(1);
+
+/// moves the clock just past a freshly published reservation deadline
+///
+/// the extra millisecond keeps the assertion off the boundary, because
+/// [`advance`] may leave the clock exactly on the deadline
+async fn advance_past_reservation_deadline() {
+    advance(TEST_RESERVATION_TTL + Duration::from_millis(1)).await;
+}
+
+fn test_factory() -> RoomFactory {
+    RoomFactory::new(
+        RoomRuntimePolicy::new(
+            RoomAdmissionPolicy::new(2),
+            RuntimeFeatureFlags::default(),
+            test_client_rtp_capabilities(),
+        ),
+        Arc::new(RuntimeMetrics::default()),
+    )
+}
+
+#[tokio::test(start_paused = true)]
+async fn an_expired_reservation_is_claimed_once_and_is_terminal() {
+    let lifecycle = RoomLifecycle::new(TEST_RESERVATION_TTL);
+
+    drop(
+        lifecycle
+            .begin()
+            .expect("work should be accepted before the deadline"),
+    );
+    assert!(
+        !lifecycle.claim_expired_reservation(),
+        "an unexpired reservation must not be claimed"
+    );
+
+    advance_past_reservation_deadline().await;
+
+    // a room stays available until a reaper pass claims it, so a passed
+    // deadline on its own must not refuse work
+    drop(
+        lifecycle
+            .begin()
+            .expect("work arriving before the reaper should still be accepted"),
+    );
+    assert!(
+        lifecycle.claim_expired_reservation(),
+        "the first claim after the deadline should win directory removal"
+    );
+    assert!(
+        !lifecycle.claim_expired_reservation(),
+        "later reaper passes must not win again, so the room gauge drops once"
+    );
+    assert!(
+        lifecycle.begin().is_none(),
+        "a claimed reservation is terminal"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn work_that_leaves_the_room_empty_keeps_the_reservation() {
+    let lifecycle = RoomLifecycle::new(TEST_RESERVATION_TTL);
+    let lease = lifecycle
+        .begin()
+        .expect("a join that will fail is still accepted");
+
+    advance_past_reservation_deadline().await;
+    assert!(
+        !lease.finish(false, true),
+        "an empty room is not removed without a removal request"
+    );
+    assert!(
+        lifecycle.claim_expired_reservation(),
+        "only a successful join may retire the reservation"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn empty_room_removal_wins_over_a_later_expiry_claim() {
+    let lifecycle = RoomLifecycle::new(TEST_RESERVATION_TTL);
+    let lease = lifecycle
+        .begin()
+        .expect("last-user teardown should be accepted");
+
+    assert!(
+        lease.finish(true, true),
+        "the last-user finisher should win directory removal"
+    );
+
+    advance_past_reservation_deadline().await;
+    assert!(
+        !lifecycle.claim_expired_reservation(),
+        "expiry must not remove a room the last-user path already removed"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn stale_expiry_never_removes_a_newer_room_for_the_same_issuer() {
+    const ISSUER: &str = "issuer-stale-expiry";
+
+    let factory = test_factory();
+    let mut directory = RoomDirectory::default();
+    let stale = factory.create(ISSUER, TEST_ROOM_KEY, &RoomConfig::default());
+    directory.insert(Arc::clone(&stale), None, TEST_RESERVATION_TTL);
+
+    advance_past_reservation_deadline().await;
+    let stale_entry = directory
+        .entry(stale.uuid())
+        .expect("the first room should be a current row");
+    assert!(stale_entry.lifecycle.claim_expired_reservation());
+    directory.remove_if_current(stale.uuid(), &stale);
+
+    // a reaper pass keeps its cloned entries while `/v1/channel` republishes the
+    // issuer, so removal must be re-validated against the current row
+    let current = factory.create(ISSUER, TEST_ROOM_KEY, &RoomConfig::default());
+    directory.insert(Arc::clone(&current), None, TEST_RESERVATION_TTL);
+    assert_ne!(
+        stale.uuid(),
+        current.uuid(),
+        "a republished issuer should get a fresh uuid"
+    );
+
+    directory.remove_if_current(stale.uuid(), &stale);
+    directory.remove_if_current(current.uuid(), &stale);
+
+    assert_eq!(
+        directory
+            .entry_by_issuer(ISSUER)
+            .map(|entry| entry.room.uuid().to_owned())
+            .as_deref(),
+        Some(current.uuid()),
+        "a stale expiry must leave the issuer alias pointing at the current room"
+    );
+}

--- a/crates/core/src/engine/room/directory.rs
+++ b/crates/core/src/engine/room/directory.rs
@@ -6,9 +6,11 @@
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use tokio::time::Instant;
 
 use super::Room;
 use crate::engine::{RoomInstanceId, sync::lock_unpoisoned};
@@ -35,10 +37,10 @@ pub(crate) struct RoomDirectoryEntry {
 }
 
 impl RoomDirectoryEntry {
-    fn new(room: Arc<Room>, remote_address: Option<&str>) -> Self {
+    fn new(room: Arc<Room>, remote_address: Option<&str>, reservation_ttl: Duration) -> Self {
         Self {
             room,
-            lifecycle: RoomLifecycle::default(),
+            lifecycle: RoomLifecycle::new(reservation_ttl),
             create_date: rfc3339_now(),
             remote_address: remote_address.unwrap_or(UNKNOWN_REMOTE_ADDRESS).to_owned(),
         }
@@ -51,7 +53,7 @@ impl RoomDirectoryEntry {
 /// callers may hold a
 /// [`RoomLifecycleLease`] while awaiting, but this mutex is only held while a
 /// lease is accepted or released
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct RoomLifecycleState {
     /// accepted room work that has not finished or been dropped
     active_mutations: usize,
@@ -59,6 +61,22 @@ struct RoomLifecycleState {
     remove_when_idle: bool,
     /// terminal marker set once one finisher wins directory removal
     closing: bool,
+    /// reservation deadline, or `None` once a successful join retired it
+    expires_at: Option<Instant>,
+    /// lease length this reservation was published with and is renewed by
+    reservation_ttl: Duration,
+}
+
+impl RoomLifecycleState {
+    fn new(reservation_ttl: Duration) -> Self {
+        Self {
+            active_mutations: 0,
+            remove_when_idle: false,
+            closing: false,
+            expires_at: Some(Instant::now() + reservation_ttl),
+            reservation_ttl,
+        }
+    }
 }
 
 /// cloneable admission gate for the current room stored in one directory row
@@ -66,12 +84,49 @@ struct RoomLifecycleState {
 /// this type coordinates manager-level liveness only
 /// room membership ordering
 /// remains owned by [`Room`] and its state transition methods
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct RoomLifecycle {
     state: Arc<Mutex<RoomLifecycleState>>,
 }
 
 impl RoomLifecycle {
+    pub(crate) fn new(reservation_ttl: Duration) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(RoomLifecycleState::new(reservation_ttl))),
+        }
+    }
+
+    /// atomically claims cleanup responsibility for an expired, idle reservation.
+    pub(crate) fn claim_expired_reservation(&self) -> bool {
+        let mut state = lock_unpoisoned(&self.state);
+        let is_expired = state.expires_at.is_some_and(|t| Instant::now() >= t);
+        if !state.closing && state.active_mutations == 0 && is_expired {
+            state.closing = true;
+            drop(state);
+            return true;
+        }
+        false
+    }
+
+    /// extends a room reservation without rearming it
+    pub(crate) fn renew_reservation(&self) {
+        let mut state = lock_unpoisoned(&self.state);
+        if state.expires_at.is_some() {
+            state.expires_at = Some(Instant::now() + state.reservation_ttl);
+        }
+    }
+
+    #[cfg(any(test, feature = "testing-transport"))]
+    pub(crate) fn expire_reservation_now_for_test(&self) {
+        lock_unpoisoned(&self.state).expires_at = Some(Instant::now());
+    }
+
+    #[cfg(any(test, feature = "testing-transport"))]
+    #[must_use]
+    pub(crate) fn has_reservation_deadline_for_test(&self) -> bool {
+        lock_unpoisoned(&self.state).expires_at.is_some()
+    }
+
     /// accept a new current-room operation
     ///
     /// `None` means empty-room removal is pending or already won
@@ -151,6 +206,10 @@ impl RoomLifecycleLease {
         drop(state);
         should_remove
     }
+
+    pub(crate) fn clear_expiration(&self) {
+        lock_unpoisoned(&self.state).expires_at = None;
+    }
 }
 
 impl Drop for RoomLifecycleLease {
@@ -168,12 +227,6 @@ pub(crate) struct RoomDirectory {
 
 impl RoomDirectory {
     #[must_use]
-    pub(crate) fn get_by_issuer(&self, issuer: &str) -> Option<Arc<Room>> {
-        let uuid = self.uuid_by_issuer.get(issuer)?;
-        self.get_by_uuid(uuid)
-    }
-
-    #[must_use]
     pub(crate) fn get_by_uuid(&self, uuid: &str) -> Option<Arc<Room>> {
         self.by_uuid.get(uuid).map(|entry| Arc::clone(&entry.room))
     }
@@ -181,6 +234,12 @@ impl RoomDirectory {
     #[must_use]
     pub(crate) fn entry(&self, uuid: &str) -> Option<RoomDirectoryEntry> {
         self.by_uuid.get(uuid).cloned()
+    }
+
+    #[must_use]
+    pub(crate) fn entry_by_issuer(&self, issuer: &str) -> Option<RoomDirectoryEntry> {
+        let uuid = self.uuid_by_issuer.get(issuer)?;
+        self.entry(uuid)
     }
 
     #[must_use]
@@ -205,14 +264,21 @@ impl RoomDirectory {
             .collect()
     }
 
-    pub(crate) fn insert(&mut self, room: Arc<Room>, remote_address: Option<&str>) {
+    pub(crate) fn insert(
+        &mut self,
+        room: Arc<Room>,
+        remote_address: Option<&str>,
+        reservation_ttl: Duration,
+    ) {
         let room_id = room.uuid().to_owned();
         self.uuid_by_issuer
             .insert(room.issuer().to_owned(), room_id.clone());
         self.uuid_by_instance
             .insert(room.instance_id(), room_id.clone());
-        self.by_uuid
-            .insert(room_id, RoomDirectoryEntry::new(room, remote_address));
+        self.by_uuid.insert(
+            room_id,
+            RoomDirectoryEntry::new(room, remote_address, reservation_ttl),
+        );
     }
 
     #[must_use]

--- a/crates/core/src/engine/room/manager/TESTS/support.rs
+++ b/crates/core/src/engine/room/manager/TESTS/support.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use o_sfu_router::test_support::rtp_samples::sample_client_rtp_capabilities;
 
@@ -15,6 +15,7 @@ use crate::{
 };
 
 const DEFAULT_TEST_MAX_SESSIONS: usize = 100;
+const DEFAULT_TEST_RESERVATION_TTL: Duration = Duration::from_mins(1);
 
 impl RoomManager {
     #[must_use]
@@ -47,7 +48,48 @@ impl RoomManager {
 
     #[must_use]
     pub fn for_test_with_runtime_policy(runtime_policy: RoomRuntimePolicy) -> Self {
-        Self::new(runtime_policy, Arc::new(RuntimeMetrics::default()))
+        Self::for_test_with_runtime_policy_and_reservation_ttl(
+            runtime_policy,
+            DEFAULT_TEST_RESERVATION_TTL,
+        )
+    }
+
+    /// builds a manager whose new rooms expire after `reservation_ttl`
+    ///
+    /// [`Duration::ZERO`] publishes rooms that are already past their deadline,
+    /// which lets reservation tests exercise expiry without touching a clock
+    #[must_use]
+    pub fn for_test_with_reservation_ttl(reservation_ttl: Duration) -> Self {
+        Self::for_test_with_runtime_policy_and_reservation_ttl(
+            test_runtime_policy(RoomAdmissionPolicy::new(DEFAULT_TEST_MAX_SESSIONS)),
+            reservation_ttl,
+        )
+    }
+
+    #[must_use]
+    pub fn for_test_with_runtime_policy_and_reservation_ttl(
+        runtime_policy: RoomRuntimePolicy,
+        reservation_ttl: Duration,
+    ) -> Self {
+        Self::new(
+            runtime_policy,
+            Arc::new(RuntimeMetrics::default()),
+            reservation_ttl,
+        )
+    }
+
+    pub async fn expire_room_reservation_now_for_test(&self, room_id: &str) -> bool {
+        let Some(entry) = self.entry(room_id).await else {
+            return false;
+        };
+        entry.lifecycle.expire_reservation_now_for_test();
+        true
+    }
+
+    pub async fn has_room_reservation_deadline_for_test(&self, room_id: &str) -> bool {
+        self.entry(room_id)
+            .await
+            .is_some_and(|entry| entry.lifecycle.has_reservation_deadline_for_test())
     }
 
     #[cfg(any(test, feature = "testing-transport"))]

--- a/crates/core/src/engine/room/manager/mod.rs
+++ b/crates/core/src/engine/room/manager/mod.rs
@@ -14,7 +14,7 @@
 
 #[cfg(any(test, feature = "testing-transport"))]
 use std::sync::Mutex;
-use std::{collections::BTreeSet, future::Future, sync::Arc};
+use std::{collections::BTreeSet, future::Future, sync::Arc, time::Duration};
 
 use o_sfu_telemetry::schema::event as telemetry_event;
 use tokio::sync::RwLock;
@@ -89,6 +89,7 @@ pub struct RuntimeRoomDirectorySnapshot {
 pub struct RoomManager {
     directory: RwLock<RoomDirectory>,
     factory: RoomFactory,
+    reservation_ttl: Duration,
     #[cfg(any(test, feature = "testing-transport"))]
     join_placement_gate: Mutex<Option<Arc<JoinPlacementTestGate>>>,
 }
@@ -97,11 +98,16 @@ impl RoomManager {
     /// builds a room manager with an empty directory
     ///
     #[must_use]
-    pub fn new(runtime_policy: RoomRuntimePolicy, metrics: Arc<RuntimeMetrics>) -> Self {
+    pub fn new(
+        runtime_policy: RoomRuntimePolicy,
+        metrics: Arc<RuntimeMetrics>,
+        reservation_ttl: Duration,
+    ) -> Self {
         let factory = RoomFactory::new(runtime_policy, metrics);
         Self {
             directory: RwLock::new(RoomDirectory::default()),
             factory,
+            reservation_ttl,
             #[cfg(any(test, feature = "testing-transport"))]
             join_placement_gate: Mutex::new(None),
         }
@@ -121,16 +127,18 @@ impl RoomManager {
     ) -> Arc<Room> {
         {
             let directory = self.directory.read().await;
-            if let Some(room) = directory.get_by_issuer(issuer) {
-                return room;
+            if let Some(entry) = directory.entry_by_issuer(issuer) {
+                entry.lifecycle.renew_reservation();
+                return entry.room;
             }
         }
         let mut directory = self.directory.write().await;
-        if let Some(room) = directory.get_by_issuer(issuer) {
-            return room;
+        if let Some(entry) = directory.entry_by_issuer(issuer) {
+            entry.lifecycle.renew_reservation();
+            return entry.room;
         }
         let room = self.factory.create(issuer, key, config);
-        directory.insert(Arc::clone(&room), remote_address);
+        directory.insert(Arc::clone(&room), remote_address, self.reservation_ttl);
         drop(directory);
         info!(
             event = telemetry_event::ROOM_CREATED,
@@ -258,27 +266,34 @@ impl RoomManager {
         request: JoinUserRequest,
         media_transport: &MediaTransport,
     ) -> Result<RoomUserAdmission, RoomManagerJoinError> {
-        let Some((room, join_result)) = self
-            .run_current_room_mutation(
-                room_id,
-                |room| async move {
-                    let admission =
-                        JoinAdmissionTurn::from_factory(request, media_transport, &self.factory);
-                    #[cfg(any(test, feature = "testing-transport"))]
-                    let admission = admission.with_gate(self.join_placement_gate_for_test());
-                    room.admit_session(admission, RoomEffectContext::runtime(media_transport))
-                        .await
-                },
-                false,
-            )
+        let mutation = self
+            .begin_current_room_mutation(room_id)
             .await
-        else {
-            return Err(RoomManagerJoinError::MissingRoom);
+            .ok_or(RoomManagerJoinError::MissingRoom)?;
+        let room = Arc::clone(&mutation.room);
+
+        let admission = JoinAdmissionTurn::from_factory(request, media_transport, &self.factory);
+        #[cfg(any(test, feature = "testing-transport"))]
+        let admission = admission.with_gate(self.join_placement_gate_for_test());
+        let join_commit = match room
+            .commit_admission(admission, RoomEffectContext::runtime(media_transport))
+            .await
+        {
+            Ok(commit) => commit,
+            Err(err) => {
+                self.finish_session_mutation(room_id, mutation, false).await;
+                return Err(match err {
+                    RoomJoinError::RoomFull => RoomManagerJoinError::RoomFull,
+                    RoomJoinError::RouterState => RoomManagerJoinError::RouterState,
+                });
+            }
         };
-        let receipt = join_result.map_err(|error| match error {
-            RoomJoinError::RoomFull => RoomManagerJoinError::RoomFull,
-            RoomJoinError::RouterState => RoomManagerJoinError::RouterState,
-        })?;
+        mutation.lease.clear_expiration();
+        let receipt = room
+            .finalize_admission(join_commit, RoomEffectContext::runtime(media_transport))
+            .await;
+
+        self.finish_session_mutation(room_id, mutation, false).await;
         Ok(RoomUserAdmission {
             room,
             connection_id: receipt.connection_id,
@@ -333,6 +348,21 @@ impl RoomManager {
                 true,
             )
             .await;
+    }
+
+    pub async fn check_expired_room_reservations(&self) {
+        let mut directory = self.directory.write().await;
+        for entry in directory.entries() {
+            if entry.lifecycle.claim_expired_reservation() {
+                directory.remove_if_current(entry.room.uuid(), &entry.room);
+                info!(
+                    event = telemetry_event::ROOM_RESERVATION_EXPIRED,
+                    room_id = entry.room.uuid(),
+                    "room reservation expired"
+                );
+            }
+        }
+        drop(directory);
     }
 
     #[cfg(test)]

--- a/crates/core/src/engine/room/membership.rs
+++ b/crates/core/src/engine/room/membership.rs
@@ -1,6 +1,6 @@
 //! Membership mutations return commits before running their effects.
 //!
-//! [`JoinCommit`](crate::engine::room::state::JoinCommit),
+//! [`JoinCommit`],
 //! [`ConnectionCloseCommit`] and
 //! [`DisconnectCommit`](crate::engine::room::state::DisconnectCommit) are produced
 //! while the `room.state` write guard is held. Each carries the transition outcome
@@ -44,7 +44,8 @@ use super::{
     state::ConnectionCloseCommit,
 };
 use crate::engine::{
-    ConnectionId, MediaWorkerId, UserId, UserInfo, UserPermissions, media_transport::MediaTransport,
+    ConnectionId, MediaWorkerId, UserId, UserInfo, UserPermissions,
+    media_transport::MediaTransport, room::state::JoinCommit,
 };
 
 /// Room-state marker that collapses every authenticated [`UserPermissions`] value.
@@ -74,23 +75,31 @@ pub struct JoinUserRequest {
 }
 
 impl Room {
-    /// Executes context-enabled [`RoomEffects`] before returning the committed receipt.
+    /// Commits the admission turn with the room router.
     ///
     /// # Errors
     ///
     /// Returns [`RoomJoinError::RoomFull`] when a new user exceeds capacity.
     /// Returns [`RoomJoinError::RouterState`] when placement cannot commit.
+    pub(super) async fn commit_admission(
+        &self,
+        admission: JoinAdmissionTurn<'_, impl FnOnce() -> o_sfu_router::RouterId>,
+        context: RoomEffectContext<'_>,
+    ) -> Result<JoinCommit, RoomJoinError> {
+        let joined_fanout = context.user_joined_fanout();
+        admission.commit(self, joined_fanout).await
+    }
+
+    /// Executes context-enabled [`RoomEffects`] before returning the committed receipt
     ///
     /// # Panics
     ///
     /// Panics when existing relay state refers to an uncommitted source placement.
-    pub(super) async fn admit_session(
+    pub(super) async fn finalize_admission(
         &self,
-        admission: JoinAdmissionTurn<'_, impl FnOnce() -> o_sfu_router::RouterId>,
+        commit: JoinCommit,
         context: RoomEffectContext<'_>,
-    ) -> Result<CommittedTransportReceipt, RoomJoinError> {
-        let joined_fanout = context.user_joined_fanout();
-        let commit = admission.commit(self, joined_fanout).await?;
+    ) -> CommittedTransportReceipt {
         let receipt = commit.receipt.clone();
         RoomEffects::from_join(commit).execute(self, context).await;
         let session = &receipt.transport_session_key;
@@ -102,7 +111,7 @@ impl Room {
             media_worker_id = session.media_worker_id().as_usize(),
             "user joined room"
         );
-        Ok(receipt)
+        receipt
     }
 
     /// Returns `true` only when `connection_id` removed the current room user.

--- a/crates/telemetry/src/schema.rs
+++ b/crates/telemetry/src/schema.rs
@@ -11,6 +11,7 @@ pub mod event {
     pub const RUNTIME_BOOT: &str = "runtime.boot";
     pub const RUNTIME_TELEMETRY_INITIALIZED: &str = "runtime.telemetry_initialized";
     pub const ROOM_CREATED: &str = "room.created";
+    pub const ROOM_RESERVATION_EXPIRED: &str = "room.reservation.expired";
     pub const USER_JOINED: &str = "user.joined";
     pub const USER_CLOSED: &str = "user.closed";
     pub const USER_DISCONNECTED: &str = "user.disconnected";

--- a/src/config/TESTS/env.rs
+++ b/src/config/TESTS/env.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::{Env, EnvKey, non_empty, positive};
 
 fn error<T>(result: anyhow::Result<T>) -> Option<String> {
@@ -10,6 +12,7 @@ fn env_loads_required_default_optional_check_and_trimmed_values() {
         "REQUIRED_ENV" => Some("value".to_owned()),
         "COUNT_ENV" => Some("4".to_owned()),
         "TOKEN_ENV" => Some("  token  ".to_owned()),
+        "DURATION_ENV" => Some("90".to_owned()),
         _ => None,
     });
 
@@ -26,6 +29,17 @@ fn env_loads_required_default_optional_check_and_trimmed_values() {
         env.var("TOKEN_ENV").check(non_empty).optional().ok(),
         Some(Some("token".to_owned()))
     );
+    assert_eq!(
+        env.var("DURATION_ENV").default(Duration::from_mins(1)).ok(),
+        Some(Duration::from_secs(90)),
+        "durations are read as whole seconds"
+    );
+    assert_eq!(
+        env.var("MISSING_DURATION_ENV")
+            .default(Duration::from_mins(1))
+            .ok(),
+        Some(Duration::from_mins(1))
+    );
     assert_eq!(env.var::<String>("MISSING_ENV").optional().ok(), Some(None));
 }
 
@@ -36,6 +50,7 @@ fn env_reports_parse_and_validation_errors() {
         "COUNT_ENV" => Some("abc".to_owned()),
         "ZERO_ENV" => Some("0".to_owned()),
         "TOKEN_ENV" => Some("   ".to_owned()),
+        "DURATION_ENV" => Some("-42".to_owned()),
         _ => None,
     });
 
@@ -58,6 +73,10 @@ fn env_reports_parse_and_validation_errors() {
     assert_eq!(
         error(env.var("TOKEN_ENV").check(non_empty).optional()).as_deref(),
         Some("TOKEN_ENV must not be empty")
+    );
+    assert_eq!(
+        error(env.var::<Duration>("DURATION_ENV").optional()).as_deref(),
+        Some("DURATION_ENV must be a valid duration in seconds")
     );
 }
 

--- a/src/config/TESTS/loader.rs
+++ b/src/config/TESTS/loader.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use base64::{
     Engine as _,
     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
@@ -93,6 +95,7 @@ fn config_uses_defaults_and_explicit_values() -> anyhow::Result<()> {
         config.user.outbound_queue_byte_capacity,
         DEFAULT_USER_OUTBOUND_QUEUE_BYTE_CAPACITY
     );
+    assert_eq!(config.user.room_reservation_ttl, Duration::from_mins(1));
     assert!(!config.http.trust_proxy_headers);
     assert_eq!(config.features, RuntimeFeatureFlags::default());
     assert_eq!(config.codecs.flags, MediaCodecFlags::default());
@@ -137,6 +140,7 @@ fn config_accepts_explicit_http_auth_and_user_settings() -> anyhow::Result<()> {
         ("PING_INTERVAL_MS", "1000"),
         ("USER_OUTBOUND_QUEUE_CAPACITY", "16"),
         ("USER_OUTBOUND_QUEUE_BYTE_CAPACITY", "8192"),
+        ("ROOM_RESERVATION_TTL", "120"),
     ])?;
     assert_eq!(config.http.bind_address.to_string(), "127.0.0.1:9000");
     assert_eq!(config.http.shutdown_timeout_ms, 2500);
@@ -148,6 +152,7 @@ fn config_accepts_explicit_http_auth_and_user_settings() -> anyhow::Result<()> {
     assert_eq!(config.user.ping_interval_ms, 1000);
     assert_eq!(config.user.outbound_queue_capacity, 16);
     assert_eq!(config.user.outbound_queue_byte_capacity, 8192);
+    assert_eq!(config.user.room_reservation_ttl, Duration::from_mins(2));
     Ok(())
 }
 

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt,
     net::{IpAddr, SocketAddr},
+    time::Duration,
 };
 
 use anyhow::{Context, Result, anyhow, ensure};
@@ -169,6 +170,17 @@ impl EnvParse for bool {
 impl EnvParse for String {
     fn parse(value: EnvValue) -> Result<Self> {
         Ok(value.into_raw())
+    }
+}
+
+impl EnvParse for Duration {
+    fn parse(value: EnvValue) -> Result<Self> {
+        let key = value.key();
+        let seconds = value
+            .into_raw()
+            .parse()
+            .map_err(|_error| anyhow!("{key} must be a valid duration in seconds"))?;
+        Ok(Self::from_secs(seconds))
     }
 }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,4 +1,7 @@
-use std::net::{IpAddr, SocketAddr};
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 
 use o_sfu_core::prelude::Bitrate;
 
@@ -47,6 +50,7 @@ pub struct UserConfig {
     pub ping_interval_ms: u64,
     pub outbound_queue_capacity: usize,
     pub outbound_queue_byte_capacity: usize,
+    pub room_reservation_ttl: Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 
 use super::{
@@ -25,6 +27,9 @@ impl UserConfig {
                 .var("USER_OUTBOUND_QUEUE_BYTE_CAPACITY")
                 .check(positive)
                 .default(DEFAULT_USER_OUTBOUND_QUEUE_BYTE_CAPACITY)?,
+            room_reservation_ttl: env
+                .var("ROOM_RESERVATION_TTL")
+                .default(Duration::from_mins(1))?,
         })
     }
 }

--- a/src/runtime/TESTS/runtime.rs
+++ b/src/runtime/TESTS/runtime.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+use o_sfu_core::server::room::RoomConfig;
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::oneshot,
@@ -21,8 +22,10 @@ use tokio_util::{sync::CancellationToken, task::task_tracker::TaskTrackerToken};
 
 use super::{
     AnyResult, RoomManager, RoomPacketSinkRegistry, Runtime, RuntimeServices, ServeError,
-    serve_http_on, test_support::RuntimeTestBuilder,
+    serve_http_on,
+    test_support::{RuntimeTestBuilder, TEST_ROOM_KEY},
 };
+use crate::runtime::metrics::RoomGaugeValues;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -175,4 +178,44 @@ async fn wait_for_room_manager_drop(rooms: &Weak<RoomManager>) {
     while rooms.upgrade().is_some() {
         sleep(Duration::from_millis(1)).await;
     }
+}
+
+/// reservation window that the wait below clears with room for a reaper tick
+///
+/// reservation orderings are pinned in the room-engine tests. this layer only
+/// owns the wiring: the configured window reaches the manager, and the spawned
+/// reaper keeps ticking
+const RESERVATION_TTL: Duration = Duration::from_secs(30);
+
+#[tokio::test(start_paused = true)]
+async fn expired_room_reservation_is_reaped() -> AnyResult<()> {
+    let builder = RuntimeTestBuilder::new().room_reservation_ttl(RESERVATION_TTL);
+    let runtime = Runtime::new(builder.config())?;
+    let rooms = Arc::clone(&runtime.room_manager);
+    tokio::spawn(runtime.serve(
+        |_state, _listener_shutdown| pending::<io::Result<()>>(),
+        pending::<io::Result<()>>(),
+    ));
+    let config = RoomConfig::default();
+
+    let room = rooms
+        .serve_room("issuer", TEST_ROOM_KEY, &config, None)
+        .await;
+    sleep(RESERVATION_TTL * 2).await;
+
+    assert!(
+        rooms.get_by_uuid(room.uuid()).await.is_none(),
+        "the reaper task should remove the expired directory row"
+    );
+    assert_eq!(rooms.room_gauges().await, RoomGaugeValues::default());
+    let room_again = rooms
+        .serve_room("issuer", TEST_ROOM_KEY, &config, None)
+        .await;
+
+    assert_ne!(
+        room.uuid(),
+        room_again.uuid(),
+        "new room request from same issuer after reservation expiration gives new uuid"
+    );
+    Ok(())
 }

--- a/src/runtime/TESTS/support.rs
+++ b/src/runtime/TESTS/support.rs
@@ -1,6 +1,7 @@
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
+    time::Duration,
 };
 
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -58,6 +59,7 @@ impl RuntimeTestBuilder {
                     ping_interval_ms: 60_000,
                     outbound_queue_capacity: DEFAULT_USER_OUTBOUND_QUEUE_CAPACITY,
                     outbound_queue_byte_capacity: DEFAULT_USER_OUTBOUND_QUEUE_BYTE_CAPACITY,
+                    room_reservation_ttl: Duration::from_secs(5),
                 },
                 transport: TransportConfig {
                     announced_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -106,6 +108,11 @@ impl RuntimeTestBuilder {
         self
     }
 
+    pub(super) fn room_reservation_ttl(mut self, value: Duration) -> Self {
+        self.config.user.room_reservation_ttl = value;
+        self
+    }
+
     pub(super) fn pre_auth_capacity(mut self, total: usize, per_origin: usize) -> Self {
         self.config.auth.max_pre_auth_websocket_sessions = total;
         self.config.auth.max_pre_auth_websocket_sessions_per_origin = per_origin;
@@ -135,6 +142,7 @@ impl RuntimeTestBuilder {
         let room_manager = build_room_manager(
             build_room_runtime_policy(&self.config, &media_transport),
             &services,
+            self.config.user.room_reservation_ttl,
         );
         let runtime_config = RuntimeConfig::from_config(&self.config);
         let state = RuntimeState::from_parts(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,7 +8,13 @@ use anyhow::Result as AnyResult;
 use thiserror::Error;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
-use tokio::{net::TcpListener, runtime::Builder, signal::ctrl_c, task::JoinHandle, time::sleep};
+use tokio::{
+    net::TcpListener,
+    runtime::Builder,
+    signal::ctrl_c,
+    task::JoinHandle,
+    time::{MissedTickBehavior, interval, sleep},
+};
 use tokio_util::{
     sync::CancellationToken,
     task::{AbortOnDropHandle, TaskTracker},
@@ -113,7 +119,11 @@ impl Runtime {
             rtc_udp_io_backend = config.transport.rtc_udp_io_backend.wire_name(),
             "runtime configuration loaded"
         );
-        let room_manager = build_room_manager(room_runtime_policy, &services);
+        let room_manager = build_room_manager(
+            room_runtime_policy,
+            &services,
+            config.user.room_reservation_ttl,
+        );
         Ok(Self {
             config: runtime_config,
             room_manager,
@@ -204,6 +214,7 @@ struct RuntimeTasks {
     session_shutdown: CancellationToken,
     session_tasks: TaskTracker,
     source_packet_policy_sync: AbortOnDropHandle<()>,
+    rooms_reservations_reaper: AbortOnDropHandle<()>,
     media_transport: MediaTransport,
 }
 
@@ -211,15 +222,18 @@ impl RuntimeTasks {
     fn spawn(room_manager: Arc<RoomManager>, media_transport: MediaTransport) -> Self {
         let shutdown_token = CancellationToken::new();
         let source_packet_policy_sync = spawn_source_packet_policy_update_task(
-            room_manager,
+            Arc::clone(&room_manager),
             media_transport.clone(),
             shutdown_token.child_token(),
         );
+        let rooms_reservations_reaper =
+            spawn_room_reservation_expiration_reaper(room_manager, shutdown_token.child_token());
         Self {
             session_shutdown: shutdown_token.child_token(),
             shutdown_token,
             session_tasks: TaskTracker::new(),
             source_packet_policy_sync: AbortOnDropHandle::new(source_packet_policy_sync),
+            rooms_reservations_reaper: AbortOnDropHandle::new(rooms_reservations_reaper),
             media_transport,
         }
     }
@@ -235,6 +249,15 @@ impl RuntimeTasks {
             warn!(
                 ?error,
                 task = "source packet policy update",
+                "runtime background task stopped unexpectedly"
+            );
+        }
+        if let Err(error) = (&mut self.rooms_reservations_reaper).await
+            && !error.is_cancelled()
+        {
+            warn!(
+                ?error,
+                task = "rooms reservation reaper",
                 "runtime background task stopped unexpectedly"
             );
         }
@@ -315,6 +338,25 @@ fn spawn_source_packet_policy_update_task(
     })
 }
 
+fn spawn_room_reservation_expiration_reaper(
+    rooms: Arc<RoomManager>,
+    shutdown_token: CancellationToken,
+) -> JoinHandle<()> {
+    info!("booted room reservation expiration reaper");
+    tokio::spawn(async move {
+        let mut interval = interval(Duration::from_secs(10));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                biased;
+                () = shutdown_token.cancelled() => return,
+                _ = interval.tick() => {},
+            };
+            rooms.check_expired_room_reservations().await;
+        }
+    })
+}
+
 fn build_media_transport(config: &Config, services: &RuntimeServices) -> AnyResult<MediaTransport> {
     Ok(MediaTransport::build(
         MediaTransportConfig {
@@ -355,10 +397,12 @@ fn build_room_runtime_policy(
 fn build_room_manager(
     runtime_policy: RoomRuntimePolicy,
     services: &RuntimeServices,
+    reservation_ttl: Duration,
 ) -> Arc<RoomManager> {
     Arc::new(RoomManager::new(
         runtime_policy,
         Arc::clone(&services.metrics),
+        reservation_ttl,
     ))
 }
 

--- a/tests/src/support/harness.rs
+++ b/tests/src/support/harness.rs
@@ -424,6 +424,8 @@ pub fn test_config(authentication_timeout_ms: u64, room_size: usize) -> Config {
             ping_interval_ms: 60_000,
             outbound_queue_capacity: DEFAULT_USER_OUTBOUND_QUEUE_CAPACITY,
             outbound_queue_byte_capacity: DEFAULT_USER_OUTBOUND_QUEUE_BYTE_CAPACITY,
+            // this window must stay open far longer than the slowest room-create-to-first-join path
+            room_reservation_ttl: Duration::from_hours(1),
         },
         transport: TransportConfig {
             announced_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),


### PR DESCRIPTION
Before this commit, a room that nobody joins remains registered until the process restarts.

This commit improves the behavior by removing rooms that have never been joined in a configurable reservation window.

issue https://github.com/ThanhDodeurOdoo/o-sfu/issues/568

#### Guidelines
<!-- You must check both -->
- [x] I read [CONTRIBUTING.md](https://github.com/ThanhDodeurOdoo/o-sfu/blob/master/.github/CONTRIBUTING.md)
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

AI used to understand the codebase, Rust concepts, write tests and used to suggest more elegant versions of hand-written code.
