### PR TITLE
[IMP] config: validate DIAGNOSTICS_AUTH_TOKEN as HTTP header value

### DIFF
--- a/src/config/TESTS/diagnostics.rs
+++ b/src/config/TESTS/diagnostics.rs
@@ -3,7 +3,7 @@ use super::{DiagnosticsConfig, Env};
 #[test]
 fn load_diagnostics_config_accepts_trimmed_bearer_token() -> anyhow::Result<()> {
     let config = DiagnosticsConfig::from_env(&Env::new(|key| match key {
-        "DIAGNOSTICS_AUTH_TOKEN" => Some("  bearer-token  ".to_owned()),
+        "DIAGNOSTICS_AUTH_TOKEN" => Some("  bearer-token  \n".to_owned()),
         _ => None,
     }))?;
     assert_eq!(config.auth_token.as_deref(), Some("bearer-token"));
@@ -23,4 +23,59 @@ fn load_diagnostics_config_rejects_empty_token() {
         error.as_deref(),
         Some("DIAGNOSTICS_AUTH_TOKEN must not be empty")
     );
+}
+
+#[expect(
+    clippy::non_ascii_literal,
+    reason = "test-only Unicode inputs are easier to read and never enter the production interface"
+)]
+#[test]
+fn load_diagnostics_config_rejects_invalid_header_value_tokens() {
+    let invalid_tokens = [
+        "你好 杭州,rust",
+        "token_with_emoji_🔒",
+        "crème_brûlée",
+        "token\r\nwith_newline",
+        "token\nwith_line_feed",
+        "token\rwith_carriage_return",
+        "token\0with_null",
+        "token\x1b[31mwith_ansi",
+    ];
+
+    for invalid_token in invalid_tokens {
+        let env = Env::new(|key| match key {
+            "DIAGNOSTICS_AUTH_TOKEN" => Some(invalid_token.to_owned()),
+            _ => None,
+        });
+
+        let error = DiagnosticsConfig::from_env(&env)
+            .err()
+            .map(|error| error.to_string());
+
+        assert_eq!(
+            error.as_deref(),
+            Some("DIAGNOSTICS_AUTH_TOKEN contains invalid HTTP header-value characters"),
+        );
+    }
+}
+
+#[test]
+fn load_diagnostics_config_accepts_valid_tokens() {
+    let valid_tokens = [
+        "simpletoken123",
+        "bearer_token-v1.0.0",
+        "Secret_Auth_Token!@#$%^&*",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "aW52YWxpZF90b2tlbl9leGFtcGxl==",
+        "token\twith_tab",
+    ];
+    for valid_token in valid_tokens {
+        let env = Env::new(|key| match key {
+            "DIAGNOSTICS_AUTH_TOKEN" => Some(valid_token.to_owned()),
+            _ => None,
+        });
+        let config = DiagnosticsConfig::from_env(&env).ok();
+        let actual_token = config.as_ref().and_then(|c| c.auth_token.as_deref());
+        assert_eq!(actual_token, Some(valid_token));
+    }
 }

--- a/src/config/diagnostics.rs
+++ b/src/config/diagnostics.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use axum::http::HeaderValue;
 
 use super::env::{Env, non_empty};
 
@@ -10,12 +11,18 @@ pub struct DiagnosticsConfig {
 
 impl DiagnosticsConfig {
     pub(super) fn from_env(env: &Env<'_>) -> Result<Self> {
-        Ok(Self {
-            auth_token: env
-                .var("DIAGNOSTICS_AUTH_TOKEN")
-                .check(non_empty)
-                .optional()?,
-        })
+        let auth_token = env
+            .var("DIAGNOSTICS_AUTH_TOKEN")
+            .check(non_empty)
+            .check(|key, value| {
+                anyhow::ensure!(
+                    HeaderValue::try_from(&value).is_ok() && value.is_ascii(),
+                    "{key} contains invalid HTTP header-value characters"
+                );
+                Ok(value)
+            })
+            .optional()?;
+        Ok(Self { auth_token })
     }
 }
 


### PR DESCRIPTION
This prevents configured diagnostics bearer tokens from containing characters that cannot appear in an HTTP header value (CR/LF, control chars, non-ASCII), which would make them unusable at runtime.

Why:

Previously DIAGNOSTICS_AUTH_TOKEN was only trimmed and rejected when empty, allowing tokens with invalid header chars to be accepted at startup. Such values cannot be used in Authorization headers and cause runtime surprises.

What:

Validate the trimmed token using http::HeaderValue::try_from(...) (HTTP header-value parser) and reject tokens that fail the parse. Preserve existing trimming and non-empty check.
Add focused unit tests for valid and invalid tokens. Add http crate dependency.

Fixes #685

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x ] I read CONTRIBUTING.md
- [x ] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
I use ai just for learning. I'll write code. let AI check. or Ai add more duplicate code.