### PR TITLE
[IMP] config: name the authentication_timeout_ms default

### DIFF
--- a/src/config/TESTS/loader.rs
+++ b/src/config/TESTS/loader.rs
@@ -8,7 +8,8 @@ use base64::{
 use super::super::transport::default_rtc_media_worker_count;
 use crate::{
     config::{
-        Bitrate, CodecPreferences, Config, DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
+        Bitrate, CodecPreferences, Config, DEFAULT_AUTHENTICATION_TIMEOUT_MS,
+        DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
         DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN, DiagnosticsConfig, MediaCodecFlags,
         RtcPortRange, RuntimeFeatureFlags, TelemetryConfig, VideoBitrateLimits,
     },
@@ -75,7 +76,10 @@ fn config_uses_defaults_and_explicit_values() -> anyhow::Result<()> {
     assert_eq!(config.http.bind_address.to_string(), "0.0.0.0:8070");
     assert_eq!(config.http.shutdown_timeout_ms, 10_000);
     assert_eq!(config.auth.key, TEST_AUTH_KEY);
-    assert_eq!(config.auth.authentication_timeout_ms, 10_000);
+    assert_eq!(
+        config.auth.authentication_timeout_ms,
+        DEFAULT_AUTHENTICATION_TIMEOUT_MS
+    );
     assert_eq!(
         config.auth.max_pre_auth_websocket_sessions,
         DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS

--- a/src/config/auth.rs
+++ b/src/config/auth.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, anyhow, ensure};
 use o_sfu_rfc::jwt::HS256_MIN_KEY_BYTES;
 
 use super::{
-    AuthConfig, DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
+    AuthConfig, DEFAULT_AUTHENTICATION_TIMEOUT_MS, DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
     DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN,
     env::{Env, EnvKey, positive},
 };
@@ -12,7 +12,10 @@ impl AuthConfig {
     pub(super) fn from_env(env: &Env<'_>) -> Result<Self> {
         Ok(Self {
             key: env.var("AUTH_KEY").check(validate_auth_key).required()?,
-            authentication_timeout_ms: env.var("AUTHENTICATION_TIMEOUT_MS").default(10_000)?,
+            authentication_timeout_ms: env
+                .var("AUTHENTICATION_TIMEOUT_MS")
+                .check(positive)
+                .default(DEFAULT_AUTHENTICATION_TIMEOUT_MS)?,
             max_pre_auth_websocket_sessions: env
                 .var("MAX_PRE_AUTH_WEBSOCKET_SESSIONS")
                 .check(positive)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,8 @@ pub use self::{
     diagnostics::DiagnosticsConfig,
     feature_flags::RuntimeFeatureFlags,
     settings::{
-        AuthConfig, CodecConfig, Config, DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
+        AuthConfig, CodecConfig, Config, DEFAULT_AUTHENTICATION_TIMEOUT_MS,
+        DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
         DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN, HttpConfig, TransportConfig,
         UserConfig,
     },

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -11,6 +11,7 @@ use super::{
     feature_flags::RuntimeFeatureFlags, telemetry::TelemetryConfig,
 };
 
+pub const DEFAULT_AUTHENTICATION_TIMEOUT_MS: u64 = 10_000;
 pub const DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS: usize = 512;
 pub const DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN: usize = 16;
 

--- a/src/runtime/TESTS/support.rs
+++ b/src/runtime/TESTS/support.rs
@@ -9,9 +9,10 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 pub(super) use crate::runtime::metrics::test_support::RuntimeMetricsSnapshotTestExt;
 use crate::{
     config::{
-        AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config, DiagnosticsConfig, HttpConfig,
-        MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcUdpIoBackend, RuntimeFeatureFlags,
-        TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning, VideoBitrateLimits,
+        AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config,
+        DEFAULT_AUTHENTICATION_TIMEOUT_MS, DiagnosticsConfig, HttpConfig, MediaCodecFlags,
+        RoomMediaLimits, RoomWorkerPolicy, RtcUdpIoBackend, RuntimeFeatureFlags, TelemetryConfig,
+        TransportConfig, UserConfig, VideoAdaptationTuning, VideoBitrateLimits,
     },
     runtime::{
         MediaTransport, RuntimeServices, RuntimeState, build_media_transport, build_room_manager,
@@ -44,7 +45,7 @@ impl RuntimeTestBuilder {
             config: Config {
                 auth: AuthConfig {
                     key: TEST_AUTH_KEY.to_owned(),
-                    authentication_timeout_ms: 10_000,
+                    authentication_timeout_ms: DEFAULT_AUTHENTICATION_TIMEOUT_MS,
                     max_pre_auth_websocket_sessions: 512,
                     max_pre_auth_websocket_sessions_per_origin: 16,
                 },


### PR DESCRIPTION
  Hoist the inline `.default(10_000)` into a named `DEFAULT_AUTHENTICATION_TIMEOUT_MS` constant, matching the sibling fields on AuthConfig, and validate the env var with `positive` to reject non-positive values.

  Closes #681

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [x] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
