### PR TITLE
[REF] core: remove receiver layout intent wrapper

### DIFF
--- a/crates/core/src/engine/room/media_graph/subscription.rs
+++ b/crates/core/src/engine/room/media_graph/subscription.rs
@@ -222,7 +222,7 @@ impl RoomState {
             );
         };
         VideoAdmissionRank::new(
-            self.receiver_video_layout_intent(target.session.user_id(), source, active_speakers)
+            self.receiver_video_layout_role(target.session.user_id(), source, active_speakers)
                 .priority(),
             None,
             target.source_id,

--- a/crates/core/src/engine/room/read_model.rs
+++ b/crates/core/src/engine/room/read_model.rs
@@ -454,11 +454,11 @@ fn diagnostics_subscriptions(
                    consumer_media: Option<TransportMediaId>,
                    source_media: TransportMediaId,
                    route_state| {
-        let layout = state.diagnostics_video_layout_intent(user_id, source);
+        let layout = state.diagnostics_video_layout_role(user_id, source);
         DiagnosticsSubscription {
             consumer_transport_media_id: consumer_media.map(TransportMediaId::as_u64),
-            layout_priority: layout.map(|intent| intent.priority().into()),
-            layout_role: layout.map(|intent| intent.role().into()),
+            layout_priority: layout.map(|role| role.priority().into()),
+            layout_role: layout.map(Into::into),
             producer_user_id: source.owner().user_id().clone(),
             selection: selection(source, route_selection),
             source_id: source.source_id().as_u64(),

--- a/crates/core/src/engine/room/source_policy/video/input.rs
+++ b/crates/core/src/engine/room/source_policy/video/input.rs
@@ -11,52 +11,10 @@ use crate::{
         room::{media_graph::SubscriptionKey, state::RoomState},
         source_model::{
             ConsumerSourceSelection, PublishedSourceDescriptor, SourceAdaptationPolicy,
-            SourceRoomPolicySelector, SourceRoutePriority,
+            SourceRoomPolicySelector,
         },
     },
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::engine::room) struct ReceiverVideoLayoutIntent {
-    role: SourceRoomPolicySelector,
-}
-
-impl ReceiverVideoLayoutIntent {
-    #[must_use]
-    pub(in crate::engine::room) const fn role(self) -> SourceRoomPolicySelector {
-        self.role
-    }
-
-    #[must_use]
-    pub(in crate::engine::room) const fn priority(self) -> SourceRoutePriority {
-        self.role.priority()
-    }
-
-    #[must_use]
-    pub(super) const fn uses_featured_quality(self) -> bool {
-        self.role.uses_featured_quality()
-    }
-
-    #[must_use]
-    const fn counts_toward_visible_budget(self) -> bool {
-        self.role.counts_toward_visible_budget()
-    }
-
-    #[must_use]
-    fn resolve(
-        source: &PublishedSourceDescriptor,
-        preference: Option<VideoLayoutIntent>,
-        active_speaker: bool,
-    ) -> Self {
-        let role = source
-            .policy()
-            .layout()
-            .map_or(SourceRoomPolicySelector::Hidden, |policy| {
-                policy.resolve(preference, active_speaker)
-            });
-        Self { role }
-    }
-}
 
 pub(super) fn receiver_video_routes<'a>(
     state: &RoomState,
@@ -72,13 +30,13 @@ pub(super) fn receiver_video_routes<'a>(
         {
             continue;
         }
-        let layout_intent = state.receiver_video_layout_intent(
+        let layout_role = state.receiver_video_layout_role(
             &route.key.receiver,
             source,
             &input.featured_source_user_ids,
         );
         if source.policy().adaptation() == SourceAdaptationPolicy::ScalableVideo
-            && layout_intent.counts_toward_visible_budget()
+            && layout_role.counts_toward_visible_budget()
         {
             *visible_scalable_route_counts
                 .entry(route.key.receiver.clone())
@@ -90,7 +48,7 @@ pub(super) fn receiver_video_routes<'a>(
             key: route.key,
             route: route.route,
             current_selection: route.selection,
-            layout_intent,
+            layout_role,
             visible_scalable_route_count: 1,
             active_speaker_rank: input
                 .active_speaker_rank_by_user
@@ -127,7 +85,7 @@ pub(super) struct ReceiverVideoRouteInput<'a> {
     pub(super) key: &'a SubscriptionKey,
     pub(super) route: &'a TransportConsumerRoute,
     pub(super) current_selection: ConsumerSourceSelection,
-    pub(super) layout_intent: ReceiverVideoLayoutIntent,
+    pub(super) layout_role: SourceRoomPolicySelector,
     pub(super) visible_scalable_route_count: usize,
     pub(super) active_speaker_rank: Option<usize>,
     pub(super) receiver_bandwidth: Option<Bitrate>,
@@ -137,37 +95,37 @@ pub(super) struct ReceiverVideoRouteInput<'a> {
 
 impl RoomState {
     #[must_use]
-    pub(in crate::engine::room) fn receiver_video_layout_intent(
+    pub(in crate::engine::room) fn receiver_video_layout_role(
         &self,
         consumer_user_id: &UserId,
         source: &PublishedSourceDescriptor,
         active_speaker_source_user_ids: &BTreeSet<UserId>,
-    ) -> ReceiverVideoLayoutIntent {
+    ) -> SourceRoomPolicySelector {
         let preference = layout_preference(self, consumer_user_id, source);
-        ReceiverVideoLayoutIntent::resolve(
-            source,
-            preference,
-            active_speaker_source_user_ids.contains(source.owner().user_id()),
-        )
+        source
+            .policy()
+            .layout()
+            .map_or(SourceRoomPolicySelector::Hidden, |policy| {
+                policy.resolve(
+                    preference,
+                    active_speaker_source_user_ids.contains(source.owner().user_id()),
+                )
+            })
     }
 
     #[must_use]
-    pub(in crate::engine::room) fn diagnostics_video_layout_intent(
+    pub(in crate::engine::room) fn diagnostics_video_layout_role(
         &self,
         consumer_user_id: &UserId,
         source: &PublishedSourceDescriptor,
-    ) -> Option<ReceiverVideoLayoutIntent> {
-        source.policy().layout()?;
+    ) -> Option<SourceRoomPolicySelector> {
+        let policy = source.policy().layout()?;
         let preference = layout_preference(self, consumer_user_id, source);
         let active_speaker = self
             .users
             .get(source.owner().user_id())
             .is_some_and(|user| user.featured() == Some(true));
-        Some(ReceiverVideoLayoutIntent::resolve(
-            source,
-            preference,
-            active_speaker,
-        ))
+        Some(policy.resolve(preference, active_speaker))
     }
 }
 

--- a/crates/core/src/engine/room/source_policy/video/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/solver.rs
@@ -550,7 +550,7 @@ fn desired_encoding_index(
     if route.user_count < tuning.multiparty_scalable_video_threshold {
         return allowed_encoding_indices(route.source, source_cap).next_back();
     }
-    let uses_featured_quality = route.layout_intent.uses_featured_quality();
+    let uses_featured_quality = route.layout_role.uses_featured_quality();
     let Some(receiver_bandwidth) = route.receiver_bandwidth else {
         return if uses_featured_quality {
             allowed_encoding_indices(route.source, source_cap).next_back()
@@ -670,7 +670,7 @@ fn active_route_count(routes: &[PlannedReceiverRoute<'_>]) -> usize {
 fn video_download_rank(route: &PlannedReceiverRoute<'_>) -> VideoAdmissionRank {
     let input = route.input;
     VideoAdmissionRank::new(
-        input.layout_intent.priority(),
+        input.layout_role.priority(),
         input.active_speaker_rank,
         input.source.source_id(),
     )
@@ -770,15 +770,15 @@ fn route_can_downgrade(route: &PlannedReceiverRoute<'_>) -> bool {
     route.selection.policy_pause_reason.is_none()
         && input.source.policy().adaptation() == SourceAdaptationPolicy::ScalableVideo
         && matches!(
-            input.layout_intent.priority(),
+            input.layout_role.priority(),
             SourceRoutePriority::VisibleThumbnail | SourceRoutePriority::HiddenOrOverflow
         )
 }
 
 fn pause_reason_for_route(route: &PlannedReceiverRoute<'_>) -> PolicyPauseReason {
-    let intent = route.input.layout_intent;
-    match intent.priority() {
-        SourceRoutePriority::HiddenOrOverflow => match intent.role() {
+    let role = route.input.layout_role;
+    match role.priority() {
+        SourceRoutePriority::HiddenOrOverflow => match role {
             SourceRoomPolicySelector::Hidden => PolicyPauseReason::HiddenTile,
             SourceRoomPolicySelector::Overflow => PolicyPauseReason::OverflowTile,
             _ => PolicyPauseReason::BudgetPressure,


### PR DESCRIPTION
`ReceiverVideoLayoutIntent` was a single-field wrapper around `SourceRoomPolicySelector` that only forwarded accessors and added no invariants. Store the selector directly on ReceiverVideoRouteInput as layout_role, and apply the "no policy -> Hidden" default in the intake helper. Diagnostics keep an Option so callers can still tell "no policy configured" from "policy resolved to Hidden".

Fixes [#667](https://github.com/ThanhDodeurOdoo/o-sfu/issues/667)

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
