### PR TITLE
[IMP] runtime: support keySeed claim in JWT on /v1/channel endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,17 @@
 //!   the HTTP [`http::CreateRoomQuery`] path through [`auth::HttpRoomClaims`] and
 //!   [`auth::HttpDisconnectClaims`]. See [`config`].
 //! - **Per-room key**: the request that creates the current room pins the signing
-//!   key from the `key` claim in [`auth::HttpRoomClaims`]. WebSocket
-//!   [`auth::WebSocketConnectClaims`] verify against that room key, never against
-//!   `AUTH_KEY`.
+//!   key from the `key` or `keySeed` claim in [`auth::HttpRoomClaims`]. For more
+//!   security, prefer the `keySeed` claim, which derives a per-room key with the
+//!   `AUTH_KEY` and provided seed using the following KDF:
+//!   ```text
+//!   room_key = Base64StdPad(HMAC-SHA256(
+//!                  key = Base64Decode(AUTH_KEY),
+//!                  message = Base64Decode(keySeed)
+//!              ))
+//!   ```
+//!   WebSocket [`auth::WebSocketConnectClaims`] verify against that room key,
+//!   never against `AUTH_KEY`.
 //!
 //! Token carriage differs per surface: HTTP room creation uses the
 //! `Authorization` header, HTTP disconnect uses the request body and the

--- a/src/runtime/TESTS/auth.rs
+++ b/src/runtime/TESTS/auth.rs
@@ -8,8 +8,8 @@ use serde_json::json;
 
 use super::{
     AuthenticationError, HttpDisconnectClaims, HttpRoomClaims, MAX_JWT_TOKEN_BYTES,
-    RegisteredJwtClaims, WebSocketConnectClaims, decode_key, duration_since_epoch, sign,
-    sign_hs256, validate_registered_claims_at, verify,
+    RegisteredJwtClaims, WebSocketConnectClaims, decode_key, derive_key_from_seed,
+    duration_since_epoch, sign, sign_hs256, validate_registered_claims_at, verify,
 };
 
 const TEST_AUTH_KEY: &str = "u6bsUQEWrHdKIuYplirRnbBmLbrKV5PxKG7DtA71mng=";
@@ -27,6 +27,7 @@ fn jwt_claims_round_trip() -> serde_json::Result<()> {
             ..RegisteredJwtClaims::default()
         },
         key: Some("Y2hhbm5lbC1rZXk=".to_owned()),
+        key_seed: None,
     };
     let expected_room_claims = json!({
         "iss": "https://odoo.example.com",
@@ -123,6 +124,7 @@ fn sign_and_verify_round_trip() {
             ..RegisteredJwtClaims::default()
         },
         key: Some("Y2hhbm5lbC1rZXk=".to_owned()),
+        key_seed: None,
     };
     let token = sign(&claims, TEST_AUTH_KEY);
     assert!(token.is_ok());
@@ -145,6 +147,7 @@ fn sign_and_verify_round_trip_with_uuid_like_channel_key() {
             ..RegisteredJwtClaims::default()
         },
         key: Some("123e4567-e89b-12d3-a456-426614174000".to_owned()),
+        key_seed: None,
     };
     let token = sign(&claims, "123e4567-e89b-12d3-a456-426614174000");
     assert!(token.is_ok());
@@ -180,6 +183,7 @@ fn verify_rejects_expired_token() {
             ..RegisteredJwtClaims::default()
         },
         key: None,
+        key_seed: None,
     };
     let token = sign(&claims, TEST_AUTH_KEY);
     assert!(token.is_ok());
@@ -203,6 +207,7 @@ fn verify_rejects_token_when_exp_matches_current_second() {
             ..RegisteredJwtClaims::default()
         },
         key: None,
+        key_seed: None,
     };
     let token = sign(&claims, TEST_AUTH_KEY);
     assert!(token.is_ok());
@@ -263,6 +268,7 @@ fn sign_emits_jose_base64url_segments() {
     let claims = HttpRoomClaims {
         registered: RegisteredJwtClaims::default(),
         key: Some("Y2hhbm5lbC1rZXk=".to_owned()),
+        key_seed: None,
     };
 
     let token = sign(&claims, TEST_AUTH_KEY);
@@ -284,6 +290,7 @@ fn verify_accepts_jose_base64url_token_without_typ_header() {
     let claims = HttpRoomClaims {
         registered: RegisteredJwtClaims::default(),
         key: Some("Y2hhbm5lbC1rZXk=".to_owned()),
+        key_seed: None,
     };
 
     let token = sign_token_for_test(&claims, TEST_AUTH_KEY, None, SegmentEncoding::Jose);
@@ -301,6 +308,7 @@ fn verify_accepts_jose_base64url_token_with_typ_header() {
     let claims = HttpRoomClaims {
         registered: RegisteredJwtClaims::default(),
         key: Some("Y2hhbm5lbC1rZXk=".to_owned()),
+        key_seed: None,
     };
 
     let token = sign_token_for_test(&claims, TEST_AUTH_KEY, Some("JWT"), SegmentEncoding::Jose);
@@ -348,6 +356,7 @@ fn verify_does_not_parse_claims_before_signature_verification() {
     let claims = HttpRoomClaims {
         registered: RegisteredJwtClaims::default(),
         key: None,
+        key_seed: None,
     };
     let token = sign(&claims, TEST_AUTH_KEY);
     assert!(token.is_ok());
@@ -438,6 +447,7 @@ fn sign_uses_rfc_header_constants() {
     let claims = HttpRoomClaims {
         registered: RegisteredJwtClaims::default(),
         key: None,
+        key_seed: None,
     };
 
     let token = sign_token_for_test(
@@ -452,4 +462,43 @@ fn sign_uses_rfc_header_constants() {
     };
     let verified = verify::<HttpRoomClaims>(&token, TEST_AUTH_KEY);
     assert_eq!(verified.ok(), Some(claims));
+}
+
+#[test]
+fn derive_key_from_seed_produces_deterministic_key() {
+    let key_b64 = TEST_AUTH_KEY;
+    let seed = "Y2hhbm5lbC1rZXk=";
+    let derived_key = derive_key_from_seed(key_b64, seed).ok();
+    assert!(derived_key.is_some());
+    let Some(derived_key) = derived_key else {
+        return;
+    };
+    assert_ne!(derived_key, key_b64);
+    let derived_key_again = derive_key_from_seed(key_b64, seed).ok();
+    assert_eq!(derived_key_again, Some(derived_key));
+}
+
+#[test]
+fn derive_key_from_seed_works_with_unpadded_seed() {
+    let key_b64 = TEST_AUTH_KEY;
+    let seed = "Y2hhbm5lbC1rZXk=";
+    let seed_unpadded = seed.trim_end_matches('=');
+    let derived_key = derive_key_from_seed(key_b64, seed_unpadded).ok();
+    assert!(derived_key.is_some());
+    let Some(derived_key) = derived_key else {
+        return;
+    };
+    let derived_key_padded = derive_key_from_seed(key_b64, seed).ok();
+    assert_eq!(derived_key_padded, Some(derived_key));
+}
+
+#[test]
+fn derive_key_from_seed_rejects_invalid_base64() {
+    let key_b64 = TEST_AUTH_KEY;
+    let invalid_seed = "invalid-base64!";
+    let derived_key = derive_key_from_seed(key_b64, invalid_seed).err();
+    assert_eq!(
+        derived_key,
+        Some(AuthenticationError::InvalidBase64Encoding)
+    );
 }

--- a/src/runtime/auth.rs
+++ b/src/runtime/auth.rs
@@ -57,6 +57,8 @@ pub struct HttpRoomClaims {
     pub registered: RegisteredJwtClaims,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename = "keySeed", skip_serializing_if = "Option::is_none")]
+    pub key_seed: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -263,6 +265,13 @@ fn pad_base64(input: &str) -> String {
         return input.to_owned();
     }
     format!("{input}{}", "=".repeat(4 - remainder))
+}
+
+pub(crate) fn derive_key_from_seed(key: &str, seed: &str) -> Result<String, AuthenticationError> {
+    let key_bytes = decode_key(key)?;
+    let seed_bytes = decode_key(seed)?;
+    let derived_key = sign_hs256(&seed_bytes, &key_bytes)?;
+    Ok(STANDARD.encode(derived_key))
 }
 
 #[cfg(test)]

--- a/src/runtime/http_server/TESTS/fixtures.rs
+++ b/src/runtime/http_server/TESTS/fixtures.rs
@@ -49,7 +49,11 @@ pub(super) fn test_state_with_handles() -> RuntimeTestState {
     RuntimeTestBuilder::new().build_state()
 }
 
-pub(super) fn signed_room_claims(issuer: Option<&str>, key: Option<&str>) -> Option<String> {
+pub(super) fn signed_room_claims(
+    issuer: Option<&str>,
+    key: Option<&str>,
+    key_seed: Option<&str>,
+) -> Option<String> {
     auth::sign(
         &HttpRoomClaims {
             registered: RegisteredJwtClaims {
@@ -57,6 +61,7 @@ pub(super) fn signed_room_claims(issuer: Option<&str>, key: Option<&str>) -> Opt
                 ..RegisteredJwtClaims::default()
             },
             key: key.map(str::to_owned),
+            key_seed: key_seed.map(str::to_owned),
         },
         TEST_AUTH_KEY,
     )

--- a/src/runtime/http_server/TESTS/room_route_tests.rs
+++ b/src/runtime/http_server/TESTS/room_route_tests.rs
@@ -4,8 +4,15 @@ use axum::extract::ConnectInfo;
 
 use super::fixtures::*;
 
-fn room_token(issuer: Option<&str>, key: Option<&str>) -> TestResult<String> {
-    require_some(signed_room_claims(issuer, key), "room JWT should sign")
+fn room_token(
+    issuer: Option<&str>,
+    key: Option<&str>,
+    key_seed: Option<&str>,
+) -> TestResult<String> {
+    require_some(
+        signed_room_claims(issuer, key, key_seed),
+        "room JWT should sign",
+    )
 }
 
 fn room_builder(token: &str, scheme: &str) -> HttpRequestBuilder {
@@ -53,13 +60,13 @@ async fn room_requires_authorization_header() -> TestResult {
 
 #[tokio::test]
 async fn room_rejects_unknown_authorization_scheme() -> TestResult {
-    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY))?;
+    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY), None)?;
     assert_room_status(room_builder(&token, "Basic"), StatusCode::UNAUTHORIZED).await
 }
 
 #[tokio::test]
 async fn room_accepts_legacy_jwt_authorization_scheme() -> TestResult {
-    let token = room_token(Some("issuer-a"), Some("Y2hhbm5lbC1rZXk="))?;
+    let token = room_token(Some("issuer-a"), Some("Y2hhbm5lbC1rZXk="), None)?;
     assert_room_status(room_builder(&token, "jwt"), StatusCode::OK).await
 }
 
@@ -71,19 +78,37 @@ async fn room_rejects_oversized_authorization_token() -> TestResult {
 
 #[tokio::test]
 async fn room_requires_issuer_claim() -> TestResult {
-    let token = room_token(None, None)?;
+    let token = room_token(None, None, None)?;
     assert_room_status(room_builder(&token, "Bearer"), StatusCode::FORBIDDEN).await
 }
 
 #[tokio::test]
 async fn room_rejects_missing_key() -> TestResult {
-    let token = room_token(Some("issuer-a"), None)?;
+    let token = room_token(Some("issuer-a"), None, None)?;
+    assert_room_status(room_builder(&token, "Bearer"), StatusCode::BAD_REQUEST).await
+}
+
+#[tokio::test]
+async fn room_rejects_empty_seed_with_key() -> TestResult {
+    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY), Some(""))?;
+    assert_room_status(room_builder(&token, "Bearer"), StatusCode::BAD_REQUEST).await
+}
+
+#[tokio::test]
+async fn room_rejects_invalid_seed() -> TestResult {
+    let token = room_token(Some("issuer-a"), None, Some("invalid-seed!"))?;
+    assert_room_status(room_builder(&token, "Bearer"), StatusCode::BAD_REQUEST).await
+}
+
+#[tokio::test]
+async fn room_rejects_malformed_seed_with_key() -> TestResult {
+    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY), Some("invalid-seed!"))?;
     assert_room_status(room_builder(&token, "Bearer"), StatusCode::BAD_REQUEST).await
 }
 
 #[tokio::test]
 async fn room_returns_uuid_and_request_base_url() -> TestResult {
-    let token = room_token(Some("issuer-a"), Some("Y2hhbm5lbC1rZXk="))?;
+    let token = room_token(Some("issuer-a"), Some("Y2hhbm5lbC1rZXk="), None)?;
     let payload: RoomResponse = route_json(
         &test_state(),
         room_builder(&token, "Bearer"),
@@ -99,7 +124,7 @@ async fn room_returns_uuid_and_request_base_url() -> TestResult {
 
 #[tokio::test]
 async fn room_route_persists_query_config() -> TestResult {
-    let token = room_token(Some("issuer-route-config"), Some(TEST_ROOM_KEY))?;
+    let token = room_token(Some("issuer-route-config"), Some(TEST_ROOM_KEY), None)?;
     let test_state = test_state_with_handles();
     let recording_address = "https://record.example.com/hook";
     let payload: RoomResponse = route_json(
@@ -143,7 +168,7 @@ async fn room_route_persists_query_config() -> TestResult {
 
 #[tokio::test]
 async fn room_ignores_forwarded_headers_when_proxy_trust_is_disabled() -> TestResult {
-    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY))?;
+    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY), None)?;
     let state = test_state();
     let payload: RoomResponse = route_json(
         &state,
@@ -167,7 +192,7 @@ async fn room_ignores_forwarded_headers_when_proxy_trust_is_disabled() -> TestRe
 
 #[tokio::test]
 async fn room_uses_forwarded_headers_when_proxy_trust_is_enabled() -> TestResult {
-    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY))?;
+    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY), None)?;
     let mut state = test_state();
     state.config.http.trust_proxy_headers = true;
     let payload: RoomResponse = route_json(
@@ -201,7 +226,7 @@ async fn room_route_updates_metrics_for_unauthorized_and_success_paths() -> Test
     )
     .await?;
 
-    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY))?;
+    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY), None)?;
     route_status(
         &state,
         room_builder(&token, "Bearer"),
@@ -215,5 +240,53 @@ async fn room_route_updates_metrics_for_unauthorized_and_success_paths() -> Test
     assert_eq!(metrics.http_room_requests(), 2);
     assert_eq!(metrics.http_room_unauthorized(), 1);
     assert_eq!(metrics.http_room_success(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn room_route_supports_key_seed_claim() -> TestResult {
+    let token = room_token(Some("issuer-a"), None, Some("c2VlZC1rZXk="))?;
+    let test_state = test_state_with_handles();
+    let payload: RoomResponse = route_json(
+        &test_state.state,
+        room_builder(&token, "Bearer"),
+        Body::empty(),
+        StatusCode::OK,
+        "room request should complete",
+    )
+    .await?;
+    let room = require_some(
+        test_state.room_manager.get_by_uuid(&payload.uuid).await,
+        "room should remain registered after route creation",
+    )?;
+    let expected_key = require_some(
+        auth::derive_key_from_seed(TEST_AUTH_KEY, "c2VlZC1rZXk=").ok(),
+        "failed to derive expected key from seed",
+    )?;
+    assert_eq!(room.key(), expected_key);
+    Ok(())
+}
+
+#[tokio::test]
+async fn room_route_key_seed_claim_takes_precedence_over_key_claim() -> TestResult {
+    let token = room_token(Some("issuer-a"), Some(TEST_ROOM_KEY), Some("c2VlZC1rZXk="))?;
+    let test_state = test_state_with_handles();
+    let payload: RoomResponse = route_json(
+        &test_state.state,
+        room_builder(&token, "Bearer"),
+        Body::empty(),
+        StatusCode::OK,
+        "room request should complete",
+    )
+    .await?;
+    let room = require_some(
+        test_state.room_manager.get_by_uuid(&payload.uuid).await,
+        "room should remain registered after route creation",
+    )?;
+    let expected_key = require_some(
+        auth::derive_key_from_seed(TEST_AUTH_KEY, "c2VlZC1rZXk=").ok(),
+        "failed to derive expected key from seed",
+    )?;
+    assert_eq!(room.key(), expected_key);
     Ok(())
 }

--- a/src/runtime/http_server/extractors.rs
+++ b/src/runtime/http_server/extractors.rs
@@ -6,10 +6,11 @@ use axum::{
     http::{HeaderMap, StatusCode, header, request::Parts},
     response::{IntoResponse, Response},
 };
+pub use o_sfu_rfc::jwt::RegisteredJwtClaims;
 
 use crate::runtime::{
     MediaTransport, RuntimeMetrics, RuntimeState,
-    auth::{self, HttpDisconnectClaims, HttpRoomClaims},
+    auth::{self, HttpDisconnectClaims, HttpRoomClaims, derive_key_from_seed},
     http_server::contract::CreateRoomQuery,
     request_origin::RequestOrigin,
     room::{RoomConfig, RoomManager},
@@ -99,21 +100,41 @@ impl FromRequestParts<RuntimeState> for VerifiedRoomRequest {
         };
         let claims = auth::verify::<HttpRoomClaims>(token, &state.config.auth.key)
             .map_err(|_error| record_room_rejection(state, StatusCode::UNAUTHORIZED))?;
-        let Some(issuer) = claims.registered.iss else {
-            return Err(record_room_rejection(state, StatusCode::FORBIDDEN));
-        };
-        let Some(room_key) = claims.key else {
-            return Err(record_room_rejection(state, StatusCode::BAD_REQUEST));
-        };
-        Ok(Self {
-            issuer,
-            room_key,
-            config: RoomConfig {
-                web_rtc_enabled: query.web_rtc_enabled(),
-                recording_address: query.recording_address,
-            },
-            origin,
-        })
+        match claims {
+            HttpRoomClaims {
+                registered: RegisteredJwtClaims { iss: None, .. },
+                ..
+            } => Err(record_room_rejection(state, StatusCode::FORBIDDEN)),
+            HttpRoomClaims {
+                registered:
+                    RegisteredJwtClaims {
+                        iss: Some(issuer), ..
+                    },
+                key,
+                key_seed,
+            } => {
+                let room_key = match (key, key_seed) {
+                    (None, None) => {
+                        return Err(record_room_rejection(state, StatusCode::BAD_REQUEST));
+                    }
+                    (Some(key), None) => key,
+                    (_, Some(seed)) if seed.is_empty() => {
+                        return Err(record_room_rejection(state, StatusCode::BAD_REQUEST));
+                    }
+                    (_, Some(seed)) => derive_key_from_seed(&state.config.auth.key, seed.as_ref())
+                        .map_err(|_error| record_room_rejection(state, StatusCode::BAD_REQUEST))?,
+                };
+                Ok(Self {
+                    issuer,
+                    room_key,
+                    config: RoomConfig {
+                        web_rtc_enabled: query.web_rtc_enabled(),
+                        recording_address: query.recording_address,
+                    },
+                    origin,
+                })
+            }
+        }
     }
 }
 

--- a/tests/src/support/harness.rs
+++ b/tests/src/support/harness.rs
@@ -471,6 +471,7 @@ pub fn signed_room_claims(issuer: &str, key: &str) -> Option<String> {
                 ..RegisteredJwtClaims::default()
             },
             key: Some(key.to_owned()),
+            key_seed: None,
         },
         TEST_AUTH_KEY,
     )


### PR DESCRIPTION
This commit improves security in the room creation flow. Previously the key was sent in clear text (though normally safe in normal conditions) would be leaked if an attacker was able to eavesdrop on the call. We now also support a `keySeed` claim in the JWT sent from the server to this SFU on the room creation endpoint. This seed is then used for the key derivation function using base64 padded and hmac-sha256 with the current shared `AUTH_KEY` secret. This allows both SFU and remote server to derive the same secret without ever sending it.

The previous `key` is still accepted if the `keySeed` claim is not set, for backward compatibility purposes, though not advised. Empty or malformed `keySeed` claim will result in a failure of the endpoint and returns 400 error to avoid silently falling back on the unsafe method.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

Github copilot was used for autocompletion only.
<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
