### PR TITLE
[IMP] runtime: count malformed queries as bad requests

### DIFF
--- a/src/runtime/http_server/TESTS/room_route_tests.rs
+++ b/src/runtime/http_server/TESTS/room_route_tests.rs
@@ -377,3 +377,25 @@ async fn room_route_reuses_a_reservation_that_repeats_key_and_config() -> TestRe
     assert_eq!(test_state.state.metrics.snapshot().http_room_conflict(), 0);
     Ok(())
 }
+
+#[tokio::test]
+async fn malformed_room_route_query_counts_as_bad_request() -> TestResult {
+    let state = test_state();
+    let token = room_token(Some("issuer-malformed-query"), Some(TEST_ROOM_KEY), None)?;
+
+    route_status(
+        &state,
+        Request::get(format!("{}?webRTC=invalid", route::v1::CHANNEL))
+            .header(header::HOST, "sfu.example.com")
+            .header(header::AUTHORIZATION, format!("Bearer {token}")),
+        Body::empty(),
+        StatusCode::BAD_REQUEST,
+        "authorized room request with malformed query should fail",
+    )
+    .await?;
+
+    let metrics = state.metrics.snapshot();
+    assert_eq!(metrics.http_room_requests(), 1);
+    assert_eq!(metrics.http_room_bad_request(), 1);
+    Ok(())
+}

--- a/src/runtime/http_server/extractors.rs
+++ b/src/runtime/http_server/extractors.rs
@@ -106,7 +106,7 @@ impl FromRequestParts<RuntimeState> for VerifiedRoomRequest {
         };
         let Query(query) = Query::<CreateRoomQuery>::from_request_parts(parts, state)
             .await
-            .map_err(|_error| StatusCode::BAD_REQUEST)?;
+            .map_err(|_error| record_room_rejection(state, StatusCode::BAD_REQUEST))?;
         let Some(token) = room_authorization_token(&parts.headers) else {
             return Err(record_room_rejection(state, StatusCode::UNAUTHORIZED));
         };


### PR DESCRIPTION
Before this commit, a failed Query extraction in the room request rout mapped directly to 400 Bad Request, bypassing the room rejection recorder.

This led to the `osfu_http_room_responses_total{status="bad_request"}` not being incremented, leaving the room requests and outcome totals inconsistent.

This commit improves the behavior by routing `CreateRoomQuery` extraction failures through the existing `record_room_rejection` helper.

fixes https://github.com/ThanhDodeurOdoo/o-sfu/issues/684

#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [x] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code
