### PR TITLE
[FIX] telemetry: inherit span correlation fields on nested log events

### DIFF
--- a/crates/telemetry/src/TESTS/setup.rs
+++ b/crates/telemetry/src/TESTS/setup.rs
@@ -4,6 +4,7 @@ use std::{
     sync::{Arc, Mutex, PoisonError},
 };
 
+use o_sfu_model::UserId;
 use tracing::{Subscriber, subscriber};
 #[cfg(feature = "otel-tracing")]
 use tracing_opentelemetry::OpenTelemetryLayer;
@@ -164,6 +165,72 @@ fn json_formatter_preserves_initial_transport_health_origin() -> Result<(), Box<
     Ok(())
 }
 
+#[test]
+fn json_formatter_inherits_span_correlation_fields() -> Result<(), Box<dyn Error>> {
+    let writer = SharedWriter::default();
+    let subscriber = json_test_subscriber(writer.clone());
+    subscriber::with_default(subscriber, || {
+        let outer = activated_span(tracing::info_span!(
+            "ws.handshake",
+            room_id = field::Empty,
+            user_id = field::Empty,
+            connection_id = field::Empty,
+            remote_address = "remote-outer",
+            stream_type = "webcam",
+            active = field::Empty,
+        ));
+        // Late-record via Span::record, same shape as session.rs::record_current_span.
+        outer.record("room_id", field::display("room-late"));
+        outer.record("user_id", field::display(UserId::Integer(7).path_segment()));
+        outer.record("connection_id", 42_u64);
+        outer.record("active", true);
+        let _outer_guard = outer.enter();
+
+        tracing::info!(event = schema::event::USER_JOINED, "outer event");
+
+        let inner = activated_span(tracing::info_span!(
+            "room.join",
+            user_id = "u-inner",
+            source_count = 3_u64,
+        ));
+        let _inner_guard = inner.enter();
+
+        tracing::info!(
+            event = schema::event::USER_JOINED,
+            room_id = "room-explicit",
+            "inner event",
+        );
+    });
+
+    let values = json_values(&writer)?;
+    let [outer_event, inner_event] = values.as_slice() else {
+        return Err(io::Error::other("expected two JSON logs").into());
+    };
+
+    assert_json_string(outer_event, "room_id", "room-late");
+    assert_json_string(outer_event, "user_id", "7");
+    assert_eq!(
+        outer_event.get("connection_id").and_then(Value::as_u64),
+        Some(42)
+    );
+    assert_json_string(outer_event, "remote_address", "remote-outer");
+
+    assert_json_string(inner_event, "room_id", "room-explicit");
+    assert_json_string(inner_event, "user_id", "u-inner");
+    assert_eq!(
+        inner_event.get("connection_id").and_then(Value::as_u64),
+        Some(42)
+    );
+    assert_json_string(inner_event, "remote_address", "remote-outer");
+
+    for event in [outer_event, inner_event] {
+        assert!(event.get("stream_type").is_none());
+        assert!(event.get("active").is_none());
+        assert!(event.get("source_count").is_none());
+    }
+    Ok(())
+}
+
 fn json_test_config() -> TelemetryConfig {
     TelemetryConfig {
         log_format: TelemetryLogFormat::Json,
@@ -184,6 +251,7 @@ fn json_test_subscriber(writer: SharedWriter) -> impl Subscriber + Send + Sync {
     let tracer = tracer_provider.tracer(TRACE_EXPORTER_NAME);
     Registry::default()
         .with(EnvFilter::new(DEFAULT_ENV_FILTER))
+        .with(SpanFieldCaptureLayer)
         .with(
             fmt_layer()
                 .fmt_fields(JsonFields::new())
@@ -199,6 +267,7 @@ fn json_test_subscriber(writer: SharedWriter) -> impl Subscriber + Send + Sync {
     let resource = telemetry_resource_fields(&json_test_config(), 7);
     Registry::default()
         .with(EnvFilter::new(DEFAULT_ENV_FILTER))
+        .with(SpanFieldCaptureLayer)
         .with(
             fmt_layer()
                 .fmt_fields(JsonFields::new())

--- a/crates/telemetry/src/setup.rs
+++ b/crates/telemetry/src/setup.rs
@@ -6,15 +6,16 @@ use time::format_description::well_known::Rfc3339;
 use tracing::{
     Span, Subscriber, field,
     field::{Field, Visit},
+    span::{Attributes, Id, Record},
 };
 use tracing_subscriber::{
-    EnvFilter, Registry,
+    EnvFilter, Layer, Registry,
     fmt::{
         FmtContext,
         format::{FormatEvent, FormatFields, JsonFields, Writer},
         layer as fmt_layer,
     },
-    layer::SubscriberExt,
+    layer::{Context as LayerContext, SubscriberExt},
     registry::LookupSpan,
     util::SubscriberInitExt,
 };
@@ -37,6 +38,12 @@ use {
 use crate::{TelemetryConfig, TelemetryLogFormat, schema};
 
 const DEFAULT_ENV_FILTER: &str = "o_sfu=info,o_sfu_core=info,o_sfu_router=info";
+const INHERITED_CORRELATION_FIELDS: &[&str] = &[
+    schema::field::CONNECTION_ID,
+    schema::field::REMOTE_ADDRESS,
+    schema::field::ROOM_ID,
+    schema::field::USER_ID,
+];
 #[cfg(feature = "otel-tracing")]
 const PRODUCTION_ENVIRONMENT_NAME: &str = "production";
 #[cfg(feature = "otel-tracing")]
@@ -67,6 +74,14 @@ struct RuntimeJsonFormatter {
 struct JsonEventVisitor {
     fields: Map<String, Value>,
 }
+
+#[derive(Debug, Default)]
+struct SpanFieldStore {
+    fields: Map<String, Value>,
+}
+
+#[derive(Debug, Default)]
+struct SpanFieldCaptureLayer;
 
 impl TelemetryHandle {
     #[cfg(feature = "otel-tracing")]
@@ -112,6 +127,13 @@ where
         let mut visitor = JsonEventVisitor::default();
         event.record(&mut visitor);
         let mut payload = visitor.fields;
+        for span in ctx.event_scope().into_iter().flatten() {
+            if let Some(store) = span.extensions().get::<SpanFieldStore>() {
+                for (key, value) in &store.fields {
+                    payload.entry(key.clone()).or_insert_with(|| value.clone());
+                }
+            }
+        }
         if payload.get(schema::field::EVENT).and_then(Value::as_str)
             == Some(schema::event::TRANSPORT_HEALTH_CHANGED)
         {
@@ -199,6 +221,35 @@ impl Visit for JsonEventVisitor {
     }
 }
 
+impl<S> Layer<S> for SpanFieldCaptureLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: LayerContext<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let mut visitor = JsonEventVisitor::default();
+        attrs.record(&mut visitor);
+        visitor
+            .fields
+            .retain(|name, _| INHERITED_CORRELATION_FIELDS.contains(&name.as_str()));
+        span.extensions_mut().insert(SpanFieldStore {
+            fields: visitor.fields,
+        });
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: LayerContext<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let mut visitor = JsonEventVisitor::default();
+        values.record(&mut visitor);
+        visitor
+            .fields
+            .retain(|name, _| INHERITED_CORRELATION_FIELDS.contains(&name.as_str()));
+        if let Some(store) = span.extensions_mut().get_mut::<SpanFieldStore>() {
+            store.fields.extend(visitor.fields);
+        }
+    }
+}
+
 #[cfg(feature = "otel-tracing")]
 /// # Errors
 ///
@@ -223,6 +274,7 @@ pub fn init_tracing(config: &TelemetryConfig, process_id: u32) -> Result<Telemet
             .try_init()?,
         TelemetryLogFormat::Json => Registry::default()
             .with(env_filter)
+            .with(SpanFieldCaptureLayer)
             .with(
                 fmt_layer()
                     .fmt_fields(JsonFields::new())
@@ -269,6 +321,7 @@ pub fn init_tracing(config: &TelemetryConfig, process_id: u32) -> Result<Telemet
             .try_init()?,
         TelemetryLogFormat::Json => Registry::default()
             .with(env_filter)
+            .with(SpanFieldCaptureLayer)
             .with(
                 fmt_layer()
                     .fmt_fields(JsonFields::new())

--- a/src/application/user_session/media.rs
+++ b/src/application/user_session/media.rs
@@ -34,8 +34,8 @@ impl User {
         skip_all,
         fields(
             room_id = %self.room_id(),
-            user_id = ?self.user_id(),
-            connection_id = ?self.connection_id()
+            user_id = %self.user_id().path_segment(),
+            connection_id = self.connection_id().as_u64()
         )
     )]
     pub(super) async fn renegotiate(&mut self) -> Result<UserOutput, UserError> {
@@ -49,8 +49,8 @@ impl User {
         skip_all,
         fields(
             room_id = %self.room_id(),
-            user_id = ?self.user_id(),
-            connection_id = ?self.connection_id(),
+            user_id = %self.user_id().path_segment(),
+            connection_id = self.connection_id().as_u64(),
             ?stream_type,
             active
         )
@@ -77,8 +77,8 @@ impl User {
         skip_all,
         fields(
             room_id = %self.room_id(),
-            user_id = ?self.user_id(),
-            connection_id = ?self.connection_id(),
+            user_id = %self.user_id().path_segment(),
+            connection_id = self.connection_id().as_u64(),
             target_session_id = field::Empty,
             source_count = field::Empty
         )
@@ -90,7 +90,10 @@ impl User {
     ) -> Result<UserOutput, UserError> {
         let target_user_id = target_user_id.normalized_for_runtime();
         let span = Span::current();
-        span.record("target_session_id", field::debug(&target_user_id));
+        span.record(
+            "target_session_id",
+            field::display(target_user_id.path_segment()),
+        );
         let source_intents = DiscussStream::all()
             .filter_map(|stream| stream.subscription_intent_if_requested(&states))
             .collect::<BTreeMap<_, _>>();
@@ -106,8 +109,8 @@ impl User {
         skip_all,
         fields(
             room_id = %self.room_id(),
-            user_id = ?self.user_id(),
-            connection_id = ?self.connection_id()
+            user_id = %self.user_id().path_segment(),
+            connection_id = self.connection_id().as_u64()
         )
     )]
     pub(super) async fn run_initial_offer(&mut self) -> Result<UserOutput, UserError> {

--- a/src/runtime/websocket_server/session.rs
+++ b/src/runtime/websocket_server/session.rs
@@ -145,7 +145,7 @@ async fn establish(
 #[instrument(
     name = "room.join",
     skip_all,
-    fields(room_id = %room.uuid(), user_id = ?claims.user_id)
+    fields(room_id = %room.uuid(), user_id = %claims.user_id.path_segment())
 )]
 async fn admit(
     services: &WebSocketServices,
@@ -221,8 +221,11 @@ impl AuthenticatedSession {
     fn record_current_span(&self) {
         let span = Span::current();
         span.record("room_id", field::display(self.user.room_id()));
-        span.record("user_id", field::debug(self.user.user_id()));
-        span.record("connection_id", field::debug(self.user.connection_id()));
+        span.record(
+            "user_id",
+            field::display(self.user.user_id().path_segment()),
+        );
+        span.record("connection_id", self.user.connection_id().as_u64());
         span.record(
             telemetry_field::REMOTE_ADDRESS,
             field::display(self.user.remote_address()),
@@ -235,8 +238,8 @@ impl AuthenticatedSession {
         let span = telemetry::activated_span(info_span!(
             "user.initialize",
             room_id = %self.user.room_id(),
-            user_id = ?self.user.user_id(),
-            connection_id = ?self.user.connection_id(),
+            user_id = %self.user.user_id().path_segment(),
+            connection_id = self.user.connection_id().as_u64(),
             remote_address = %self.user.remote_address()
         ));
         async move {


### PR DESCRIPTION
  In logs, we record correlation fields such as `room_id`, `user_id`,
  `connection_id`, and `remote_address` on tracing spans, but the JSON
  formatter currently only inherits the trace_id. So nested events
  lose useful session context in final logs.

  Update the JSON formatter to inherit room_id, user_id,
  connection_id, and remote_address from active spans:

  - Flatten inherited fields into the top-level JSON object.
  - Apply outer spans before inner spans, with explicit event fields taking precedence.
  - Only inherit the approved correlation fields; do not copy arbitrary span fields.
  - Preserve the existing trace_id behavior.
  - Update runtime span producers to emit `user_id` and `connection_id` in a way that
  matches core lifecycle events.
  - Add regression tests to `TESTS/setup.rs` covering span inheritance and field precedence.

  Closes #690

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [x] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

AI was used for Rust concept exploration and code optimization.