### PR TITLE
[ADD] tests: verify NACK/RTX under reordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "str0m",
+ "str0m-netem",
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tokio-util",
@@ -2155,6 +2156,16 @@ dependencies = [
  "dimpl",
  "str0m-proto",
  "time",
+]
+
+[[package]]
+name = "str0m-netem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c93838ef4196ab2d588154d7c87db3da034699124a669886fe288b90b5ecb91"
+dependencies = [
+ "fastrand",
+ "str0m-proto",
 ]
 
 [[package]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -30,6 +30,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 serde_json.workspace = true
 str0m.workspace = true
+str0m-netem = "0.3"
 tokio.workspace = true
 tokio-tungstenite.workspace = true
 tokio-util.workspace = true

--- a/tests/integration/full_stack/nack_recovery.rs
+++ b/tests/integration/full_stack/nack_recovery.rs
@@ -5,6 +5,8 @@ use super::support::{self as s, media as m, setup as st};
 const RECOVERY_TIMEOUT: s::Duration = s::Duration::from_secs(3);
 const POST_RECOVERY_SETTLE: s::Duration = s::Duration::from_millis(200);
 const RTC_POLL_SLICE: s::Duration = s::Duration::from_millis(50);
+// Keeps the primary queued beyond RECOVERY_TIMEOUT until the test releases it.
+const LATE_PRIMARY_DELAY: s::Duration = s::Duration::from_secs(10);
 const GAP_EXPOSING_PACKET_COUNT: usize = 6;
 const RIDLESS_POLICY_WARMUP_PACKET_COUNT: usize = 60;
 
@@ -360,6 +362,114 @@ async fn fake_rtc_recovers_publisher_video_loss_with_nack_and_rtx() -> s::TestRe
         read_payload(&mut subscriber, &expected_payload, RECOVERY_TIMEOUT).await,
         "subscriber should receive the normalized replacement repair",
     )?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn fake_rtc_does_not_forward_late_primary_after_rtx() -> s::TestResult {
+    let _guard = st::full_stack_test_guard().await;
+    let (peers, mut source, mut clock) = Box::pin(ready_nack_route(
+        "issuer-late-primary-after-rtx",
+        122,
+        123,
+        Some("hi"),
+    ))
+    .await?;
+    let st::ReadyRoomFakePeers {
+        mut publisher,
+        mut subscriber,
+        ..
+    } = peers;
+    let (primary_payload_type, repair_payload_type) = s::require_some(
+        publisher.repair_payload_types(&s::CodecName::Vp8),
+        "publisher should negotiate VP8 RTX",
+    )?;
+    let (primary_ssrc, repair_ssrc) = s::require_some(
+        publisher.send_stream_ssrc_pair(source.media_kind(), Some("hi")),
+        "publisher should negotiate a matching primary and repair SSRC pair",
+    )?;
+
+    publisher.start_rtc_trace();
+    // A link-layer retransmission or unequal delay across load-balanced paths
+    // can make one RTP packet arrive after later packets. RFC 4737 section 1.1
+    // lists both causes.
+    // https://www.rfc-editor.org/rfc/rfc4737.html#section-1.1
+    // The held primary creates that sequence gap. O-SFU must request it with
+    // Generic NACK and accept its RTX repair before the original arrives.
+    assert!(publisher.try_delay_next_outbound_rtp(
+        primary_payload_type,
+        primary_ssrc,
+        LATE_PRIMARY_DELAY,
+    ));
+    let expected_payload = s::require_some(
+        publisher.send_rtp_packet(&mut source, &mut clock).await,
+        "publisher should send the packet selected for delay",
+    )?;
+    let mut trace = publisher.take_rtc_trace();
+    let delayed_sequence_number = s::require_some(
+        matching_primary_payload(&trace, s::RtcTraceDirection::Tx, &expected_payload),
+        "publisher trace should contain the delayed primary packet",
+    )?
+    .sequence_number;
+
+    s::require_some(
+        publisher
+            .send_rtp_packets(&mut source, &mut clock, GAP_EXPOSING_PACKET_COUNT)
+            .await,
+        "publisher should expose the delayed primary gap",
+    )?;
+    s::require_some(
+        pump_until_rtx(
+            &mut publisher,
+            &mut trace,
+            s::RtcTraceDirection::Tx,
+            delayed_sequence_number,
+            RECOVERY_TIMEOUT,
+        )
+        .await,
+        "publisher should repair the delayed primary through RTX",
+    )?;
+    // Tie feedback and repair to delayed_sequence_number. An unrelated NACK or
+    // RTX packet would not prove that the delayed primary was recovered.
+    assert!(nack_contains(
+        &trace,
+        s::RtcTraceDirection::Rx,
+        primary_ssrc,
+        delayed_sequence_number,
+    ));
+    let rtx = s::require_some(
+        matching_rtx(&trace, s::RtcTraceDirection::Tx, delayed_sequence_number),
+        "publisher should emit a matching RTX packet",
+    )?;
+    assert_eq!(rtx.payload_type, repair_payload_type);
+    assert_eq!(rtx.ssrc, repair_ssrc);
+    assert_eq!(
+        rtx.payload.get(RTX_ORIGINAL_SEQUENCE_NUMBER_BYTES..),
+        Some(expected_payload.as_slice())
+    );
+
+    s::require_some(
+        read_payload(&mut subscriber, &expected_payload, RECOVERY_TIMEOUT).await,
+        "subscriber should receive the repaired publisher packet",
+    )?;
+    // Keeping the primary queued proves the subscriber recovered through RTX.
+    // If the original had reached O-SFU first, the same payload assertion could
+    // pass without exercising retransmission.
+    assert!(publisher.has_delayed_outbound_rtp());
+
+    // A reordered primary may arrive after its RTX repair. The subscriber's
+    // `str0m::Rtc` must not emit a second `Event::RtpPacket` for that payload.
+    s::require_some(
+        publisher.release_delayed_outbound_rtp().await,
+        "publisher should release the delayed primary packet",
+    )?;
+    assert!(!publisher.has_delayed_outbound_rtp());
+    assert!(
+        read_payload(&mut subscriber, &expected_payload, POST_RECOVERY_SETTLE)
+            .await
+            .is_none(),
+        "subscriber should not receive the late primary after RTX"
+    );
     Ok(())
 }
 

--- a/tests/src/support/fake_rtc_peer.rs
+++ b/tests/src/support/fake_rtc_peer.rs
@@ -21,12 +21,13 @@ use str0m::{
     change::SdpOffer,
     format::{Codec, PayloadParams},
     media::{KeyframeRequest, Mid, Pt, Rid},
-    net::{Protocol, Receive},
+    net::{Protocol, Receive, Transmit},
     rtp::{
         RawPacket, RtpHeader, RtpPacket, RtpWrite, Ssrc,
         rtcp::{Nack, Rtcp},
     },
 };
+use str0m_netem::{Input as NetemInput, Netem, NetemConfig, Output as NetemOutput};
 use tokio::{net::UdpSocket, time::timeout};
 use tokio_util::bytes::Bytes;
 
@@ -110,6 +111,7 @@ pub struct FakeRtcPeer {
     trace: RtcPeerTrace,
     trace_enabled: bool,
     outbound_rtp_hold: Option<RtpSelector>,
+    outbound_rtp_delay: Option<OutboundRtpDelay>,
     drop_next_inbound_rtp: Option<RtpSelector>,
     held_outbound_rtp: VecDeque<(SocketAddr, Vec<u8>)>,
 }
@@ -118,6 +120,17 @@ pub struct FakeRtcPeer {
 struct RtpSelector {
     payload_type: u8,
     ssrc: u32,
+}
+
+struct OutboundRtpDelay {
+    selector: Option<RtpSelector>,
+    pending: Netem<PendingOutboundDatagram>,
+}
+
+#[derive(Clone)]
+struct PendingOutboundDatagram {
+    destination: SocketAddr,
+    contents: Bytes,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -171,6 +184,7 @@ impl FakeRtcPeer {
             trace: RtcPeerTrace::default(),
             trace_enabled: false,
             outbound_rtp_hold: None,
+            outbound_rtp_delay: None,
             drop_next_inbound_rtp: None,
             held_outbound_rtp: VecDeque::new(),
         })
@@ -281,6 +295,37 @@ impl FakeRtcPeer {
 
     pub fn clear_outbound_rtp_hold(&mut self) {
         self.outbound_rtp_hold = None;
+    }
+
+    pub(super) fn try_delay_next_outbound_rtp(
+        &mut self,
+        payload_type: u8,
+        ssrc: u32,
+        delay: Duration,
+    ) -> bool {
+        if self.outbound_rtp_delay.is_some() {
+            return false;
+        }
+        self.trace_enabled = true;
+        self.outbound_rtp_delay = Some(OutboundRtpDelay::new(
+            RtpSelector { payload_type, ssrc },
+            delay,
+        ));
+        true
+    }
+
+    pub(super) fn has_delayed_outbound_rtp(&self) -> bool {
+        self.outbound_rtp_delay
+            .as_ref()
+            .is_some_and(|delay| !delay.pending.is_empty())
+    }
+
+    pub(super) async fn release_delayed_outbound_rtp(&mut self) -> Option<()> {
+        // Evaluate `Netem` at its own deadline so tests can release a late packet
+        // deterministically without sleeping for the configured delay.
+        let release_at = self.outbound_rtp_delay.as_ref()?.next_timeout()?;
+        self.flush_delayed_outbound_rtp(release_at).await?;
+        self.outbound_rtp_delay.is_none().then_some(())
     }
 
     pub fn drop_next_inbound_rtp(&mut self, payload_type: u8, ssrc: u32) {
@@ -464,6 +509,9 @@ impl FakeRtcPeer {
                             .push_back((transmit.destination, Vec::from(transmit.contents)));
                         continue;
                     }
+                    let Some(transmit) = self.schedule_delayed_outbound_rtp(now, transmit) else {
+                        continue;
+                    };
                     self.socket
                         .send_to(&transmit.contents, transmit.destination)
                         .await
@@ -501,11 +549,10 @@ impl FakeRtcPeer {
                         self.rtc.handle_input(Input::Timeout(now)).ok()?;
                         continue;
                     }
+                    self.flush_delayed_outbound_rtp(now).await?;
+                    let now = Instant::now();
 
-                    let wait_duration = timeout_at
-                        .saturating_duration_since(now)
-                        .min(MAX_SOCKET_WAIT)
-                        .min(deadline.saturating_duration_since(now));
+                    let wait_duration = self.socket_wait_duration(timeout_at, now, deadline);
                     if wait_duration.is_zero() {
                         self.rtc.handle_input(Input::Timeout(Instant::now())).ok()?;
                         continue;
@@ -541,6 +588,73 @@ impl FakeRtcPeer {
         Some(PumpResult::Deadline)
     }
 
+    fn socket_wait_duration(
+        &self,
+        rtc_timeout: Instant,
+        now: Instant,
+        deadline: Instant,
+    ) -> Duration {
+        // Keep polling str0m while netem holds the primary so RTX can overtake it.
+        let netem_wait = self
+            .outbound_rtp_delay
+            .as_ref()
+            .and_then(OutboundRtpDelay::next_timeout)
+            .map_or(Duration::MAX, |timeout| {
+                timeout.saturating_duration_since(now)
+            });
+        rtc_timeout
+            .saturating_duration_since(now)
+            .min(netem_wait)
+            .min(MAX_SOCKET_WAIT)
+            .min(deadline.saturating_duration_since(now))
+    }
+
+    async fn flush_delayed_outbound_rtp(&mut self, now: Instant) -> Option<()> {
+        while let Some(datagram) = self
+            .outbound_rtp_delay
+            .as_mut()
+            .and_then(|delay| delay.pop_due(now))
+        {
+            self.socket
+                .send_to(&datagram.contents, datagram.destination)
+                .await
+                .ok()?;
+        }
+        if self
+            .outbound_rtp_delay
+            .as_ref()
+            .is_some_and(OutboundRtpDelay::is_complete)
+        {
+            self.outbound_rtp_delay = None;
+        }
+        Some(())
+    }
+
+    fn schedule_delayed_outbound_rtp(
+        &mut self,
+        now: Instant,
+        transmit: Transmit,
+    ) -> Option<Transmit> {
+        let Some(delay) = self.outbound_rtp_delay.as_mut() else {
+            return Some(transmit);
+        };
+        let Some(selector) = delay.selector else {
+            return Some(transmit);
+        };
+        let Some(header) = rtp::parse_muxed_rtp_fixed_header(transmit.contents.as_ref()) else {
+            return Some(transmit);
+        };
+        if !selector.matches(header.payload_type(), header.ssrc().value()) {
+            return Some(transmit);
+        }
+        let datagram = PendingOutboundDatagram {
+            destination: transmit.destination,
+            contents: Bytes::from(Vec::from(transmit.contents)),
+        };
+        delay.push(now, datagram);
+        None
+    }
+
     fn intercept_selected_rtp(&mut self, direction: RtcTraceDirection, packet: &[u8]) -> bool {
         let Some(packet) =
             dropped_rtp_packet(direction, packet, self.transport_sequence_extension_id)
@@ -551,7 +665,7 @@ impl FakeRtcPeer {
             RtcTraceDirection::Tx => self.outbound_rtp_hold,
             RtcTraceDirection::Rx => self.drop_next_inbound_rtp,
         };
-        if !selected.is_some_and(|selector| selector.matches(&packet)) {
+        if !selected.is_some_and(|selector| selector.matches(packet.payload_type, packet.ssrc)) {
             return false;
         }
         if direction == RtcTraceDirection::Rx {
@@ -727,8 +841,47 @@ fn dropped_rtp_packet(
 }
 
 impl RtpSelector {
-    fn matches(self, packet: &DroppedRtpPacket) -> bool {
-        self.payload_type == packet.payload_type && self.ssrc == packet.ssrc
+    fn matches(self, payload_type: u8, ssrc: u32) -> bool {
+        self.payload_type == payload_type && self.ssrc == ssrc
+    }
+}
+
+impl OutboundRtpDelay {
+    fn new(selector: RtpSelector, delay: Duration) -> Self {
+        Self {
+            selector: Some(selector),
+            pending: Netem::new(NetemConfig::new().latency(delay)),
+        }
+    }
+
+    fn push(&mut self, now: Instant, datagram: PendingOutboundDatagram) {
+        self.selector = None;
+        self.pending.handle_input(NetemInput::Packet(now, datagram));
+    }
+
+    fn pop_due(&mut self, now: Instant) -> Option<PendingOutboundDatagram> {
+        if self.pending.is_empty() || self.pending.poll_timeout() > now {
+            return None;
+        }
+        self.pending.handle_input(NetemInput::Timeout(now));
+        match self.pending.poll_output() {
+            Some(NetemOutput::Packet(datagram)) => Some(datagram),
+            Some(NetemOutput::Timeout(_)) | None => None,
+        }
+    }
+
+    fn next_timeout(&self) -> Option<Instant> {
+        (!self.pending.is_empty()).then(|| self.pending.poll_timeout())
+    }
+
+    fn is_complete(&self) -> bool {
+        self.selector.is_none() && self.pending.is_empty()
+    }
+}
+
+impl AsRef<[u8]> for PendingOutboundDatagram {
+    fn as_ref(&self) -> &[u8] {
+        &self.contents
     }
 }
 

--- a/tests/src/support/protocol_full_stack.rs
+++ b/tests/src/support/protocol_full_stack.rs
@@ -310,6 +310,24 @@ impl ProtocolFakePeer {
         self.rtc_peer.clear_outbound_rtp_hold();
     }
 
+    pub fn try_delay_next_outbound_rtp(
+        &mut self,
+        payload_type: u8,
+        ssrc: u32,
+        delay: Duration,
+    ) -> bool {
+        self.rtc_peer
+            .try_delay_next_outbound_rtp(payload_type, ssrc, delay)
+    }
+
+    pub fn has_delayed_outbound_rtp(&self) -> bool {
+        self.rtc_peer.has_delayed_outbound_rtp()
+    }
+
+    pub async fn release_delayed_outbound_rtp(&mut self) -> Option<()> {
+        self.rtc_peer.release_delayed_outbound_rtp().await
+    }
+
     pub fn drop_next_inbound_rtp(&mut self, payload_type: u8, ssrc: u32) {
         self.rtc_peer.drop_next_inbound_rtp(payload_type, ssrc);
     }


### PR DESCRIPTION
NACK/RTX recovery starts from a sequence gap, but a gap does not always mean permanent loss. Link-layer retransmission, unequal path delay or queue inversion can let the original RTP packet arrive after its RTX repair. The full-stack harness needs to reproduce that ordering on the real UDP path so recovery is tested against the event order seen in production.

Add `str0m-netem` as a test-only dependency and integrate a outbound RTP delay into FakeRtcPeer. Later RTP packets, RTCP feedback and RTX remain deliverable while the selected primary packet is queued.

Add a full-stack VP8 scenario that proves O-SFU NACKs the exact missing sequence number, accepts the matching RTX payload and recovers media before the original packet is released. It then verifies that the late primary does not surface as duplicate media at the subscriber.

This provides a deterministic network impairment base for follow-up loss, jitter and reordering cases (will implement them later).

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
