### PR TITLE
[IMP] verification: strengthen Kani proofs

### DIFF
--- a/.github/workflows/formal-verification-pr.yml
+++ b/.github/workflows/formal-verification-pr.yml
@@ -5,13 +5,11 @@ on:
     branches: [main, master]
     paths:
       - .github/actions/setup-rust/**
-      - .github/workflows/formal-verification.yml
-      - .github/workflows/formal-verification-pr.yml
-      - Cargo.lock
-      - Cargo.toml
+      - .github/workflows/formal-verification*.yml
       - rust-toolchain.toml
-      - crates/rfc/**
-      - tests/proofs/**
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
 
 permissions:
   contents: read
@@ -21,30 +19,90 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  KANI_VERSION: 0.67.0
+  # Kani 0.67 uses rustc 1.93, which rejects o-sfu-core's rust-version = 1.95.
+  # Remove KANI_REV and prepare-kani once a Kani release can compile o-sfu-core.
+  KANI_REV: 101f81401da8fffcefcb4d87305c6c7c4073badf
 
 jobs:
+  prepare-kani:
+    name: Build pinned Kani
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      bundle_sha256: ${{ steps.checksums.outputs.bundle_sha256 }}
+      installer_sha256: ${{ steps.checksums.outputs.installer_sha256 }}
+    steps:
+      - name: Checkout Kani
+        # actions/checkout v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          repository: model-checking/kani
+          ref: ${{ env.KANI_REV }}
+          persist-credentials: false
+
+      - name: Verify Kani revision
+        run: test "$(git rev-parse HEAD)" = "$KANI_REV"
+
+      - name: Install Kani build dependencies
+        uses: ./.github/actions/setup
+        with:
+          os: ubuntu-24.04
+
+      - name: Build Kani bundle and installer
+        run: |
+          set -euo pipefail
+          cargo bundle -- source
+          cargo package --locked -p kani-verifier
+          mv target/package/kani-verifier-*.crate kani-verifier.crate
+
+      - name: Record Kani bundle checksums
+        id: checksums
+        run: |
+          set -euo pipefail
+          sha256sum kani-source-x86_64-unknown-linux-gnu.tar.gz \
+            | awk '{ print "bundle_sha256=" $1 }' >> "$GITHUB_OUTPUT"
+          sha256sum kani-verifier.crate \
+            | awk '{ print "installer_sha256=" $1 }' >> "$GITHUB_OUTPUT"
+
+      - name: Upload Kani bundle
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kani-${{ env.KANI_REV }}-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            kani-source-x86_64-unknown-linux-gnu.tar.gz
+            kani-verifier.crate
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   kani-pr:
     name: PR Kani (${{ matrix.shard }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    needs: prepare-kani
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - shard: rfc-h264
-            command: >-
-              cargo kani -p o-sfu-proofs
-              --harness h264_profile_level_id_parse_matches_rfc_patterns
+            package: o-sfu-proofs
+            harness: h264_profile_level_id_parse_matches_rfc_patterns
+            timeout_minutes: 20
           - shard: rfc-vp8
+            package: o-sfu-proofs
+            harness: vp8_keyframe_prefix_matches_rfc_model
             covers: 11
-            command: >-
-              cargo kani -p o-sfu-proofs
-              --harness vp8_keyframe_prefix_matches_rfc_model
+            timeout_minutes: 30
+          - shard: core-vp8-identity
+            package: o-sfu-core
+            harness: vp8_identity_projection_matches_modular_model
+            covers: 10
+            timeout_minutes: 30
 
     steps:
       - name: Checkout repository
-        # actions/checkout v5
+        # actions/checkout v7.0.0
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
@@ -55,56 +113,53 @@ jobs:
       - name: Cache Rust build artifacts
         # Swatinem/rust-cache v2
         uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16
-
-      - name: Cache Kani installation
-        # actions/cache v5
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          path: ~/.kani
-          key: ${{ runner.os }}-${{ runner.arch }}-kani-${{ env.KANI_VERSION }}
+          key: kani-${{ env.KANI_REV }}
+          cache-bin: false
 
-      - name: Install Kani CLI
-        run: cargo install --locked --version "$KANI_VERSION" kani-verifier
+      - name: Download Kani bundle
+        # actions/download-artifact v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        with:
+          name: kani-${{ env.KANI_REV }}-${{ runner.os }}-${{ runner.arch }}
+          path: ${{ runner.temp }}/kani-artifact
 
-      - name: Bootstrap Kani release bundle
-        shell: bash
+      - name: Verify Kani bundle checksums
+        env:
+          KANI_BUNDLE_SHA256: ${{ needs.prepare-kani.outputs.bundle_sha256 }}
+          KANI_INSTALLER_SHA256: ${{ needs.prepare-kani.outputs.installer_sha256 }}
         run: |
           set -euo pipefail
+          cd "$RUNNER_TEMP/kani-artifact"
+          printf '%s  %s\n' \
+            "$KANI_BUNDLE_SHA256" kani-source-x86_64-unknown-linux-gnu.tar.gz \
+            "$KANI_INSTALLER_SHA256" kani-verifier.crate \
+            | sha256sum --check --strict
 
-          kani_dir="$HOME/.kani/kani-${KANI_VERSION}"
-          if [[ -f "$kani_dir/rust-toolchain-version" ]]; then
-            exit 0
-          fi
-
-          case "$(uname -m)" in
-            x86_64)
-              target="x86_64-unknown-linux-gnu"
-              ;;
-            aarch64 | arm64)
-              target="aarch64-unknown-linux-gnu"
-              ;;
-            *)
-              echo "Unsupported runner architecture for Kani: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          bundle="kani-${KANI_VERSION}-${target}.tar.gz"
-          url="https://github.com/model-checking/kani/releases/download/kani-${KANI_VERSION}/${bundle}"
-
-          rm -rf "$kani_dir"
-          curl --retry 5 --retry-delay 5 --retry-all-errors -sSLf \
-            -o "$RUNNER_TEMP/$bundle" \
-            "$url"
-          cargo-kani setup --use-local-bundle "$RUNNER_TEMP/$bundle"
+      - name: Install pinned Kani
+        run: |
+          set -euo pipefail
+          installer_dir="$RUNNER_TEMP/kani-installer"
+          mkdir -p "$installer_dir"
+          tar --extract --gzip \
+            --file "$RUNNER_TEMP/kani-artifact/kani-verifier.crate" \
+            --directory "$installer_dir" \
+            --strip-components=1
+          cargo install --locked --force --path "$installer_dir"
+          cargo kani setup --use-local-bundle \
+            "$RUNNER_TEMP/kani-artifact/kani-source-x86_64-unknown-linux-gnu.tar.gz"
+          cargo kani --version --verbose
 
       - name: Run PR Kani proof shard
         env:
           EXPECTED_COVERS: ${{ matrix.covers || 0 }}
+          KANI_HARNESS: ${{ matrix.harness }}
+          KANI_PACKAGE: ${{ matrix.package }}
         run: |
           set -euo pipefail
           output="$(mktemp)"
-          ${{ matrix.command }} 2>&1 | tee "$output"
+          cargo kani --package "$KANI_PACKAGE" --lib \
+            --harness "$KANI_HARNESS" --output-format terse 2>&1 | tee "$output"
           if (( EXPECTED_COVERS > 0 )) && \
             ! grep -Fq "** $EXPECTED_COVERS of $EXPECTED_COVERS cover properties satisfied" "$output"
           then

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -2,7 +2,7 @@ name: Formal Verification
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '17 1 * * *'
   workflow_dispatch:
 
 permissions:
@@ -13,30 +13,90 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  KANI_VERSION: 0.67.0
+  # Kani 0.67 uses rustc 1.93, which rejects o-sfu-core's rust-version = 1.95.
+  # Remove KANI_REV and prepare-kani once a Kani release can compile o-sfu-core.
+  KANI_REV: 101f81401da8fffcefcb4d87305c6c7c4073badf
 
 jobs:
+  prepare-kani:
+    name: Build pinned Kani
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      bundle_sha256: ${{ steps.checksums.outputs.bundle_sha256 }}
+      installer_sha256: ${{ steps.checksums.outputs.installer_sha256 }}
+    steps:
+      - name: Checkout Kani
+        # actions/checkout v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          repository: model-checking/kani
+          ref: ${{ env.KANI_REV }}
+          persist-credentials: false
+
+      - name: Verify Kani revision
+        run: test "$(git rev-parse HEAD)" = "$KANI_REV"
+
+      - name: Install Kani build dependencies
+        uses: ./.github/actions/setup
+        with:
+          os: ubuntu-24.04
+
+      - name: Build Kani bundle and installer
+        run: |
+          set -euo pipefail
+          cargo bundle -- source
+          cargo package --locked -p kani-verifier
+          mv target/package/kani-verifier-*.crate kani-verifier.crate
+
+      - name: Record Kani bundle checksums
+        id: checksums
+        run: |
+          set -euo pipefail
+          sha256sum kani-source-x86_64-unknown-linux-gnu.tar.gz \
+            | awk '{ print "bundle_sha256=" $1 }' >> "$GITHUB_OUTPUT"
+          sha256sum kani-verifier.crate \
+            | awk '{ print "installer_sha256=" $1 }' >> "$GITHUB_OUTPUT"
+
+      - name: Upload Kani bundle
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kani-${{ env.KANI_REV }}-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            kani-source-x86_64-unknown-linux-gnu.tar.gz
+            kani-verifier.crate
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   kani:
     name: Kani (${{ matrix.shard }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    needs: prepare-kani
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - shard: rfc-h264
-            command: >-
-              cargo kani -p o-sfu-proofs
-              --harness h264_profile_level_id_parse_matches_rfc_patterns
+            package: o-sfu-proofs
+            harness: h264_profile_level_id_parse_matches_rfc_patterns
+            timeout_minutes: 20
           - shard: rfc-vp8
+            package: o-sfu-proofs
+            harness: vp8_keyframe_prefix_matches_rfc_model
             covers: 11
-            command: >-
-              cargo kani -p o-sfu-proofs
-              --harness vp8_keyframe_prefix_matches_rfc_model
+            timeout_minutes: 30
+          - shard: core-vp8-identity
+            package: o-sfu-core
+            harness: vp8_identity_projection_matches_modular_model
+            covers: 10
+            timeout_minutes: 30
 
     steps:
       - name: Checkout repository
-        # actions/checkout v5
+        # actions/checkout v7.0.0
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
@@ -47,56 +107,53 @@ jobs:
       - name: Cache Rust build artifacts
         # Swatinem/rust-cache v2
         uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16
-
-      - name: Cache Kani installation
-        # actions/cache v5
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          path: ~/.kani
-          key: ${{ runner.os }}-${{ runner.arch }}-kani-${{ env.KANI_VERSION }}
+          key: kani-${{ env.KANI_REV }}
+          cache-bin: false
 
-      - name: Install Kani CLI
-        run: cargo install --locked --version "$KANI_VERSION" kani-verifier
+      - name: Download Kani bundle
+        # actions/download-artifact v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        with:
+          name: kani-${{ env.KANI_REV }}-${{ runner.os }}-${{ runner.arch }}
+          path: ${{ runner.temp }}/kani-artifact
 
-      - name: Bootstrap Kani release bundle
-        shell: bash
+      - name: Verify Kani bundle checksums
+        env:
+          KANI_BUNDLE_SHA256: ${{ needs.prepare-kani.outputs.bundle_sha256 }}
+          KANI_INSTALLER_SHA256: ${{ needs.prepare-kani.outputs.installer_sha256 }}
         run: |
           set -euo pipefail
+          cd "$RUNNER_TEMP/kani-artifact"
+          printf '%s  %s\n' \
+            "$KANI_BUNDLE_SHA256" kani-source-x86_64-unknown-linux-gnu.tar.gz \
+            "$KANI_INSTALLER_SHA256" kani-verifier.crate \
+            | sha256sum --check --strict
 
-          kani_dir="$HOME/.kani/kani-${KANI_VERSION}"
-          if [[ -f "$kani_dir/rust-toolchain-version" ]]; then
-            exit 0
-          fi
-
-          case "$(uname -m)" in
-            x86_64)
-              target="x86_64-unknown-linux-gnu"
-              ;;
-            aarch64 | arm64)
-              target="aarch64-unknown-linux-gnu"
-              ;;
-            *)
-              echo "Unsupported runner architecture for Kani: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          bundle="kani-${KANI_VERSION}-${target}.tar.gz"
-          url="https://github.com/model-checking/kani/releases/download/kani-${KANI_VERSION}/${bundle}"
-
-          rm -rf "$kani_dir"
-          curl --retry 5 --retry-delay 5 --retry-all-errors -sSLf \
-            -o "$RUNNER_TEMP/$bundle" \
-            "$url"
-          cargo-kani setup --use-local-bundle "$RUNNER_TEMP/$bundle"
+      - name: Install pinned Kani
+        run: |
+          set -euo pipefail
+          installer_dir="$RUNNER_TEMP/kani-installer"
+          mkdir -p "$installer_dir"
+          tar --extract --gzip \
+            --file "$RUNNER_TEMP/kani-artifact/kani-verifier.crate" \
+            --directory "$installer_dir" \
+            --strip-components=1
+          cargo install --locked --force --path "$installer_dir"
+          cargo kani setup --use-local-bundle \
+            "$RUNNER_TEMP/kani-artifact/kani-source-x86_64-unknown-linux-gnu.tar.gz"
+          cargo kani --version --verbose
 
       - name: Run Kani proofs
         env:
           EXPECTED_COVERS: ${{ matrix.covers || 0 }}
+          KANI_HARNESS: ${{ matrix.harness }}
+          KANI_PACKAGE: ${{ matrix.package }}
         run: |
           set -euo pipefail
           output="$(mktemp)"
-          ${{ matrix.command }} 2>&1 | tee "$output"
+          cargo kani --package "$KANI_PACKAGE" --lib \
+            --harness "$KANI_HARNESS" --output-format terse 2>&1 | tee "$output"
           if (( EXPECTED_COVERS > 0 )) && \
             ! grep -Fq "** $EXPECTED_COVERS of $EXPECTED_COVERS cover properties satisfied" "$output"
           then

--- a/crates/core/src/engine/media_transport/rtc/codec/PROOFS/vp8.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/PROOFS/vp8.rs
@@ -1,0 +1,295 @@
+use std::fmt::Debug;
+
+use super::{CounterProjection, Identity, Projection};
+
+const PICTURE_ID_MODULUS: u32 = 1 << 15;
+const PICTURE_ID_MASK: u16 = 0x7fff;
+const TL0_PIC_IDX_MODULUS: u32 = 1 << 8;
+
+/// `Anchored` omits `CounterProjection::Anchored::last` because every reachable
+/// anchored state has `last == dst_anchor`. `snapshot` checks that invariant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModelState<T> {
+    Empty,
+    LastOnly(T),
+    Anchored { src_anchor: T, dst_anchor: T },
+}
+
+impl<T> ModelState<T> {
+    fn map<U>(self, mut map: impl FnMut(T) -> U) -> ModelState<U> {
+        match self {
+            Self::Empty => ModelState::Empty,
+            Self::LastOnly(last) => ModelState::LastOnly(map(last)),
+            Self::Anchored {
+                src_anchor,
+                dst_anchor,
+            } => ModelState::Anchored {
+                src_anchor: map(src_anchor),
+                dst_anchor: map(dst_anchor),
+            },
+        }
+    }
+}
+
+struct ModelTransition {
+    output: Option<u32>,
+    state: ModelState<u32>,
+}
+
+/// Proves `Projection::project` and `Projection::reanchor` for every reachable
+/// combination of PictureID and TL0PICIDX state.
+///
+/// `reach_state` constructs each stored state through `Projection` calls. The
+/// proof applies one arbitrary call then compares its returned counters and
+/// stored state with a widened modular model. `Projection::default` satisfies
+/// the model and every call preserves it, so the property holds after any
+/// finite sequence of direct calls.
+///
+/// The proof excludes descriptor parsing and patching, the caller's reanchor
+/// decision and whether an outer RTP projection commits the result.
+#[kani::proof]
+fn vp8_identity_projection_matches_modular_model() {
+    let default = Projection::default();
+    assert_eq!(snapshot(default.picture_id), ModelState::Empty);
+    assert_eq!(snapshot(default.tl0_pic_idx), ModelState::Empty);
+
+    let picture_state = arbitrary_picture_state();
+    let tl0_state = arbitrary_tl0_state();
+    let mut projection = reach_state(picture_state, tl0_state);
+    let reanchor = kani::any::<bool>();
+    let identity = Identity {
+        picture_id: kani::any::<bool>().then(arbitrary_picture_id),
+        tl0_pic_idx: kani::any::<bool>().then(kani::any::<u8>),
+    };
+
+    let expected_picture = model_transition(
+        picture_state.map(u32::from),
+        identity.picture_id.map(u32::from),
+        reanchor,
+        PICTURE_ID_MODULUS,
+    );
+    let expected_tl0 = model_transition(
+        tl0_state.map(u32::from),
+        identity.tl0_pic_idx.map(u32::from),
+        reanchor,
+        TL0_PIC_IDX_MODULUS,
+    );
+    let projected = if reanchor {
+        projection.reanchor(identity)
+    } else {
+        projection.project(identity)
+    };
+
+    assert_eq!(projected.picture_id.map(u32::from), expected_picture.output);
+    assert_eq!(projected.tl0_pic_idx.map(u32::from), expected_tl0.output);
+    assert_eq!(
+        snapshot(projection.picture_id).map(u32::from),
+        expected_picture.state
+    );
+    assert_eq!(
+        snapshot(projection.tl0_pic_idx).map(u32::from),
+        expected_tl0.state
+    );
+
+    let both_present = identity.picture_id.is_some() && identity.tl0_pic_idx.is_some();
+    let both_absent = identity.picture_id.is_none() && identity.tl0_pic_idx.is_none();
+    let both_empty =
+        matches!(picture_state, ModelState::Empty) && matches!(tl0_state, ModelState::Empty);
+    let both_anchored = matches!(picture_state, ModelState::Anchored { .. })
+        && matches!(tl0_state, ModelState::Anchored { .. });
+    let both_last_only = matches!(picture_state, ModelState::LastOnly(_))
+        && matches!(tl0_state, ModelState::LastOnly(_));
+
+    kani::cover!(!reanchor && both_empty && both_present, "first observation");
+    kani::cover!(
+        !reanchor && both_anchored && both_present,
+        "anchored continuation"
+    );
+    kani::cover!(
+        reanchor && both_anchored && both_present,
+        "anchored source switch"
+    );
+    kani::cover!(
+        reanchor && both_anchored && both_absent,
+        "reanchor with absent counters"
+    );
+    kani::cover!(
+        !reanchor && both_last_only && both_present,
+        "resume after absent counters"
+    );
+    kani::cover!(
+        !reanchor
+            && both_anchored
+            && identity.picture_id.is_none()
+            && identity.tl0_pic_idx.is_some(),
+        "PictureID absent with TL0PICIDX present"
+    );
+    kani::cover!(
+        !reanchor
+            && both_anchored
+            && identity.picture_id.is_some()
+            && identity.tl0_pic_idx.is_none(),
+        "TL0PICIDX absent with PictureID present"
+    );
+    kani::cover!(
+        matches!(picture_state, ModelState::LastOnly(PICTURE_ID_MASK))
+            && identity.picture_id.is_some()
+            && projected.picture_id == Some(0),
+        "PictureID destination rollover"
+    );
+    kani::cover!(
+        matches!(tl0_state, ModelState::LastOnly(u8::MAX))
+            && identity.tl0_pic_idx.is_some()
+            && projected.tl0_pic_idx == Some(0),
+        "TL0PICIDX destination rollover"
+    );
+    kani::cover!(
+        !reanchor
+            && matches!(
+                picture_state,
+                ModelState::Anchored {
+                    src_anchor: PICTURE_ID_MASK,
+                    ..
+                }
+            )
+            && identity.picture_id == Some(0),
+        "PictureID source rollover"
+    );
+}
+
+/// Reaches every `ModelState` pair through `Projection` calls.
+///
+/// The proof never assigns `CounterProjection` directly. Empty fields remain
+/// absent. Last-only fields observe a value then lose their source anchor.
+/// Anchored fields resume from the predecessor of their target destination so
+/// the final projection lands on the requested anchor.
+fn reach_state(picture_state: ModelState<u16>, tl0_state: ModelState<u8>) -> Projection {
+    let mut projection = Projection::default();
+    let _ = projection.project(Identity {
+        picture_id: first_input(picture_state, picture_predecessor),
+        tl0_pic_idx: first_input(tl0_state, tl0_predecessor),
+    });
+    let _ = projection.reanchor(Identity::default());
+    let _ = projection.project(Identity {
+        picture_id: final_input(picture_state),
+        tl0_pic_idx: final_input(tl0_state),
+    });
+
+    assert_eq!(snapshot(projection.picture_id), picture_state);
+    assert_eq!(snapshot(projection.tl0_pic_idx), tl0_state);
+    projection
+}
+
+fn arbitrary_picture_state() -> ModelState<u16> {
+    match kani::any::<u8>() % 3 {
+        0 => ModelState::Empty,
+        1 => ModelState::LastOnly(arbitrary_picture_id()),
+        _ => ModelState::Anchored {
+            src_anchor: arbitrary_picture_id(),
+            dst_anchor: arbitrary_picture_id(),
+        },
+    }
+}
+
+fn arbitrary_tl0_state() -> ModelState<u8> {
+    match kani::any::<u8>() % 3 {
+        0 => ModelState::Empty,
+        1 => ModelState::LastOnly(kani::any()),
+        _ => ModelState::Anchored {
+            src_anchor: kani::any(),
+            dst_anchor: kani::any(),
+        },
+    }
+}
+
+fn arbitrary_picture_id() -> u16 {
+    kani::any::<u16>() & PICTURE_ID_MASK
+}
+
+fn first_input<T>(state: ModelState<T>, predecessor: impl FnOnce(T) -> T) -> Option<T> {
+    match state {
+        ModelState::Empty => None,
+        ModelState::LastOnly(last) => Some(last),
+        ModelState::Anchored { dst_anchor, .. } => Some(predecessor(dst_anchor)),
+    }
+}
+
+fn final_input<T>(state: ModelState<T>) -> Option<T> {
+    match state {
+        ModelState::Anchored { src_anchor, .. } => Some(src_anchor),
+        ModelState::Empty | ModelState::LastOnly(_) => None,
+    }
+}
+
+fn picture_predecessor(value: u16) -> u16 {
+    if value == 0 {
+        PICTURE_ID_MASK
+    } else {
+        value - 1
+    }
+}
+
+fn tl0_predecessor(value: u8) -> u8 {
+    value.wrapping_sub(1)
+}
+
+fn snapshot<T: Debug + PartialEq>(state: CounterProjection<T>) -> ModelState<T> {
+    match state {
+        CounterProjection::Empty => ModelState::Empty,
+        CounterProjection::LastOnly(last) => ModelState::LastOnly(last),
+        CounterProjection::Anchored {
+            src_anchor,
+            dst_anchor,
+            last,
+        } => {
+            assert_eq!(last, dst_anchor);
+            ModelState::Anchored {
+                src_anchor,
+                dst_anchor,
+            }
+        }
+    }
+}
+
+fn model_transition(
+    state: ModelState<u32>,
+    source: Option<u32>,
+    reanchor: bool,
+    modulus: u32,
+) -> ModelTransition {
+    let Some(source) = source else {
+        let state = match (reanchor, state) {
+            (true, ModelState::Anchored { dst_anchor, .. }) => ModelState::LastOnly(dst_anchor),
+            (_, state) => state,
+        };
+        return ModelTransition {
+            output: None,
+            state,
+        };
+    };
+
+    let destination = match state {
+        ModelState::Anchored { dst_anchor, .. } if reanchor => successor(dst_anchor, modulus),
+        ModelState::Anchored {
+            src_anchor,
+            dst_anchor,
+        } => translated(source, src_anchor, dst_anchor, modulus),
+        ModelState::LastOnly(last) => successor(last, modulus),
+        ModelState::Empty => source,
+    };
+    ModelTransition {
+        output: Some(destination),
+        state: ModelState::Anchored {
+            src_anchor: source,
+            dst_anchor: destination,
+        },
+    }
+}
+
+fn successor(value: u32, modulus: u32) -> u32 {
+    (value + 1) % modulus
+}
+
+fn translated(source: u32, src_anchor: u32, dst_anchor: u32, modulus: u32) -> u32 {
+    (dst_anchor + modulus + source - src_anchor) % modulus
+}

--- a/crates/core/src/engine/media_transport/rtc/codec/vp8.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/vp8.rs
@@ -271,6 +271,10 @@ impl From<Vp8Descriptor> for Identity {
     }
 }
 
+#[cfg(kani)]
+#[path = "PROOFS/vp8.rs"]
+mod proofs;
+
 #[cfg(test)]
 #[path = "TESTS/vp8.rs"]
 mod tests;

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,33 @@ run one target explicitly:
 cargo +nightly-2026-04-01 fuzz run --fuzz-dir tests/fuzz --features fuzz-targets protocol_decode
 ```
 
+## Formal verification
+
+`o-sfu-proofs` is a dependency leaf for proofs over public production APIs.
+Proofs that require private state belong in a `PROOFS/` directory beside the
+owning module behind `cfg(kani)`. Add a module-local proof to CI only when the
+pinned Kani build can compile that crate.
+
+Production crates never depend on `o-sfu-proofs`. CI selects Cargo packages and
+harnesses without including production source or naming source files.
+
+```bash
+cargo kani --package o-sfu-proofs --lib \
+  --harness h264_profile_level_id_parse_matches_rfc_patterns
+
+cargo kani --package o-sfu-proofs --lib \
+  --harness vp8_keyframe_prefix_matches_rfc_model
+
+cargo kani --package o-sfu-core --lib \
+  --harness vp8_identity_projection_matches_modular_model
+```
+
+CI builds its Rust 1.95-compatible Kani toolchain from an exact upstream
+revision until that compiler support is available in a Kani release.
+
+Run Kani in CI unless a proof is under local development. Ordinary Cargo
+commands do not execute solver harnesses.
+
 ## Callgrind benchmarks
 
 There are four comparison targets. Each scenario is documented once, on its

--- a/tests/proofs/Cargo.toml
+++ b/tests/proofs/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.93"
 version.workspace = true
 
 [dependencies]
-o-sfu-rfc = { path = "../../crates/rfc" }
+o-sfu-rfc.workspace = true
 
 [lints]
 workspace = true

--- a/tests/proofs/src/rfc/h264.rs
+++ b/tests/proofs/src/rfc/h264.rs
@@ -2,9 +2,11 @@ use o_sfu_rfc::rtp::h264::{LevelIdc, Profile, ProfileLevelId};
 
 const CONSTRAINT_SET3_FLAG: u8 = 0x10;
 
-/// Proves the full 24-bit `profile-level-id` space against an independent
-/// RFC-shaped model. Profile parsing feeds every later H264 compatibility
-/// decision while unit tests can only sample the accepted and rejected space.
+/// Proves every 24-bit value encoded as six lowercase ASCII hexadecimal bytes
+/// against an independent RFC 6184 profile and level model. Alternate and
+/// malformed ASCII encodings are outside this proof. Profile parsing feeds
+/// every later H264 compatibility decision while unit tests can only sample
+/// accepted and rejected values.
 #[kani::proof]
 fn h264_profile_level_id_parse_matches_rfc_patterns() {
     let raw = kani::any::<u32>() & 0x00FF_FFFF;
@@ -14,25 +16,24 @@ fn h264_profile_level_id_parse_matches_rfc_patterns() {
     let expected = spec_profile_from_bytes(bytes[1], bytes[2])
         .zip(spec_normalized_level_idc(bytes[1], bytes[2], bytes[3]));
 
-    assert_eq!(parsed.is_some(), expected.is_some());
-    if let (Some(parsed), Some((profile, level))) = (parsed, expected) {
-        assert_eq!(parsed.profile(), profile);
-        assert_eq!(parsed.level(), level);
-    }
+    assert_eq!(
+        parsed.map(|parsed| (parsed.profile(), parsed.level())),
+        expected
+    );
 }
 
 fn hex_profile_level_id(raw: u32) -> [u8; 6] {
     [
-        hex_byte(((raw >> 20) & 0x0F) as u8),
-        hex_byte(((raw >> 16) & 0x0F) as u8),
-        hex_byte(((raw >> 12) & 0x0F) as u8),
-        hex_byte(((raw >> 8) & 0x0F) as u8),
-        hex_byte(((raw >> 4) & 0x0F) as u8),
-        hex_byte((raw & 0x0F) as u8),
+        lower_hex_digit(((raw >> 20) & 0x0F) as u8),
+        lower_hex_digit(((raw >> 16) & 0x0F) as u8),
+        lower_hex_digit(((raw >> 12) & 0x0F) as u8),
+        lower_hex_digit(((raw >> 8) & 0x0F) as u8),
+        lower_hex_digit(((raw >> 4) & 0x0F) as u8),
+        lower_hex_digit((raw & 0x0F) as u8),
     ]
 }
 
-fn hex_byte(nibble: u8) -> u8 {
+fn lower_hex_digit(nibble: u8) -> u8 {
     match nibble {
         0..=9 => b'0' + nibble,
         10..=15 => b'a' + (nibble - 10),

--- a/tests/proofs/src/rfc/vp8.rs
+++ b/tests/proofs/src/rfc/vp8.rs
@@ -27,7 +27,7 @@ fn vp8_keyframe_prefix_matches_rfc_model() {
     let payload = &prefix[..payload_len];
 
     let actual = production::payload_starts_keyframe(payload);
-    let frame = spec_frame(payload);
+    let frame = model_frame_payload(payload);
     let expected = frame.is_some_and(is_keyframe_prefix);
     let descriptor = payload.first().copied().unwrap_or_default();
     let extension = payload.get(1).copied().unwrap_or_default();
@@ -84,7 +84,7 @@ fn vp8_keyframe_prefix_matches_rfc_model() {
     kani::cover!(
         frame.is_some_and(|frame| {
             has_complete_prefix(frame)
-                && has_defined_keyframe_tag(frame)
+                && has_keyframe_type_and_defined_version(frame)
                 && !has_start_code(frame)
                 && has_nonzero_dimensions(frame)
         }) && !actual,
@@ -93,7 +93,7 @@ fn vp8_keyframe_prefix_matches_rfc_model() {
     kani::cover!(
         frame.is_some_and(|frame| {
             has_complete_prefix(frame)
-                && has_defined_keyframe_tag(frame)
+                && has_keyframe_type_and_defined_version(frame)
                 && has_start_code(frame)
                 && !has_nonzero_dimensions(frame)
         }) && !actual,
@@ -115,7 +115,7 @@ fn vp8_keyframe_prefix_matches_rfc_model() {
 ///
 /// The offset follows only the advertised descriptor fields so shared parser
 /// control flow cannot make the equivalence assertion pass by construction.
-fn spec_frame(payload: &[u8]) -> Option<&[u8]> {
+fn model_frame_payload(payload: &[u8]) -> Option<&[u8]> {
     let descriptor = *payload.first()?;
     if descriptor & S_BIT == 0 || descriptor & PARTITION_ID_MASK != 0 {
         return None;
@@ -151,7 +151,7 @@ fn spec_frame(payload: &[u8]) -> Option<&[u8]> {
 
 fn is_keyframe_prefix(frame: &[u8]) -> bool {
     has_complete_prefix(frame)
-        && has_defined_keyframe_tag(frame)
+        && has_keyframe_type_and_defined_version(frame)
         && has_start_code(frame)
         && has_nonzero_dimensions(frame)
 }
@@ -160,7 +160,7 @@ fn has_complete_prefix(frame: &[u8]) -> bool {
     frame.len() >= 10
 }
 
-fn has_defined_keyframe_tag(frame: &[u8]) -> bool {
+fn has_keyframe_type_and_defined_version(frame: &[u8]) -> bool {
     frame
         .first()
         .is_some_and(|tag| tag & INTERFRAME_BIT == 0 && (tag & VERSION_MASK) >> 1 <= 3)


### PR DESCRIPTION
Prove H264 profile-level-id parsing for every 24-bit value in canonical lowercase encoding and VP8 keyframe detection across its complete parser decision window against RFC 6184, RFC 7741 and RFC 6386.

Prove VP8 PictureID and TL0PICIDX projection across every reachable state and modular transition, then run each finite model in a pinned Kani shard

RFC 6184: https://www.rfc-editor.org/rfc/rfc6184.html#section-8.1
RFC 7741: https://www.rfc-editor.org/rfc/rfc7741.html#section-4.2
RFC 6386: https://www.rfc-editor.org/rfc/rfc6386.html#section-9.1

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
