### PR TITLE
[IMP] tests: trace late RTP before str0m

### DIFF
--- a/tests/integration/full_stack/nack_recovery.rs
+++ b/tests/integration/full_stack/nack_recovery.rs
@@ -448,7 +448,8 @@ async fn fake_rtc_does_not_forward_late_primary_after_rtx() -> s::TestResult {
         Some(expected_payload.as_slice())
     );
 
-    s::require_some(
+    subscriber.start_rtc_trace();
+    let delivered = s::require_some(
         read_payload(&mut subscriber, &expected_payload, RECOVERY_TIMEOUT).await,
         "subscriber should receive the repaired publisher packet",
     )?;
@@ -457,8 +458,8 @@ async fn fake_rtc_does_not_forward_late_primary_after_rtx() -> s::TestResult {
     // pass without exercising retransmission.
     assert!(publisher.has_delayed_outbound_rtp());
 
-    // A reordered primary may arrive after its RTX repair. The subscriber's
-    // `str0m::Rtc` must not emit a second `Event::RtpPacket` for that payload.
+    // A second datagram with the recovered identity proves O-SFU forwarded the
+    // late primary even when str0m suppresses its duplicate media event.
     s::require_some(
         publisher.release_delayed_outbound_rtp().await,
         "publisher should release the delayed primary packet",
@@ -469,6 +470,12 @@ async fn fake_rtc_does_not_forward_late_primary_after_rtx() -> s::TestResult {
             .await
             .is_none(),
         "subscriber should not receive the late primary after RTX"
+    );
+    let subscriber_trace = subscriber.take_rtc_trace();
+    assert_eq!(
+        matching_inbound_rtp_count(&subscriber_trace, &delivered),
+        1,
+        "subscriber should receive one wire packet for the recovered sequence"
     );
     Ok(())
 }
@@ -1364,9 +1371,26 @@ fn merge_trace(trace: &mut s::RtcPeerTrace, mut next: s::RtcPeerTrace) {
     trace.nacks.append(&mut next.nacks);
     trace.rtp_packets.append(&mut next.rtp_packets);
     trace
+        .inbound_rtp_headers
+        .append(&mut next.inbound_rtp_headers);
+    trace
         .dropped_rtp_packets
         .append(&mut next.dropped_rtp_packets);
     trace.keyframe_requests += next.keyframe_requests;
+}
+
+fn matching_inbound_rtp_count(trace: &s::RtcPeerTrace, packet: &s::ReceivedRtpPacket) -> usize {
+    trace
+        .inbound_rtp_headers
+        .iter()
+        .filter(|header| {
+            header.payload_type() == packet.payload_type
+                && header.sequence_number() == packet.sequence_number
+                && header.timestamp() == packet.timestamp
+                && header.marker() == packet.marker
+                && header.ssrc().value() == packet.ssrc
+        })
+        .count()
 }
 
 fn nack_contains(

--- a/tests/src/support/fake_rtc_peer.rs
+++ b/tests/src/support/fake_rtc_peer.rs
@@ -94,6 +94,7 @@ pub struct DroppedRtpPacket {
 pub struct RtcPeerTrace {
     pub nacks: Vec<TracedNack>,
     pub rtp_packets: Vec<TracedRtpPacket>,
+    pub inbound_rtp_headers: Vec<rtp::RtpFixedHeader>,
     pub dropped_rtp_packets: Vec<DroppedRtpPacket>,
     pub keyframe_requests: usize,
 }
@@ -571,6 +572,13 @@ impl FakeRtcPeer {
                                 continue;
                             }
                             let packet = receive_buffer.get(..received_size)?;
+                            // Trace before `handle_input` because str0m rejects a late primary
+                            // recovered by RTX before `Event::RawPacket` or `Event::RtpPacket`.
+                            if self.trace_enabled
+                                && let Some(header) = rtp::parse_muxed_rtp_fixed_header(packet)
+                            {
+                                self.trace.inbound_rtp_headers.push(header);
+                            }
                             if self.intercept_selected_rtp(RtcTraceDirection::Rx, packet) {
                                 continue;
                             }


### PR DESCRIPTION
<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
