### PR TITLE
[REF] rtc: move SDP parse off packet loop

### DIFF
--- a/crates/core/src/engine/media_transport/mod.rs
+++ b/crates/core/src/engine/media_transport/mod.rs
@@ -58,7 +58,10 @@ pub mod fuzz_support {
         client_rtp_capabilities_from_answer, fuzz_support::route_packet_loop_ingress_demux,
     };
 }
-use rtc::{RtcWorker, RtcWorkerCommand, RtcWorkerResponse, RtpProfile};
+use rtc::{
+    ParsedSessionAnswer, RtcSessionOffer, RtcWorker, RtcWorkerCommand, RtcWorkerResponse,
+    RtpProfile,
+};
 use tracing::warn;
 pub use types::{
     ActiveSpeakerActivityReason, ActiveSpeakerActivityState, ActiveSpeakerSource,
@@ -191,6 +194,7 @@ impl MediaTransport {
             },
         )
         .await
+        .map(RtcSessionOffer::into_session_offer)
     }
 
     /// Creates a new SDP offer after transport media state changed.
@@ -222,6 +226,7 @@ impl MediaTransport {
             },
         )
         .await
+        .map(RtcSessionOffer::into_session_offer)
     }
 
     /// Applies a browser SDP answer to a pending transport offer.
@@ -239,24 +244,27 @@ impl MediaTransport {
         session_key: &TransportSessionKey,
         answer_sdp: &str,
     ) -> Result<AppliedSessionAnswer, TransportAdapterError> {
-        self.request_session_command(
-            session_key,
-            |response| RtcWorkerCommand::ApplySessionAnswer {
-                session_key: session_key.clone(),
-                answer_sdp: answer_sdp.to_owned(),
-                response,
-            },
-            |error| {
-                warn!(
-                    ?session_key,
-                    op = ?TransportCommandOp::ApplySessionAnswer,
-                    answer_len = answer_sdp.len(),
-                    ?error,
-                    "media transport worker command failed"
-                );
-            },
-        )
+        async {
+            let worker = self.require_worker_for_user(session_key)?;
+            let answer = ParsedSessionAnswer::parse(answer_sdp)?;
+            worker
+                .request_worker(|response| RtcWorkerCommand::ApplySessionAnswer {
+                    session_key: session_key.clone(),
+                    answer,
+                    response,
+                })
+                .await
+        }
         .await
+        .inspect_err(|error| {
+            warn!(
+                ?session_key,
+                op = ?TransportCommandOp::ApplySessionAnswer,
+                answer_len = answer_sdp.len(),
+                ?error,
+                "media transport failed to apply session answer"
+            );
+        })
     }
 
     /// Declares a new producer on a transport session.

--- a/crates/core/src/engine/media_transport/rtc/TESTS/benchmark_support/worker.rs
+++ b/crates/core/src/engine/media_transport/rtc/TESTS/benchmark_support/worker.rs
@@ -15,7 +15,10 @@ use str0m::media::MediaKind;
 use tokio::runtime::{Builder, Runtime};
 
 use super::{
-    super::{RtcWorker, RtpProfile, test_support::test_transport_session_key},
+    super::{
+        RtcSessionOffer, RtcWorker, RtcWorkerCommand, RtpProfile,
+        test_support::test_transport_session_key,
+    },
     FanoutBenchTopology,
 };
 use crate::{
@@ -153,11 +156,14 @@ impl Drop for WorkerLoopBenchFixture {
 /// each lifecycle burst enters the real worker mailbox and executes the command
 /// sequence affected by observation locking: session creation, receive-media
 /// registration, media removal and session close
+/// typed offer responses remain retained until teardown so their destruction is
+/// outside the measured command mix
 pub struct WorkerPacketCommandMixBenchFixture {
     runtime: Runtime,
     worker: RtcWorker,
     base_session_key: TransportSessionKey,
     fanout: FanoutBenchTopology,
+    retained_offers: Vec<RtcSessionOffer>,
     next_session_id: u64,
 }
 
@@ -187,10 +193,14 @@ impl WorkerPacketCommandMixBenchFixture {
             worker: benchmark_worker(rtc_port_range),
             base_session_key: benchmark_session_key(10_000),
             fanout: FanoutBenchTopology::with_local_destinations(WORKER_PACKET_COMMAND_MIX_FANOUT),
+            retained_offers: Vec::with_capacity(
+                WORKER_PACKET_COMMAND_MIX_PACKETS / PACKETS_PER_LIFECYCLE_BURST,
+            ),
             next_session_id: 10_001,
         };
         fixture.bootstrap_base_session();
         let _ = fixture.run_packet_command_mix();
+        fixture.retained_offers.clear();
         fixture
     }
 
@@ -205,6 +215,7 @@ impl WorkerPacketCommandMixBenchFixture {
         let runtime = &self.runtime;
         let worker = &self.worker;
         let fanout = &mut self.fanout;
+        let retained_offers = &mut self.retained_offers;
         let mut next_session_id = self.next_session_id;
         let observed = runtime.block_on(async {
             let mut observed = 0_usize;
@@ -213,8 +224,9 @@ impl WorkerPacketCommandMixBenchFixture {
                 if (packet_index + 1) % PACKETS_PER_LIFECYCLE_BURST == 0 {
                     let session_key = benchmark_session_key(next_session_id);
                     next_session_id = next_session_id.saturating_add(1);
-                    observed =
-                        observed.saturating_add(run_lifecycle_burst(worker, &session_key).await);
+                    let (lifecycle_work, offer) = run_lifecycle_burst(worker, &session_key).await;
+                    retained_offers.push(offer);
+                    observed = observed.saturating_add(lifecycle_work);
                 }
             }
             observed
@@ -244,10 +256,17 @@ impl Drop for WorkerPacketCommandMixBenchFixture {
     }
 }
 
-async fn run_lifecycle_burst(worker: &RtcWorker, session_key: &TransportSessionKey) -> usize {
-    require_ok(
+async fn run_lifecycle_burst(
+    worker: &RtcWorker,
+    session_key: &TransportSessionKey,
+) -> (usize, RtcSessionOffer) {
+    let offer = require_ok(
         worker
-            .create_initial_session_offer("test-room", session_key)
+            .request_worker(|response| RtcWorkerCommand::CreateInitialSessionOffer {
+                room_id: Arc::from("test-room"),
+                session_key: session_key.clone(),
+                response,
+            })
             .await,
         "temporary session offer failed",
     );
@@ -269,7 +288,7 @@ async fn run_lifecycle_burst(worker: &RtcWorker, session_key: &TransportSessionK
         worker.close_session(session_key).await,
         "temporary session close failed",
     );
-    usize::try_from(media_id.as_u64()).unwrap_or(0)
+    (usize::try_from(media_id.as_u64()).unwrap_or(0), offer)
 }
 
 fn benchmark_session_key(connection_id: u64) -> TransportSessionKey {

--- a/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
+++ b/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
@@ -581,25 +581,29 @@ async fn rtc_simulcast_answer_rejects_larger_max_br_than_offer() {
         .expect("staged simulcast renegotiation offer should be available")
         .into_parts()
         .0;
-    let answer_sdp = remote
+    let valid_answer_sdp = remote
         .sdp_api()
         .accept_offer(
             SdpOffer::from_sdp_string(&renegotiation_offer).expect("simulcast offer should parse"),
         )
         .expect("remote simulcast answer should build")
         .to_sdp_string();
-    let answer_sdp = answer_with_simulcast_send_rids(
-        &answer_sdp,
+    let invalid_answer_sdp = answer_with_simulcast_send_rids(
+        &valid_answer_sdp,
         &negotiated_mid,
         &[("lo", Some(150_001)), ("hi", Some(900_000))],
     );
 
     assert_eq!(
         adapter
-            .apply_session_answer(&session_key, &answer_sdp)
+            .apply_session_answer(&session_key, &invalid_answer_sdp)
             .await,
         Err(TransportAdapterError::InvalidInput)
     );
+    adapter
+        .apply_session_answer(&session_key, &valid_answer_sdp)
+        .await
+        .expect("rejected answer should preserve the pending offer");
 }
 
 #[tokio::test]

--- a/crates/core/src/engine/media_transport/rtc/codec/TESTS/rid.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/TESTS/rid.rs
@@ -9,6 +9,13 @@ use crate::Bitrate;
 
 const HIGH_MAX_BITRATE: Bitrate = Bitrate::from_kbps(900);
 
+fn send_rids(
+    answer_sdp: &str,
+    offered_encodings: &[SessionUploadEncoding],
+) -> Result<Vec<NegotiatedRid>, SimulcastAnswerError> {
+    negotiate_answer_rids(&parse_section_rids(answer_sdp)?, offered_encodings)
+}
+
 #[test]
 fn answer_preserves_declared_bitrate() {
     let answer = answer(
@@ -18,7 +25,7 @@ fn answer_preserves_declared_bitrate() {
     );
 
     assert_eq!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Ok(vec![
             NegotiatedRid {
                 rid: Rid::from(DEFAULT_LOW_RID),
@@ -41,7 +48,7 @@ fn answer_keeps_only_accepted_simulcast_rids() {
     );
 
     assert_eq!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Ok(vec![NegotiatedRid {
             rid: Rid::from(DEFAULT_LOW_RID),
             max_bitrate: Some(DEFAULT_LOW_MAX_BITRATE),
@@ -58,7 +65,7 @@ fn answer_preserves_simulcast_order() {
     );
 
     assert_eq!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Ok(vec![
             NegotiatedRid {
                 rid: Rid::from(DEFAULT_LOW_RID),
@@ -77,7 +84,7 @@ fn answer_uses_offered_bitrate_when_omitted() {
     let answer = answer("video_0", &[("lo", None), ("hi", None)], Some("lo;hi"));
 
     assert_eq!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Ok(vec![
             NegotiatedRid {
                 rid: Rid::from(DEFAULT_LOW_RID),
@@ -96,11 +103,7 @@ fn answer_rejects_bitrate_when_offer_has_none() {
     let answer = answer("video_0", &[("lo", Some("max-br=150000"))], Some("lo"));
 
     assert_eq!(
-        send_rids_for_mid(
-            &answer,
-            Mid::from("video_0"),
-            &custom_upload_encodings("lo", None),
-        ),
+        send_rids(&answer, &custom_upload_encodings("lo", None)),
         Err(SimulcastAnswerError)
     );
 }
@@ -110,11 +113,7 @@ fn answer_accepts_lower_bitrate_than_offer() {
     let answer = answer("video_0", &[("lo", Some("max-br=149999"))], Some("lo"));
 
     assert_eq!(
-        send_rids_for_mid(
-            &answer,
-            Mid::from("video_0"),
-            &custom_upload_encodings("lo", Some(150_000)),
-        ),
+        send_rids(&answer, &custom_upload_encodings("lo", Some(150_000))),
         Ok(vec![NegotiatedRid {
             rid: Rid::from("lo"),
             max_bitrate: Some(Bitrate::from_bps(149_999)),
@@ -128,11 +127,7 @@ fn answer_rejects_malformed_or_valueless_bitrate() {
         let answer = answer("video_0", &[("lo", Some(restriction))], Some("lo"));
 
         assert_eq!(
-            send_rids_for_mid(
-                &answer,
-                Mid::from("video_0"),
-                &custom_upload_encodings("lo", Some(150_000)),
-            ),
+            send_rids(&answer, &custom_upload_encodings("lo", Some(150_000))),
             Err(SimulcastAnswerError)
         );
     }
@@ -147,11 +142,7 @@ fn answer_rejects_duplicate_rid_declaration() {
     );
 
     assert_eq!(
-        send_rids_for_mid(
-            &answer,
-            Mid::from("video_0"),
-            &custom_upload_encodings("lo", Some(150_000)),
-        ),
+        send_rids(&answer, &custom_upload_encodings("lo", Some(150_000))),
         Err(SimulcastAnswerError)
     );
 }
@@ -162,14 +153,20 @@ fn answer_rejects_unmodeled_restrictions() {
         let answer = answer("video_0", &[("lo", Some(restriction))], Some("lo"));
 
         assert_eq!(
-            send_rids_for_mid(
-                &answer,
-                Mid::from("video_0"),
-                &custom_upload_encodings("lo", Some(150_000)),
-            ),
+            send_rids(&answer, &custom_upload_encodings("lo", Some(150_000))),
             Err(SimulcastAnswerError)
         );
     }
+}
+
+#[test]
+fn answer_rejects_rid_prefix_alias() {
+    let answer = answer("video_0", &[("abcdefghX", None)], Some("abcdefghX"));
+
+    assert_eq!(
+        send_rids(&answer, &custom_upload_encodings("abcdefgh", None)),
+        Err(SimulcastAnswerError)
+    );
 }
 
 #[test]
@@ -181,7 +178,7 @@ fn answer_requires_accepted_simulcast_send_list() {
     );
 
     assert!(matches!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Ok(rids) if rids.is_empty()
     ));
 }
@@ -205,23 +202,31 @@ fn answer_rejects_simulcast_alternatives() {
     );
 
     assert_eq!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Err(SimulcastAnswerError)
     );
 }
 
 #[test]
-fn answer_matches_exact_mid_section() {
-    let answer = format!(
+fn answer_matches_exact_mid_section() -> Result<(), SimulcastAnswerError> {
+    let answer_sdp = format!(
         concat!(
             "v=0\r\n",
+            "o=- 1 1 IN IP4 0.0.0.0\r\n",
+            "s=-\r\n",
+            "t=0 0\r\n",
+            "a=group:BUNDLE camera cam\r\n",
             "a=mid:cam\r\n",
             "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n",
             "a=mid:camera\r\n",
+            "a=sendonly\r\n",
+            "a=rtpmap:96 VP8/90000\r\n",
             "a={rid}:wrong {send} {max_br}=111000\r\n",
             "a={simulcast}:{send} wrong\r\n",
             "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n",
             "a=mid:cam\r\n",
+            "a=sendonly\r\n",
+            "a=rtpmap:96 VP8/90000\r\n",
             "a={rid}:right {send} {max_br}=222000\r\n",
             "a={simulcast}:{send} right\r\n"
         ),
@@ -230,12 +235,13 @@ fn answer_matches_exact_mid_section() {
         send = webrtc::sdp::rid::DIRECTION_SEND,
         max_br = webrtc::sdp::rid_restriction::MAX_BITRATE,
     );
+    let answer = SdpAnswer::from_sdp_string(&answer_sdp).map_err(|_error| SimulcastAnswerError)?;
+    let rids = ParsedAnswerRids::parse(&answer_sdp, &answer);
 
     assert_eq!(
-        send_rids_for_mid(
-            &answer,
+        rids.negotiate(
             Mid::from("cam"),
-            &custom_upload_encodings("right", Some(222_000)),
+            &custom_upload_encodings("right", Some(222_000))
         ),
         Ok(vec![NegotiatedRid {
             rid: Rid::from("right"),
@@ -243,16 +249,16 @@ fn answer_matches_exact_mid_section() {
         }])
     );
     assert_eq!(
-        send_rids_for_mid(
-            &answer,
+        rids.negotiate(
             Mid::from("camera"),
-            &custom_upload_encodings("wrong", Some(111_000)),
+            &custom_upload_encodings("wrong", Some(111_000))
         ),
         Ok(vec![NegotiatedRid {
             rid: Rid::from("wrong"),
             max_bitrate: Some(Bitrate::from_bps(111_000)),
         }])
     );
+    Ok(())
 }
 
 #[test]
@@ -272,7 +278,7 @@ fn answer_rejects_invalid_rfc8852_ids() {
     );
 
     assert_eq!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Err(SimulcastAnswerError)
     );
 }
@@ -294,7 +300,7 @@ fn answer_rejects_extra_simulcast_streams() {
     );
 
     assert_eq!(
-        send_rids_for_mid(&answer, Mid::from("video_0"), &default_upload_encodings()),
+        send_rids(&answer, &default_upload_encodings()),
         Err(SimulcastAnswerError)
     );
 }

--- a/crates/core/src/engine/media_transport/rtc/codec/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/mod.rs
@@ -26,7 +26,7 @@ pub(super) use packet::{
 };
 pub(in crate::engine::media_transport) use profile::RtpProfile;
 pub(super) use rid::{
-    NegotiatedRid, initial_packet_gate as initial_consumer_packet_gate, send_rids_for_mid,
+    NegotiatedRid, ParsedAnswerRids, initial_packet_gate as initial_consumer_packet_gate,
 };
 use str0m::{
     format::Codec,

--- a/crates/core/src/engine/media_transport/rtc/codec/rid.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/rid.rs
@@ -1,8 +1,13 @@
 //! Shared RID and SDP mechanics for codec simulcast profiles.
 
-use o_sfu_rfc::webrtc;
+use std::collections::BTreeMap;
+
+use o_sfu_rfc::webrtc::{self, sdp::attribute};
 use o_sfu_router::rtp::MediaStream;
-use str0m::media::{Mid, Rid, Simulcast, SimulcastLayer};
+use str0m::{
+    change::SdpAnswer,
+    media::{Mid, Rid, Simulcast, SimulcastLayer},
+};
 
 use crate::{
     Bitrate, VideoBitrateLimits,
@@ -22,6 +27,46 @@ pub(in crate::engine::media_transport::rtc) struct NegotiatedRid {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::engine::media_transport::rtc) struct SimulcastAnswerError;
+
+pub(in crate::engine::media_transport::rtc) struct ParsedAnswerRids {
+    by_mid: BTreeMap<Mid, Result<Vec<AnswerRid>, SimulcastAnswerError>>,
+}
+
+impl ParsedAnswerRids {
+    pub(in crate::engine::media_transport::rtc) fn parse(
+        answer_sdp: &str,
+        answer: &SdpAnswer,
+    ) -> Self {
+        let mut by_mid = BTreeMap::new();
+        // Replacing this raw parsing require an upstream Str0m API that exposes
+        // lossless RID and simulcast declarations through `SdpAnswer`.
+        for (media_line, section) in answer
+            .media_lines
+            .iter()
+            .zip(answer_sdp.split("\nm=").skip(1))
+        {
+            match parse_section_rids(section) {
+                Ok(rids) if rids.is_empty() => {}
+                result => {
+                    by_mid.insert(media_line.mid(), result);
+                }
+            }
+        }
+        Self { by_mid }
+    }
+
+    pub(in crate::engine::media_transport::rtc) fn negotiate(
+        &self,
+        mid: Mid,
+        offered_encodings: &[SessionUploadEncoding],
+    ) -> Result<Vec<NegotiatedRid>, SimulcastAnswerError> {
+        match self.by_mid.get(&mid) {
+            Some(Ok(parsed_rids)) => negotiate_answer_rids(parsed_rids, offered_encodings),
+            Some(Err(error)) => Err(*error),
+            None => Ok(Vec::new()),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct LayerSpec<'a> {
@@ -112,89 +157,64 @@ pub(in crate::engine::media_transport::rtc) fn initial_packet_gate(
     first_rid.map_or(PacketLayerGate::Open, PacketLayerGate::Rid)
 }
 
-pub(in crate::engine::media_transport::rtc) fn send_rids_for_mid(
-    answer_sdp: &str,
-    mid: Mid,
-    offered_encodings: &[SessionUploadEncoding],
-) -> Result<Vec<NegotiatedRid>, SimulcastAnswerError> {
-    let Some(section) = media_section_for_mid(answer_sdp, mid) else {
-        return Ok(Vec::new());
-    };
-    let mut rids = Vec::with_capacity(MAX_SEND_STREAMS);
-    for rid in accepted_send_simulcast_rids(section)? {
+fn parse_section_rids(section: &str) -> Result<Vec<AnswerRid>, SimulcastAnswerError> {
+    let accepted_rids = accepted_send_simulcast_rids(section)?;
+    let mut rids = Vec::with_capacity(accepted_rids.len());
+    for rid in accepted_rids {
         let declaration = send_rid_declaration(section, rid)?;
-        let max_bitrate = negotiated_rid_max_bitrate(declaration, offered_encodings)?;
-        rids.push(NegotiatedRid {
-            rid: Rid::from(declaration.rid),
-            max_bitrate,
+        rids.push(AnswerRid {
+            rid: declaration.rid.to_owned(),
+            max_bitrate: declaration.max_bitrate,
         });
     }
     Ok(rids)
 }
 
+fn negotiate_answer_rids(
+    answer_rids: &[AnswerRid],
+    offered_encodings: &[SessionUploadEncoding],
+) -> Result<Vec<NegotiatedRid>, SimulcastAnswerError> {
+    answer_rids
+        .iter()
+        .map(|answer_rid| {
+            let max_bitrate = negotiated_rid_max_bitrate(answer_rid, offered_encodings)?;
+            Ok(NegotiatedRid {
+                rid: Rid::from(answer_rid.rid.as_str()),
+                max_bitrate,
+            })
+        })
+        .collect()
+}
+
 fn negotiated_rid_max_bitrate(
-    declaration: SendRidDeclaration<'_>,
+    answer_rid: &AnswerRid,
     offered_encodings: &[SessionUploadEncoding],
 ) -> Result<Option<Bitrate>, SimulcastAnswerError> {
+    let rid = answer_rid.rid.as_str();
     let Some(offered) = offered_encodings
         .iter()
-        .find(|encoding| encoding.rid == declaration.rid)
+        .find(|encoding| encoding.rid == rid)
     else {
         return Err(SimulcastAnswerError);
     };
-    match (declaration.max_bitrate, offered.max_bitrate) {
+    match (answer_rid.max_bitrate, offered.max_bitrate) {
         (RidMaxBitrate::Absent, offered) => Ok(offered),
         (RidMaxBitrate::Value(answer), Some(offer)) if answer <= offer => Ok(Some(answer)),
         (RidMaxBitrate::Value(_) | RidMaxBitrate::Valueless, _) => Err(SimulcastAnswerError),
     }
 }
 
-fn media_section_for_mid(sdp: &str, mid: Mid) -> Option<&str> {
-    let marker = format!(
-        "{}{}:{mid}",
-        webrtc::sdp::ATTRIBUTE_PREFIX,
-        webrtc::sdp::attribute::MID
-    );
-    let media_prefix = format!("\n{}", webrtc::sdp::MEDIA_PREFIX);
-    let mut section_search_start = 0;
-    while let Some(section_start) =
-        find_next_media_section_start(sdp, section_search_start, &media_prefix)
-    {
-        let section_body_start = section_start + webrtc::sdp::MEDIA_PREFIX.len();
-        let section_end = find_next_media_section_start(sdp, section_body_start, &media_prefix)
-            .unwrap_or(sdp.len());
-        let section = &sdp[section_start..section_end];
-        if section
-            .lines()
-            .map(|line| line.trim_end_matches('\r'))
-            .any(|line| line == marker)
-        {
-            return Some(section);
-        }
-        section_search_start = section_end;
-    }
-    None
-}
-
-fn find_next_media_section_start(sdp: &str, start: usize, media_prefix: &str) -> Option<usize> {
-    let remaining = sdp.get(start..)?;
-    if remaining.starts_with(webrtc::sdp::MEDIA_PREFIX) {
-        return Some(start);
-    }
-    // `media_prefix` is "\nm=" so the match anchors `m=` to a line start.
-    // `+ 1` moves past the newline to the section start.
-    remaining
-        .find(media_prefix)
-        .map(|offset| start + offset + 1)
-}
-
-#[derive(Debug, Clone, Copy)]
 struct SendRidDeclaration<'a> {
     rid: &'a str,
     max_bitrate: RidMaxBitrate,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AnswerRid {
+    rid: String,
+    max_bitrate: RidMaxBitrate,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum RidMaxBitrate {
     Absent,
     Valueless,
@@ -221,12 +241,7 @@ fn send_rid_declaration<'a>(
 }
 
 fn parse_send_rid(line: &str) -> Result<Option<SendRidDeclaration<'_>>, SimulcastAnswerError> {
-    let rid_prefix = format!(
-        "{}{}:",
-        webrtc::sdp::ATTRIBUTE_PREFIX,
-        webrtc::sdp::attribute::RID
-    );
-    let Some(rid_value) = line.strip_prefix(&rid_prefix) else {
+    let Some(rid_value) = sdp_attribute_value(line, attribute::RID) else {
         return Ok(None);
     };
     let mut parts = rid_value.splitn(3, ' ');
@@ -251,7 +266,7 @@ fn parse_send_rid(line: &str) -> Result<Option<SendRidDeclaration<'_>>, Simulcas
 fn accepted_send_simulcast_rids(section: &str) -> Result<Vec<&str>, SimulcastAnswerError> {
     let mut lines = section
         .lines()
-        .filter_map(|line| parse_simulcast_value(line.trim_end_matches('\r')));
+        .filter_map(|line| sdp_attribute_value(line.trim_end_matches('\r'), attribute::SIMULCAST));
     let Some(value) = lines.next() else {
         return Ok(Vec::new());
     };
@@ -261,13 +276,10 @@ fn accepted_send_simulcast_rids(section: &str) -> Result<Vec<&str>, SimulcastAns
     parse_send_simulcast_value(value)
 }
 
-fn parse_simulcast_value(line: &str) -> Option<&str> {
-    let simulcast_prefix = format!(
-        "{}{}:",
-        webrtc::sdp::ATTRIBUTE_PREFIX,
-        webrtc::sdp::attribute::SIMULCAST
-    );
-    line.strip_prefix(&simulcast_prefix)
+fn sdp_attribute_value<'a>(line: &'a str, attribute: &str) -> Option<&'a str> {
+    line.strip_prefix(webrtc::sdp::ATTRIBUTE_PREFIX)?
+        .strip_prefix(attribute)?
+        .strip_prefix(':')
 }
 
 fn parse_send_simulcast_value(value: &str) -> Result<Vec<&str>, SimulcastAnswerError> {

--- a/crates/core/src/engine/media_transport/rtc/commands.rs
+++ b/crates/core/src/engine/media_transport/rtc/commands.rs
@@ -9,11 +9,16 @@
 
 use std::sync::Arc;
 
+use o_sfu_rfc::webrtc;
 use o_sfu_router::rtp::MediaStream as RouterRtpParameters;
-use str0m::media::{KeyframeRequestKind, MediaKind, Rid};
+use str0m::{
+    change::{SdpAnswer, SdpOffer},
+    media::{KeyframeRequestKind, MediaKind, Rid},
+};
 use tokio::sync::{mpsc, oneshot};
 
 use super::{
+    codec::{ParsedAnswerRids, RtpProfile},
     relay_registry::{RelayPacketMailbox, RelayTargetId},
     route_control::PacketLayerGate,
 };
@@ -21,8 +26,9 @@ use crate::engine::{
     media_transport::{
         ActiveSpeakerSource, AppliedSessionAnswer, ConsumerRouteControl,
         ConsumerRouteControlOutcome, ProducerRouteControl, ReceiverBweTargetUpdate, SessionOffer,
-        SourceActivityUpdate, TransportConsumerRoute, TransportMediaId, TransportResult,
-        TransportSessionKey, TransportSourceDiagnosticsSnapshot, TransportSourceKey,
+        SessionUploadSlot, SourceActivityUpdate, TransportAdapterError, TransportConsumerRoute,
+        TransportMediaId, TransportResult, TransportSessionKey, TransportSourceDiagnosticsSnapshot,
+        TransportSourceKey,
     },
     metrics::{RtcMetricsRecorder, RtcRemoteControlDropKind, RtcRemotePacketGateConvergence},
 };
@@ -141,6 +147,42 @@ impl RemoteSourceControl {
 /// mutation that is already being handled
 pub type RtcWorkerResponse<T> = oneshot::Sender<TransportResult<T>>;
 
+pub struct ParsedSessionAnswer {
+    pub(super) answer: SdpAnswer,
+    pub(super) rids: ParsedAnswerRids,
+}
+
+impl ParsedSessionAnswer {
+    pub(in crate::engine::media_transport) fn parse(answer_sdp: &str) -> TransportResult<Self> {
+        RtpProfile::validate_answer_sdp(answer_sdp)?;
+        let answer = SdpAnswer::from_sdp_string(answer_sdp)
+            .map_err(|_error| TransportAdapterError::InvalidInput)?;
+        let rids = ParsedAnswerRids::parse(answer_sdp, &answer);
+        Ok(Self { answer, rids })
+    }
+}
+
+pub struct RtcSessionOffer {
+    offer: SdpOffer,
+    upload_slots: Vec<SessionUploadSlot>,
+}
+
+impl RtcSessionOffer {
+    pub(super) fn new(offer: SdpOffer, upload_slots: Vec<SessionUploadSlot>) -> Self {
+        Self {
+            offer,
+            upload_slots,
+        }
+    }
+
+    pub(in crate::engine::media_transport) fn into_session_offer(self) -> SessionOffer {
+        let mut sdp = self.offer.to_sdp_string();
+        let media_line_start = sdp.find("\r\nm=").map_or(sdp.len(), |index| index + 2);
+        sdp.insert_str(media_line_start, webrtc::sdp::END_OF_CANDIDATES_LINE);
+        SessionOffer::new(sdp).with_upload_slots(self.upload_slots)
+    }
+}
+
 #[derive(Debug)]
 pub enum WorkerMediaControlBatch {
     ReceiverBwe(Vec<(usize, ReceiverBweTargetUpdate)>),
@@ -205,7 +247,7 @@ pub enum RtcWorkerCommand {
     CreateInitialSessionOffer {
         room_id: Arc<str>,
         session_key: TransportSessionKey,
-        response: RtcWorkerResponse<SessionOffer>,
+        response: RtcWorkerResponse<RtcSessionOffer>,
     },
     /// drain a staged follow-up offer after media topology changed
     ///
@@ -215,7 +257,7 @@ pub enum RtcWorkerCommand {
     /// one-outstanding-offer rule owned by the worker
     CreateSessionRenegotiationOffer {
         session_key: TransportSessionKey,
-        response: RtcWorkerResponse<SessionOffer>,
+        response: RtcWorkerResponse<RtcSessionOffer>,
     },
     /// read active-speaker sources from worker-local route-control state
     ///
@@ -236,7 +278,7 @@ pub enum RtcWorkerCommand {
     /// and returns the producer details that became usable after the answer
     ApplySessionAnswer {
         session_key: TransportSessionKey,
-        answer_sdp: String,
+        answer: ParsedSessionAnswer,
         response: RtcWorkerResponse<AppliedSessionAnswer>,
     },
     /// remove a session from worker state

--- a/crates/core/src/engine/media_transport/rtc/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/mod.rs
@@ -66,6 +66,7 @@ mod worker;
 pub(super) use codec::RtpProfile;
 #[cfg(any(test, fuzzing))]
 pub use codec::client_rtp_capabilities_from_answer;
+pub(super) use commands::{ParsedSessionAnswer, RtcSessionOffer};
 pub use commands::{
     RtcWorkerCommand, RtcWorkerResponse, WorkerMediaControlBatch, WorkerMediaControlBatchOutcome,
 };

--- a/crates/core/src/engine/media_transport/rtc/state/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/state/mod.rs
@@ -34,7 +34,7 @@ use std::{
 use o_sfu_router::rtp::MediaStream as RouterRtpParameters;
 use str0m::{
     Rtc,
-    change::SdpPendingOffer,
+    change::{SdpOffer, SdpPendingOffer},
     media::{Mid, Rid},
     rtp::Ssrc,
 };
@@ -154,7 +154,7 @@ pub(super) struct SessionSdpNegotiationState {
     /// `str0m` token that must be accepted by the next remote answer
     pub(super) pending_offer: Option<SdpPendingOffer>,
     /// follow-up local offer prepared by media lifecycle and not yet delivered
-    pub(super) staged_offer_sdp: Option<String>,
+    pub(super) staged_offer: Option<Box<SdpOffer>>,
     pub(super) staged_offer_upload_slots: Vec<SessionUploadSlot>,
     /// whether the remote side has answered the initial transport offer
     pub(super) initial_offer_applied: bool,

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/dispatcher.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/dispatcher.rs
@@ -107,7 +107,7 @@ pub fn handle_worker_command(
         ),
         RtcWorkerCommand::ApplySessionAnswer {
             session_key,
-            answer_sdp,
+            answer,
             response,
         } => respond(
             response,
@@ -115,7 +115,7 @@ pub fn handle_worker_command(
                 state,
                 context.config.bitrate_limits.max_bitrate_in(),
                 &session_key,
-                &answer_sdp,
+                answer,
             ),
         ),
         #[cfg(test)]

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/media/lifecycle.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/media/lifecycle.rs
@@ -220,7 +220,7 @@ fn can_unregister_unnegotiated_producer(
 /// must reject new additions that would need a second concurrent offer
 fn offer_is_awaiting_answer(session_state: &RtcSessionState) -> bool {
     session_state.sdp_negotiation.pending_offer.is_some()
-        && session_state.sdp_negotiation.staged_offer_sdp.is_none()
+        && session_state.sdp_negotiation.staged_offer.is_none()
 }
 
 /// "Removal" for negotiated media means preserving the existing MID and
@@ -253,7 +253,7 @@ fn worker_stage_native_media_removal(
         return Err(TransportAdapterError::InvalidInput);
     };
     session_state.sdp_negotiation.pending_offer = Some(pending_offer);
-    session_state.sdp_negotiation.staged_offer_sdp = Some(offer.to_sdp_string());
+    session_state.sdp_negotiation.staged_offer = Some(Box::new(offer));
     session_state
         .sdp_negotiation
         .staged_offer_upload_slots
@@ -367,7 +367,7 @@ fn worker_stage_native_recv_media(
         return Err(TransportAdapterError::TransportUnavailable);
     };
     session_state.sdp_negotiation.pending_offer = Some(pending_offer);
-    session_state.sdp_negotiation.staged_offer_sdp = Some(offer.to_sdp_string());
+    session_state.sdp_negotiation.staged_offer = Some(Box::new(offer));
     session_state.sdp_negotiation.staged_offer_upload_slots = vec![upload_slot(
         mid,
         media_kind,
@@ -531,7 +531,7 @@ fn worker_stage_native_send_media(
         return Err(TransportAdapterError::TransportUnavailable);
     };
     session_state.sdp_negotiation.pending_offer = Some(pending_offer);
-    session_state.sdp_negotiation.staged_offer_sdp = Some(offer.to_sdp_string());
+    session_state.sdp_negotiation.staged_offer = Some(Box::new(offer));
     session_state
         .sdp_negotiation
         .staged_offer_upload_slots

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/negotiation.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/negotiation.rs
@@ -14,7 +14,7 @@ use std::{
     time::Duration,
 };
 
-use o_sfu_rfc::webrtc::{self, MediaKind as ProtocolMediaKind};
+use o_sfu_rfc::webrtc::MediaKind as ProtocolMediaKind;
 use str0m::{
     change::{SdpAnswer, SdpApi},
     media::{Direction, Media, MediaKind, Mid},
@@ -23,7 +23,11 @@ use tracing::debug;
 
 use super::{
     super::super::{
-        RtpProfile, bitrate::BitrateRegistry, bootstrap, codec, state::PacketLoopState,
+        RtpProfile,
+        bitrate::BitrateRegistry,
+        bootstrap, codec,
+        commands::{ParsedSessionAnswer, RtcSessionOffer},
+        state::PacketLoopState,
     },
     publication::{answer_producer_projection, refresh_negotiated_producer_parameters},
     recv_stream::{StaleSsrcPolicy, apply_recv_stream},
@@ -32,8 +36,8 @@ use crate::{
     Bitrate, VideoBitrateLimits,
     engine::{
         media_transport::{
-            AppliedProducer, AppliedSessionAnswer, SessionOffer, SessionUploadEncoding,
-            SessionUploadSlot, TransportAdapterError, TransportSessionKey,
+            AppliedProducer, AppliedSessionAnswer, SessionUploadEncoding, SessionUploadSlot,
+            TransportAdapterError, TransportSessionKey,
         },
         metrics::RuntimeMetrics,
     },
@@ -64,7 +68,7 @@ pub(super) fn worker_create_initial_session_offer(
     config: OfferBootstrapConfig<'_>,
     room_id: Arc<str>,
     session_key: &TransportSessionKey,
-) -> Result<SessionOffer, TransportAdapterError> {
+) -> Result<RtcSessionOffer, TransportAdapterError> {
     ensure_session_ready_for_offer(state, bitrate_registry, config, room_id, session_key)?;
     if state.session_has_registered_media(session_key) {
         return Err(TransportAdapterError::UnsupportedFeature);
@@ -94,32 +98,28 @@ pub(super) fn worker_create_initial_session_offer(
     };
 
     session_state.sdp_negotiation.pending_offer = Some(pending_offer);
-    session_state.sdp_negotiation.staged_offer_sdp = None;
+    session_state.sdp_negotiation.staged_offer = None;
     session_state
         .sdp_negotiation
         .staged_offer_upload_slots
         .clear();
-    Ok(
-        SessionOffer::new(offer_sdp_with_end_of_candidates(offer.to_sdp_string()))
-            .with_upload_slots(initial_upload_slots(
-                bootstrap_mids,
-                config.profile,
-                config.video_bitrate_limits,
-            )),
-    )
+    Ok(RtcSessionOffer::new(
+        offer,
+        initial_upload_slots(bootstrap_mids, config.profile, config.video_bitrate_limits),
+    ))
 }
 
 pub(super) fn worker_create_session_renegotiation_offer(
     state: &mut PacketLoopState,
     session_key: &TransportSessionKey,
-) -> Result<SessionOffer, TransportAdapterError> {
+) -> Result<RtcSessionOffer, TransportAdapterError> {
     let Some(session_state) = state.users.get_mut(session_key) else {
         return Err(TransportAdapterError::TransportUnavailable);
     };
     if !session_state.sdp_negotiation.initial_offer_applied {
         return Err(TransportAdapterError::InvalidInput);
     }
-    let Some(offer_sdp) = session_state.sdp_negotiation.staged_offer_sdp.take() else {
+    let Some(offer) = session_state.sdp_negotiation.staged_offer.take() else {
         if session_state.sdp_negotiation.pending_offer.is_some() {
             return Err(TransportAdapterError::InvalidInput);
         }
@@ -129,10 +129,7 @@ pub(super) fn worker_create_session_renegotiation_offer(
         .sdp_negotiation
         .staged_offer_upload_slots
         .clone();
-    Ok(
-        SessionOffer::new(offer_sdp_with_end_of_candidates(offer_sdp))
-            .with_upload_slots(upload_slots),
-    )
+    Ok(RtcSessionOffer::new(*offer, upload_slots))
 }
 
 /// Accept the currently pending local offer and reconcile every worker-local
@@ -146,16 +143,14 @@ pub(super) fn worker_apply_session_answer(
     state: &mut PacketLoopState,
     max_bitrate_in: Bitrate,
     session_key: &TransportSessionKey,
-    answer_sdp: &str,
+    parsed_answer: ParsedSessionAnswer,
 ) -> Result<AppliedSessionAnswer, TransportAdapterError> {
-    RtpProfile::validate_answer_sdp(answer_sdp)?;
     let producer_media_snapshot = state.producer_media_snapshot(session_key);
     let producer_mids = producer_media_snapshot
         .iter()
         .map(|(_transport_media_id, mid)| *mid)
         .collect::<Vec<_>>();
-    let answer = SdpAnswer::from_sdp_string(answer_sdp)
-        .map_err(|_error| TransportAdapterError::InvalidInput)?;
+    let ParsedSessionAnswer { answer, rids } = parsed_answer;
     let remote_candidate_addrs = answer_remote_candidate_addrs(&answer);
     let client_capabilities = codec::client_rtp_capabilities_from_sdp_answer(&answer)?;
     let producer_answer_projection = answer_producer_projection(&answer, &producer_mids)?;
@@ -167,7 +162,7 @@ pub(super) fn worker_apply_session_answer(
                 .get(mid)
                 .map(Vec::as_slice)
                 .unwrap_or_default();
-            codec::send_rids_for_mid(answer_sdp, *mid, encodings)
+            rids.negotiate(*mid, encodings)
                 .map(|rids| (*mid, rids))
                 .map_err(|_error| TransportAdapterError::InvalidInput)
         })
@@ -185,7 +180,7 @@ pub(super) fn worker_apply_session_answer(
             .accept_answer(pending_offer, answer)
             .map_err(|_error| TransportAdapterError::InvalidInput)?;
         session_state.sdp_negotiation.initial_offer_applied = true;
-        session_state.sdp_negotiation.staged_offer_sdp = None;
+        session_state.sdp_negotiation.staged_offer = None;
         let staged_upload_slots =
             mem::take(&mut session_state.sdp_negotiation.staged_offer_upload_slots);
         apply_pending_recv_streams(session_state, max_bitrate_in);
@@ -355,19 +350,11 @@ fn stage_queued_removal_offer(session_state: &mut super::super::super::state::Rt
         return;
     };
     session_state.sdp_negotiation.pending_offer = Some(pending_offer);
-    session_state.sdp_negotiation.staged_offer_sdp = Some(offer.to_sdp_string());
+    session_state.sdp_negotiation.staged_offer = Some(Box::new(offer));
     session_state
         .sdp_negotiation
         .staged_offer_upload_slots
         .clear();
-}
-
-fn offer_sdp_with_end_of_candidates(mut offer_sdp: String) -> String {
-    let media_line_start = offer_sdp
-        .find("\r\nm=")
-        .map_or(offer_sdp.len(), |index| index + 2);
-    offer_sdp.insert_str(media_line_start, webrtc::sdp::END_OF_CANDIDATES_LINE);
-    offer_sdp
 }
 
 fn ensure_initial_negotiation_media(

--- a/crates/core/src/engine/media_transport/rtc/worker/handlers/publication.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/handlers/publication.rs
@@ -220,7 +220,7 @@ pub(super) fn worker_resolve_negotiated_producer_parameters(
             ?mid,
             initial_offer_applied = session_state.sdp_negotiation.initial_offer_applied,
             pending_offer = session_state.sdp_negotiation.pending_offer.is_some(),
-            staged_offer = session_state.sdp_negotiation.staged_offer_sdp.is_some(),
+            staged_offer = session_state.sdp_negotiation.staged_offer.is_some(),
             negotiated_mids = ?session_state
                 .sdp_negotiation
                 .negotiated_producer_parameters

--- a/crates/core/src/engine/media_transport/rtc/worker/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/worker/mod.rs
@@ -59,6 +59,10 @@ use str0m::media::MediaKind;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(test)]
+use super::commands::ParsedSessionAnswer;
+#[cfg(any(test, feature = "internal-benchmarks"))]
+use super::commands::RtcSessionOffer;
 use super::{
     bitrate::BitrateRegistry,
     commands::{RemoteSourceControl, RouteControlRequest, RtcWorkerCommand},
@@ -147,6 +151,7 @@ impl RtcWorker {
             },
         )
         .await
+        .map(RtcSessionOffer::into_session_offer)
     }
 
     #[cfg(test)]
@@ -161,6 +166,7 @@ impl RtcWorker {
             },
         )
         .await
+        .map(RtcSessionOffer::into_session_offer)
     }
 
     #[cfg(test)]
@@ -169,9 +175,10 @@ impl RtcWorker {
         session_key: &TransportSessionKey,
         answer_sdp: &str,
     ) -> Result<AppliedSessionAnswer, TransportAdapterError> {
+        let answer = ParsedSessionAnswer::parse(answer_sdp)?;
         self.request_worker(|response| RtcWorkerCommand::ApplySessionAnswer {
             session_key: session_key.clone(),
-            answer_sdp: answer_sdp.to_owned(),
+            answer,
             response,
         })
         .await

--- a/tests/benchmarks/packet_loop_callgrind.rs
+++ b/tests/benchmarks/packet_loop_callgrind.rs
@@ -287,10 +287,13 @@ fn keyframe_coalesce_512(mut fixture: KeyframeCoalescingBenchFixture) -> usize {
 // side goes through the real worker mailbox
 // this keeps the observation-lock cost visible in the regular base-versus-head
 // Callgrind suite without adding fake peer negotiation to the measured window
-#[library_benchmark(config = callgrind_config(1.0))]
+#[library_benchmark(config = callgrind_config(1.0), teardown = drop)]
 #[bench::packet_cmd_mix(WorkerPacketCommandMixBenchFixture::packet_command_mix_current_thread())]
-fn interleaved_fanout(mut fixture: WorkerPacketCommandMixBenchFixture) -> usize {
-    black_box(fixture.run_packet_command_mix())
+fn interleaved_fanout(
+    mut fixture: WorkerPacketCommandMixBenchFixture,
+) -> WorkerPacketCommandMixBenchFixture {
+    black_box(fixture.run_packet_command_mix());
+    black_box(fixture)
 }
 
 // measures ready session output draining


### PR DESCRIPTION
SDP parsing, RID policy extraction and offer rendering ran on the worker even though they do not require mutable packet-loop state.

Parse answers and RID infos before sending the worker command

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
