### PR TITLE
[FIX] http: protect observation routes

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -32,12 +32,6 @@ RTC Server URL = https://<sfu-domain>
 RTC server KEY = <same value as AUTH_KEY>
 ```
 
-`AUTH_KEY` must be valid base64 that decodes to at least 32 bytes and should be generated from cryptographically safe randomness
-
-```bash
-openssl rand -base64 32
-```
-
 ## basic production environment
 
 ```env
@@ -51,30 +45,61 @@ TELEMETRY_LOG_FORMAT=json
 TELEMETRY_DEPLOYMENT_ENVIRONMENT=production
 ```
 
-`PROXY=true` is valid only when the trusted public proxy overwrites forwarded headers before requests reach `o-sfu`
-
 `RTC_MIN_PORT` and `RTC_MAX_PORT` must match the cloud firewall, host firewall and container or service binding
 
 `TELEMETRY_DEPLOYMENT_ENVIRONMENT=production` setting it to `production` makes the tracing switch to ratio-based sampling so only a subset of traces is captured to reduce load on the tracing system
 
 `ROOM_MAX_LOCAL_ROUTERS` must be less than or equal to `RTC_MEDIA_WORKER_COUNT`
 
-> [!WARNING]
-> IO_URING
->
-> io_uring is known to be a security risk:
-> see https://i.blackhat.com/BH-US-23/Presentations/US-23-Lin-bad_io_uring.pdf
->
-> that being said, there is no indication that it leads to vulnerabilities in o-sfu use case,
-> and io_uring is "commonly" used in many high throughput systems.
->
-> If you know what you are doing and want to enable it, use `RTC_UDP_IO_BACKEND=io_uring`.
->
-> If you're running inside docker, docker must be explicitely configured in `unconfined` mode.
->```
->security_opt:
->      - seccomp=unconfined
->```
+## security
+
+see [SECURITY.md](SECURITY.md) for privacy and vulnerability reporting
+
+### credentials
+
+`AUTH_KEY` must match Odoo and be valid base64 that decodes to at least 32
+cryptographically random bytes. Generate it and `DIAGNOSTICS_AUTH_TOKEN`
+independently by running this command for each:
+
+```bash
+openssl rand -base64 32
+```
+
+### network and proxy trust
+
+keep port `8070` unreachable from untrusted networks. Bind it to loopback for a
+host proxy or expose it only on an isolated same-host container network
+
+set `PROXY=true` only when the trusted public proxy strips or overwrites
+client-supplied forwarded headers. Use `$proxy_add_x_forwarded_for` only when a
+trusted upstream has already stripped client input
+
+`/v1/stats`, `/metrics` and `/internal/diagnostics/...` require
+`DIAGNOSTICS_AUTH_TOKEN` on every request when configured. Without it, the
+actual listener must use loopback. A same-host reverse proxy can reach that
+fallback, so configure the token and block these routes at every public edge
+
+port `8070` serves plaintext HTTP. Keep bearer traffic on loopback or an
+isolated same-host network limited to trusted services. Otherwise use a
+TLS-terminating proxy or authenticated encrypted overlay. A firewall alone
+does not protect plaintext credentials
+
+### io_uring
+
+Docker's [default seccomp profile](https://docs.docker.com/engine/security/seccomp/)
+blocks the `io_uring` system calls. Keep the default `tokio` backend unless the
+container has a reviewed seccomp policy. `seccomp=unconfined` permits those
+calls by removing the default syscall filter:
+
+```yaml
+security_opt:
+  - seccomp=unconfined
+```
+
+### release integrity
+
+promote only non-prerelease release-tag images and assets after completing the
+verification steps under [image](#image) and [release assets](#release-assets)
 
 ## image
 
@@ -308,12 +333,6 @@ common fields it needs and tolerate unknown extra keys
 the reviewed event and field catalog lives in `crates/telemetry/src/schema.rs`
 the formatter is in `crates/telemetry/src/setup.rs`
 
-### systemd deployment
-
-when NGINX and Prometheus run on the same host, set
-`BIND_ADDRESS=127.0.0.1:8070`. Remote Prometheus requires a private interface
-and a source-restricted firewall. Port `8070` must reject public access
-
 ## NGINX public edge
 
 ```nginx
@@ -330,6 +349,10 @@ server {
     ssl_certificate_key <certificate-key-path>;
 
     location = /metrics {
+        return 404;
+    }
+
+    location = /v1/stats {
         return 404;
     }
 
@@ -354,43 +377,47 @@ server {
 }
 ```
 
-do not use `$proxy_add_x_forwarded_for` at the public edge unless an upstream trusted proxy already stripped client-supplied forwarding headers
-
-`o-sfu` uses forwarded headers for proxy-aware request metadata when `PROXY=true`, so those headers must not preserve untrusted client input
-
 ## private observability
-
-### query reference
 
 use the telemetry reference for exact queries and response shapes:
 
 - [Prometheus metrics](https://thanhdodeurodoo.github.io/o-sfu/o_sfu/http/telemetry/metrics/index.html)
 - [HTTP diagnostics](https://thanhdodeurodoo.github.io/o-sfu/o_sfu/http/telemetry/diagnostics/index.html)
 
-public routes:
+remote Prometheus scrape through a private TLS endpoint when
+`DIAGNOSTICS_AUTH_TOKEN` is configured:
 
-```text
-/v1/noop -> allowed
-/metrics -> blocked
-/internal/diagnostics/... -> blocked
+```yaml
+scrape_configs:
+  - job_name: o-sfu
+    scheme: https
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials_file: /run/secrets/o_sfu_diagnostics_token
+    tls_config:
+      ca_file: /run/secrets/o_sfu_observability_ca
+      server_name: o-sfu-observability.internal
+    static_configs:
+      - targets: ["o-sfu-observability.internal:443"]
 ```
 
-private Prometheus scrape:
+the private endpoint proxies operator routes to `http://127.0.0.1:8070`
 
-```text
-http://<private-sfu-address>:8070/metrics
-```
+private stats and diagnostics access:
 
-private diagnostics access:
-
-```text
-Authorization: Bearer <diagnostics-token>
+```bash
+curl -H 'Authorization: Bearer <diagnostics-token>' \
+  https://o-sfu-observability.internal/v1/stats
+curl -H 'Authorization: Bearer <diagnostics-token>' \
+  https://o-sfu-observability.internal/internal/diagnostics/summary
 ```
 
 ## rollout validation
 
 ```bash
 curl -i https://<sfu-domain>/v1/noop
+curl -i https://<sfu-domain>/v1/stats
 curl -i https://<sfu-domain>/metrics
 curl -i https://<sfu-domain>/internal/diagnostics/summary
 ```
@@ -399,13 +426,14 @@ expected:
 
 ```text
 /v1/noop -> 200 with {"result":"ok"}
+/v1/stats -> 404
 /metrics -> 404
 /internal/diagnostics/summary -> 404
 ```
 
-confirm direct port `8070` is unreachable from untrusted networks and the
-permitted private scrape returns `200`. Then validate a real browser join from
-Odoo because HTTP health does not validate the UDP media path
+confirm direct port `8070` is unreachable from untrusted networks and authorized
+private operator requests return `200`. Then validate a real browser join
+from Odoo because HTTP health does not validate the UDP media path
 
 ## deployment checklist
 
@@ -426,8 +454,7 @@ proxy:
 - NGINX uses HTTP/1.1 upstream for WebSocket upgrade support
 - NGINX forwards `Upgrade` and `Connection`
 - NGINX overwrites `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Real-IP` and `Host`
-- `/metrics` is not public
-- `/internal/diagnostics/...` is not public
+- `/v1/stats`, `/metrics` and `/internal/diagnostics/...` are not public
 
 runtime:
 
@@ -440,16 +467,15 @@ runtime:
 - `PROXY=true` is set only behind the trusted NGINX edge
 - `AUTH_KEY` matches the Odoo caller configuration
 - `AUTH_KEY` decodes to at least 32 bytes generated with cryptographically safe randomness
-- `DIAGNOSTICS_AUTH_TOKEN` is set for operator routes
+- `DIAGNOSTICS_AUTH_TOKEN` is generated independently from at least 32 random bytes
 - `RTC_MEDIA_WORKER_COUNT` fits the VM capacity
 - `ROOM_MAX_LOCAL_ROUTERS` does not exceed `RTC_MEDIA_WORKER_COUNT`
 
 validation:
 
 - `GET /v1/noop` succeeds through HTTPS
-- public `/metrics` returns `404`
-- public `/internal/diagnostics/summary` returns `404`
-- private Prometheus can scrape `/metrics`
+- public `/v1/stats`, `/metrics` and `/internal/diagnostics/summary` return `404`
+- private operator requests send `DIAGNOSTICS_AUTH_TOKEN` over a confidential transport
 - browser join through Odoo succeeds
 - if HTTP succeeds but media fails, check UDP firewalls and the `sfu-server` tag first
 
@@ -462,13 +488,13 @@ required:
 | `ANNOUNCED_IP` | required | concrete advertised IP address used in ICE-lite SDP |
 | `AUTH_KEY` | required | base64 key with at least 32 decoded bytes used to sign and verify SFU JWTs |
 
-HTTP, proxy and diagnostics:
+HTTP and operator access:
 
 | variable | default | description |
 | --- | --- | --- |
 | `BIND_ADDRESS` | `0.0.0.0:8070` | HTTP and WebSocket listening address |
 | `PROXY` | `false` | trusts proxy-provided request metadata when `true` |
-| `DIAGNOSTICS_AUTH_TOKEN` | unset | bearer token for `/internal/diagnostics/...`, diagnostics are allowed only on loopback listeners when unset |
+| `DIAGNOSTICS_AUTH_TOKEN` | unset | bearer token for `/v1/stats`, `/metrics` and `/internal/diagnostics/...`. Tokenless access requires the actual listener to use loopback |
 | `SHUTDOWN_TIMEOUT_MS` | `10000` | positive total deadline in milliseconds for listener, WebSocket session, background task and RTC worker drainage |
 
 authentication and websocket admission:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,8 +74,10 @@ see: https://github.com/ThanhDodeurOdoo/o-sfu/releases
 ### 3. Logging & Observability
 
 - **Operational Logs**: Server logs (stdout/stderr) record connection lifecycle events, IP addresses, and user IDs for debugging, performance monitoring, and abuse detection. Media content and secret keys are never logged.
-- **Metrics**: Aggregate Prometheus metrics (`/metrics`) contain only high-level operational counters and never expose IP addresses, user IDs, or room names.
-- **Diagnostics**: Detailed internal runtime diagnostics are protected by authentication and restricted to private administrative access.
+- **Statistics**: `/v1/stats` exposes room UUIDs, remote addresses and participant media counts to authorized operators.
+- **Metrics**: Aggregate Prometheus metrics (`/metrics`) contain only high-level operational counters and never expose IP addresses, user IDs or room names.
+- **Diagnostics**: Detailed internal runtime diagnostics expose current room and user facts to authorized operators.
+- **Observation Access**: `/v1/stats`, `/metrics` and diagnostics require the configured bearer token on every listener. Without one, the actual listener must be loopback.
 
 ### 4. Operator Privacy Responsibilities
 
@@ -83,4 +85,5 @@ Operators hosting `o-sfu` control their deployment environment and should ensure
 
 - **Log Retention**: Configure appropriate log rotation and retention limits on host or container logging systems to manage IP and identifier storage.
 - **Transport Security**: Deploy `o-sfu` behind a trusted reverse proxy with TLS/WSS enabled for signaling traffic.
-- **Access Control**: Restrict access to internal diagnostic endpoints and securely manage shared authentication keys.
+- **Access Control**: Keep observation routes private and securely manage their bearer token plus shared authentication keys.
+- **Observation Transport**: Send the observation bearer token only over same-host loopback, an isolated same-host container network, TLS or an authenticated encrypted transport. Only trusted telemetry services may join the container network. The `o-sfu` HTTP listener does not terminate TLS.

--- a/src/config/diagnostics.rs
+++ b/src/config/diagnostics.rs
@@ -4,6 +4,7 @@ use super::env::{Env, non_empty};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DiagnosticsConfig {
+    /// Bearer token required on every listener when configured.
     pub auth_token: Option<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,14 @@
 //!                                      |
 //!                                      v
 //!                                MediaTransport
-//!                                      |
-//!                                      v
-//!                             RTC worker packet loops
-//!                                      |
-//!                        UDP in -> RTP fanout -> UDP out
+//!                                 |    |    |
+//!                                 v    v    v
+//!                          RTC workers / packet loops
+//!                         |            |              |
+//!                      UDP:40001   UDP:40002      UDP:40003
+//!                         |            |              |
+//!                         v            v              v
+//!                      fanout        fanout        fanout
 //! ```
 //!
 //! # Admission Edge
@@ -52,8 +55,35 @@
 //! JWT authentication before admission.
 //!
 //! ```text
-//! App GET /v1/channel -> verify auth -> RoomManager::serve_room
-//! WebSocket client connect -> verify auth -> SfuCore::admit_user -> MediaSession
+//!                     +----------------------------------------+
+//!                     |     Incoming HTTP / WebSocket I/O      |
+//!                     +----------------------------------------+
+//!                                         |
+//!                                         v
+//!                     +----------------------------------------+
+//!                     |              Axum Router               |
+//!                     +----------------------------------------+
+//!                                         |
+//!        +--------------------+-----------+-----------+--------------------+
+//!        |                    |                       |                    |
+//!        v                    v                       v                    v
+//!  [ GET /v1/noop ]  [ GET /v1/channel ]     [ WebSocket / ]   [ Operator Routes ]   <-- Routes
+//!  (Public Liveness) [ POST /v1/disconnect ] (Signaling Path)  - GET /v1/stats
+//!        |                    |                     |          - GET /metrics
+//!        |                    |                     |          - GET /internal/...
+//!        |                    v                     v                  |
+//!        |           +---------------+     +---------------+   +---------------+
+//!        |           | VerifiedRoom  |     | Upgrade       |   | OperatorAccess|     <-- Extractors
+//!        |           | VerifiedClaims|     | ConnectInfo   |   | (Route Layer) |
+//!        |           | (JWT Header)  |     | 1st-Frame JWT |   | (Bearer/Local)|
+//!        |           +---------------+     +---------------+   +---------------+
+//!        |                    |                     |                  |
+//!        v                    v                     v                  v
+//!  +---------------+ +---------------+     +---------------+   +---------------+
+//!  | noop          | | room          |     | upgrade       |   | stats         |     <-- Handlers
+//!  |               | | disconnect    |     | -> admit_user |   | metrics       |
+//!  | -> 200 JSON   | | -> Room State |     | -> WS Session |   | diagnostics_* |
+//!  +---------------+ +---------------+     +---------------+   +---------------+
 //! ```
 //!
 //! - **HTTP**: Parses server-to-server requests using [`http::CreateRoomQuery`]. Verifies [`auth::HttpRoomClaims`]. The request that creates the current room fixes its signing key.
@@ -151,9 +181,7 @@
 //! HTTP and WebSocket are served in plaintext in process. HTTPS and WSS are
 //! terminated by an external reverse proxy, so a forwarded scheme and client
 //! address are trusted only when the proxy is trusted through [`config`]
-//! (`PROXY`). Diagnostics require a bearer token or a loopback listener. The
-//! metrics endpoint carries no application authentication and must be restricted
-//! at the deployment boundary.
+//! (`PROXY`). Operator route access is documented by [`http`].
 //!
 //! # Room and Router Ownership
 //!
@@ -305,6 +333,12 @@ pub mod auth {
     };
 }
 
+/// HTTP route and payload contracts.
+///
+/// `/v1/stats`, `/metrics` and diagnostics require the configured
+/// [`crate::config::DiagnosticsConfig::auth_token`] on every listener. Without
+/// one, the actual listener must be loopback. Missing or invalid tokens return
+/// `401 Unauthorized`. Tokenless non-loopback access returns `403 Forbidden`.
 pub mod http {
     pub use crate::runtime::{
         http_server::contract::{
@@ -319,9 +353,7 @@ pub mod http {
         /// Prometheus metric scrape contract.
         ///
         /// `GET` [`metrics::PATH`] returns `200 OK` Prometheus text exposition
-        /// with [`metrics::CONTENT_TYPE`] and requires no application-layer
-        /// authentication.
-        /// Operators should restrict access at the deployment boundary.
+        /// with [`metrics::CONTENT_TYPE`].
         ///
         /// This is a scrape endpoint.
         /// Configure Prometheus to scrape [`metrics::PATH`], then issue `PromQL`
@@ -331,14 +363,19 @@ pub mod http {
         ///
         /// # Scrape and Query
         ///
-        /// Prometheus scrapes o-sfu directly.
-        ///
         /// ```yaml
         /// scrape_configs:
         ///   - job_name: o-sfu
+        ///     scheme: https
         ///     metrics_path: /metrics
+        ///     authorization:
+        ///       type: Bearer
+        ///       credentials_file: /run/secrets/o_sfu_diagnostics_token
+        ///     tls_config:
+        ///       ca_file: /run/secrets/o_sfu_observability_ca
+        ///       server_name: o-sfu-observability.internal
         ///     static_configs:
-        ///       - targets: ["o-sfu:8070"]
+        ///       - targets: ["o-sfu-observability.internal:443"]
         /// ```
         ///
         /// The endpoint returns Prometheus text exposition.
@@ -378,12 +415,8 @@ pub mod http {
 
         /// JSON diagnostics contract.
         ///
-        /// Every constant in [`diagnostics::route`] is a `GET` endpoint.
-        /// When a diagnostics token is configured, requests must send it as an
-        /// `Authorization: Bearer <token>` header.
-        /// Without a configured token, the server permits access only when its
-        /// HTTP listener is bound to a loopback address.
-        /// Successful requests return `200 OK` JSON.
+        /// Every constant in [`diagnostics::route`] is a `GET` endpoint returning
+        /// `200 OK` JSON on success.
         ///
         /// # Routes and Parameters
         ///
@@ -402,11 +435,11 @@ pub mod http {
         /// `userKey` is always the string to put into `{id}`.
         /// URL-encode both path values before substitution.
         ///
-        /// # Summary Request and Response
+        /// # Summary Request and Response over HTTPS
         ///
         /// ```text
         /// GET /internal/diagnostics/summary HTTP/1.1
-        /// Host: o-sfu:8070
+        /// Host: o-sfu-observability.internal
         /// Authorization: Bearer <diagnostics-token>
         /// Accept: application/json
         ///
@@ -431,7 +464,7 @@ pub mod http {
         /// # JavaScript Fetch Example
         ///
         /// ```javascript
-        /// const origin = "http://o-sfu:8070";
+        /// const origin = "https://o-sfu-observability.internal";
         /// const headers = {
         ///   Authorization: `Bearer ${process.env.DIAGNOSTICS_AUTH_TOKEN}`,
         /// };

--- a/src/runtime/http_server/TESTS/access_route_tests.rs
+++ b/src/runtime/http_server/TESTS/access_route_tests.rs
@@ -1,0 +1,57 @@
+use std::net::SocketAddr;
+
+use super::fixtures::*;
+
+const OPERATOR_ROUTES: [&str; 2] = [route::v1::STATS, route::METRICS];
+
+#[tokio::test]
+async fn stats_and_metrics_preserve_method_not_allowed() -> TestResult {
+    let mut state = test_state();
+    state.config.http.bind_address = SocketAddr::from(([0, 0, 0, 0], 8070));
+
+    for path in OPERATOR_ROUTES {
+        route_status(
+            &state,
+            Request::post(path),
+            Body::empty(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            path,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn stats_and_metrics_require_configured_token_on_loopback_listener() -> TestResult {
+    let mut state = test_state();
+    state.config.diagnostics.auth_token = Some(String::from("operator-secret"));
+
+    for path in OPERATOR_ROUTES {
+        route_status(
+            &state,
+            Request::get(path),
+            Body::empty(),
+            StatusCode::UNAUTHORIZED,
+            path,
+        )
+        .await?;
+        route_status(
+            &state,
+            Request::get(path).header(header::AUTHORIZATION, "Bearer wrong-secret"),
+            Body::empty(),
+            StatusCode::UNAUTHORIZED,
+            path,
+        )
+        .await?;
+        route_status(
+            &state,
+            Request::get(path).header(header::AUTHORIZATION, "Bearer operator-secret"),
+            Body::empty(),
+            StatusCode::OK,
+            path,
+        )
+        .await?;
+    }
+    Ok(())
+}

--- a/src/runtime/http_server/TESTS/fixtures.rs
+++ b/src/runtime/http_server/TESTS/fixtures.rs
@@ -98,7 +98,12 @@ pub(super) async fn response(
     request: Request<Body>,
     context: &'static str,
 ) -> TestResult<AxumResponse> {
-    require_ok(app(state.clone()).oneshot(request).await, context)
+    require_ok(
+        app(state.clone(), state.config.http.bind_address)
+            .oneshot(request)
+            .await,
+        context,
+    )
 }
 
 pub(super) async fn route_response(

--- a/src/runtime/http_server/TESTS/mod.rs
+++ b/src/runtime/http_server/TESTS/mod.rs
@@ -1,3 +1,5 @@
+#[path = "access_route_tests.rs"]
+mod access_route_tests;
 #[path = "app_tests.rs"]
 mod app_tests;
 #[path = "diagnostics_route_tests.rs"]

--- a/src/runtime/http_server/contract.rs
+++ b/src/runtime/http_server/contract.rs
@@ -7,28 +7,19 @@ use serde::{Deserialize, Serialize};
 
 pub mod route {
     pub const WEBSOCKET: &str = "/";
-    /// `GET` Prometheus text scrape with no application-layer authentication.
-    ///
-    /// this endpoint exposes samples and is not a `PromQL` query API.
-    /// see [`crate::http::telemetry::metrics`] for its query catalog and examples.
+    /// Prometheus scrape endpoint, not a `PromQL` API.
+    /// See [`crate::http::telemetry::metrics`] for queries and examples.
     pub const METRICS: &str = "/metrics";
 
     pub mod v1 {
         pub const NOOP: &str = "/v1/noop";
+        /// Compatibility channel statistics.
         pub const STATS: &str = "/v1/stats";
         pub const CHANNEL: &str = "/v1/channel";
         pub const DISCONNECT: &str = "/v1/disconnect";
     }
 
-    /// diagnostics `GET` routes.
-    ///
-    /// requests require `Authorization: Bearer <token>` when a diagnostics
-    /// token is configured.
-    /// without a configured token, the server permits access only when its HTTP
-    /// listener is bound to a loopback address.
-    /// rejected requests return `401 Unauthorized` for a missing or invalid
-    /// configured token and `403 Forbidden` for a public listener without one.
-    /// successful requests return `200 OK` JSON.
+    /// Diagnostics `GET` routes.
     pub mod diagnostics {
         /// returns [`crate::http::telemetry::diagnostics::DiagnosticsSummaryResponse`].
         pub const SUMMARY: &str = "/internal/diagnostics/summary";

--- a/src/runtime/http_server/controller.rs
+++ b/src/runtime/http_server/controller.rs
@@ -24,8 +24,8 @@ use crate::{
                 UsersStatsResponse, route,
             },
             extractors::{
-                DiagnosticsAccess, DiagnosticsServices, MetricsServices, RoomServices,
-                VerifiedDisconnectClaims, VerifiedRoomRequest,
+                DiagnosticsServices, MetricsServices, OperatorAccess, OperatorAccessPolicy,
+                RoomServices, VerifiedDisconnectClaims, VerifiedRoomRequest,
             },
         },
         metrics::{HttpRoute, RuntimeMetrics},
@@ -61,32 +61,44 @@ pub(crate) async fn serve_http_on(
     );
     axum::serve(
         listener,
-        app(state).into_make_service_with_connect_info::<SocketAddr>(),
+        app(state, local_address).into_make_service_with_connect_info::<SocketAddr>(),
     )
     .with_graceful_shutdown(shutdown_token.cancelled_owned())
     .await
 }
 
 /// builds the Axum router for the HTTP control plane and WebSocket listener
-pub(crate) fn app(state: RuntimeState) -> Router {
+pub(crate) fn app(state: RuntimeState, listener_address: SocketAddr) -> Router {
     let metrics = Arc::clone(&state.metrics);
+    let operator_policy = OperatorAccessPolicy::new(
+        state.config.diagnostics.auth_token.as_deref(),
+        listener_address,
+    );
     Router::new()
         .route(route::WEBSOCKET, get(websocket_server::upgrade))
-        .merge(http_router(metrics))
-        .merge(diagnostics_router(state.clone()))
+        .merge(http_router(metrics, operator_policy.clone()))
+        .merge(diagnostics_router(operator_policy))
         .with_state(state)
 }
 
-fn http_router(runtime_metrics: Arc<RuntimeMetrics>) -> Router<RuntimeState> {
+fn http_router(
+    runtime_metrics: Arc<RuntimeMetrics>,
+    operator_policy: OperatorAccessPolicy,
+) -> Router<RuntimeState> {
+    let operator_layer =
+        middleware::from_extractor_with_state::<OperatorAccess, _>(operator_policy);
     Router::new()
         .route(route::v1::NOOP, get(noop))
-        .route(route::v1::STATS, get(stats))
+        .route(
+            route::v1::STATS,
+            get(stats).route_layer(operator_layer.clone()),
+        )
         .route(route::v1::CHANNEL, get(room))
         .route(
             route::v1::DISCONNECT,
             post(disconnect).layer(DefaultBodyLimit::max(MAX_DISCONNECT_BODY_BYTES)),
         )
-        .route(route::METRICS, get(metrics))
+        .route(route::METRICS, get(metrics).route_layer(operator_layer))
         .route_layer(middleware::from_fn_with_state(
             runtime_metrics,
             track_http_request,
@@ -111,8 +123,7 @@ async fn track_http_request(
     next.run(request).await
 }
 
-/// diagnostics route group protected by [`DiagnosticsAccess`]
-fn diagnostics_router(state: RuntimeState) -> Router<RuntimeState> {
+fn diagnostics_router(operator_policy: OperatorAccessPolicy) -> Router<RuntimeState> {
     Router::new()
         .route(route::diagnostics::SUMMARY, get(diagnostics_summary))
         .route(route::diagnostics::ROOMS, get(diagnostics_rooms))
@@ -122,7 +133,9 @@ fn diagnostics_router(state: RuntimeState) -> Router<RuntimeState> {
         .route(route::diagnostics::ROOM_USER, get(diagnostics_user_detail))
         .route(route::diagnostics::ROOM_GRAPH, get(diagnostics_room_graph))
         .route(route::diagnostics::USER_GRAPH, get(diagnostics_user_graph))
-        .route_layer(middleware::from_extractor_with_state::<DiagnosticsAccess, _>(state))
+        .route_layer(middleware::from_extractor_with_state::<OperatorAccess, _>(
+            operator_policy,
+        ))
 }
 
 /// liveness endpoint for a cheap control-plane round trip

--- a/src/runtime/http_server/extractors.rs
+++ b/src/runtime/http_server/extractors.rs
@@ -1,4 +1,4 @@
-use std::{str, sync::Arc};
+use std::{net::SocketAddr, str, sync::Arc};
 
 use axum::{
     body::Bytes,
@@ -46,12 +46,24 @@ pub(super) struct VerifiedRoomRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct VerifiedDisconnectClaims(pub(super) HttpDisconnectClaims);
 
-/// authorizes diagnostics routes with a configured bearer token or loopback-only fallback
-///
-/// configured tokens take precedence over loopback access so public listeners
-/// cannot bypass operator auth
-#[derive(Debug, Clone, Copy)]
-pub(super) struct DiagnosticsAccess;
+/// Operator authorization bound to the listener that serves the router.
+#[derive(Clone)]
+pub(super) struct OperatorAccessPolicy {
+    auth_token: Option<Arc<str>>,
+    listener_is_loopback: bool,
+}
+
+impl OperatorAccessPolicy {
+    pub(super) fn new(auth_token: Option<&str>, listener_address: SocketAddr) -> Self {
+        Self {
+            auth_token: auth_token.map(Arc::from),
+            listener_is_loopback: listener_address.ip().is_loopback(),
+        }
+    }
+}
+
+/// A configured token disables the loopback fallback.
+pub(super) struct OperatorAccess;
 
 impl FromRef<RuntimeState> for RoomServices {
     fn from_ref(state: &RuntimeState) -> Self {
@@ -156,20 +168,20 @@ impl FromRequest<RuntimeState> for VerifiedDisconnectClaims {
     }
 }
 
-impl FromRequestParts<RuntimeState> for DiagnosticsAccess {
+impl FromRequestParts<OperatorAccessPolicy> for OperatorAccess {
     type Rejection = StatusCode;
 
     async fn from_request_parts(
         parts: &mut Parts,
-        state: &RuntimeState,
+        policy: &OperatorAccessPolicy,
     ) -> Result<Self, Self::Rejection> {
-        if let Some(expected_token) = state.config.diagnostics.auth_token.as_deref() {
+        if let Some(expected_token) = policy.auth_token.as_deref() {
             return match bearer_authorization_token(&parts.headers) {
                 Some(actual_token) if tokens_match(actual_token, expected_token) => Ok(Self),
                 _ => Err(StatusCode::UNAUTHORIZED),
             };
         }
-        if state.config.http.bind_address.ip().is_loopback() {
+        if policy.listener_is_loopback {
             Ok(Self)
         } else {
             Err(StatusCode::FORBIDDEN)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -134,6 +134,8 @@ impl Runtime {
 
     /// Serves a caller-provided listener until `shutdown` resolves.
     ///
+    /// Tokenless operator access follows the listener's actual local address.
+    ///
     /// # Errors
     ///
     /// Returns [`ServeError::Io`] for serving failures or

--- a/src/runtime/websocket_server/TESTS/fixtures.rs
+++ b/src/runtime/websocket_server/TESTS/fixtures.rs
@@ -191,7 +191,7 @@ impl TestServerBuilder {
         )
         .ok()?;
         let handle = tokio::spawn(async move {
-            let result = axum::serve(listener, app(state_for_server)).await;
+            let result = axum::serve(listener, app(state_for_server, addr)).await;
             assert!(
                 result.is_ok(),
                 "test server should stop cleanly: {result:?}"

--- a/tests/integration/server_smoke.rs
+++ b/tests/integration/server_smoke.rs
@@ -3,9 +3,9 @@
     reason = "integration tests use panic-based assertions for clear failures"
 )]
 
-use std::{collections::BTreeMap, future::Future, pin::Pin};
+use std::{collections::BTreeMap, future::Future, net::SocketAddr, pin::Pin};
 
-use o_sfu::config::Config;
+use o_sfu::{config::Config, http::route};
 use o_sfu_protocol::wire::{
     ClientBroadcastPayload, ClientMessage, DownloadStates, ServerMessage, ServerRequest,
     SubscribePayload, UserId,
@@ -14,15 +14,24 @@ use o_sfu_tests::support::{
     TEST_ROOM_KEY, TestResult, TestServer, connect_websocket, create_room,
     disconnect_sessions_via_http, metrics_text,
     protocol_harness::{ProtocolWebSocketClient, connect_protocol_pair, read_until_server_message},
-    read_close_code, require_some, signed_connect_claims, spawn_test_server, test_config,
+    read_close_code, require_some, signed_connect_claims, spawn_test_server,
+    spawn_test_server_with_listener, test_config,
 };
 use reqwest::StatusCode;
 use str0m::change::SdpOffer;
-use tokio::time::{Duration, timeout};
+use tokio::{
+    net::TcpListener,
+    time::{Duration, timeout},
+};
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 
 const SLOW_CONSUMER_BATCH_LEN: usize = 64;
 const SLOW_CONSUMER_PAYLOAD_BYTES: usize = 1_024;
+const OPERATOR_ROUTES: [&str; 3] = [
+    route::v1::STATS,
+    route::METRICS,
+    route::diagnostics::SUMMARY,
+];
 
 async fn server_with_room(issuer: &str) -> TestResult<(TestServer, String)> {
     server_with_configured_room(test_config(1_000, 10), issuer).await
@@ -119,6 +128,34 @@ async fn runtime_shutdown_drains_pending_and_admitted_websockets() -> TestResult
     assert_eq!(admitted_close, Some(CloseCode::Away));
     assert!(connect_websocket(&server).await.is_none());
     server.join().await
+}
+
+#[tokio::test]
+async fn operator_access_uses_listener_address() -> TestResult {
+    let mut loopback_config = test_config(1_000, 10);
+    loopback_config.http.bind_address = SocketAddr::from(([127, 0, 0, 1], 0));
+    let wildcard_listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], 0))).await?;
+    let wildcard_server = spawn_test_server_with_listener(&loopback_config, wildcard_listener)?;
+
+    for path in OPERATOR_ROUTES {
+        let response = reqwest::get(format!("{}{path}", wildcard_server.http_base_url())).await?;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{path}");
+    }
+    let path = route::v1::NOOP;
+    let response = reqwest::get(format!("{}{path}", wildcard_server.http_base_url())).await?;
+    assert_eq!(response.status(), StatusCode::OK, "{path}");
+    wildcard_server.join().await?;
+
+    let mut wildcard_config = test_config(1_000, 10);
+    wildcard_config.http.bind_address = SocketAddr::from(([0, 0, 0, 0], 0));
+    let loopback_listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+    let loopback_server = spawn_test_server_with_listener(&wildcard_config, loopback_listener)?;
+
+    for path in OPERATOR_ROUTES {
+        let response = reqwest::get(format!("{}{path}", loopback_server.http_base_url())).await?;
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+    }
+    loopback_server.join().await
 }
 
 #[tokio::test]

--- a/tests/src/support/harness.rs
+++ b/tests/src/support/harness.rs
@@ -6,7 +6,7 @@
 use std::{
     collections::BTreeMap,
     future::Future,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
 
@@ -378,16 +378,33 @@ fn stream_id_for_stream_type(stream_type: StreamType) -> &'static str {
 ///
 /// Returns an error when runtime construction or listener binding fails.
 pub async fn spawn_test_server(config: Config) -> Result<TestServer> {
-    let runtime = Runtime::new(&config)?;
-    let media_transport = runtime.media_transport_for_test();
     let listener = TcpListener::bind(config.http.bind_address).await?;
-    let addr = listener
+    spawn_test_server_with_listener(&config, listener)
+}
+
+/// Spawns the production server with a caller-provided listener.
+///
+/// # Errors
+///
+/// Returns an error when runtime construction or listener inspection fails.
+pub fn spawn_test_server_with_listener(
+    config: &Config,
+    listener: TcpListener,
+) -> Result<TestServer> {
+    let runtime = Runtime::new(config)?;
+    let media_transport = runtime.media_transport_for_test();
+    let mut client_addr = listener
         .local_addr()
         .map_err(|error| anyhow!("failed to read test listener address: {error}"))?;
+    client_addr.set_ip(match client_addr.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => Ipv4Addr::LOCALHOST.into(),
+        IpAddr::V6(ip) if ip.is_unspecified() => Ipv6Addr::LOCALHOST.into(),
+        ip => ip,
+    });
     let shutdown = CancellationToken::new();
     let handle = tokio::spawn(runtime.serve_listener(listener, shutdown.clone().cancelled_owned()));
     Ok(TestServer {
-        addr,
+        addr: client_addr,
         handle: AbortOnDropHandle::new(handle),
         media_transport,
         shutdown,


### PR DESCRIPTION
Statistics and Prometheus metrics expose operator data but did not share the diagnostics access policy.

Apply the bearer-token or loopback guard to both GET routes. Preserve 405 handling and document proxy plus scraper requirements.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
