### PR TITLE
[CLN] tests: use env vars default values

### DIFF
--- a/src/runtime/TESTS/support.rs
+++ b/src/runtime/TESTS/support.rs
@@ -10,9 +10,10 @@ pub(super) use crate::runtime::metrics::test_support::RuntimeMetricsSnapshotTest
 use crate::{
     config::{
         AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config,
-        DEFAULT_AUTHENTICATION_TIMEOUT_MS, DiagnosticsConfig, HttpConfig, MediaCodecFlags,
-        RoomMediaLimits, RoomWorkerPolicy, RtcUdpIoBackend, RuntimeFeatureFlags, TelemetryConfig,
-        TransportConfig, UserConfig, VideoAdaptationTuning, VideoBitrateLimits,
+        DEFAULT_AUTHENTICATION_TIMEOUT_MS, DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
+        DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN, DiagnosticsConfig, HttpConfig,
+        MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcUdpIoBackend, RuntimeFeatureFlags,
+        TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning, VideoBitrateLimits,
     },
     runtime::{
         MediaTransport, RuntimeServices, RuntimeState, build_media_transport, build_room_manager,
@@ -46,8 +47,9 @@ impl RuntimeTestBuilder {
                 auth: AuthConfig {
                     key: TEST_AUTH_KEY.to_owned(),
                     authentication_timeout_ms: DEFAULT_AUTHENTICATION_TIMEOUT_MS,
-                    max_pre_auth_websocket_sessions: 512,
-                    max_pre_auth_websocket_sessions_per_origin: 16,
+                    max_pre_auth_websocket_sessions: DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
+                    max_pre_auth_websocket_sessions_per_origin:
+                        DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN,
                 },
                 http: HttpConfig {
                     bind_address: SocketAddr::from(([127, 0, 0, 1], 0)),

--- a/tests/src/support/harness.rs
+++ b/tests/src/support/harness.rs
@@ -18,7 +18,9 @@ use o_sfu::{
         HttpDisconnectClaims, HttpRoomClaims, RegisteredJwtClaims, WebSocketConnectClaims, sign,
     },
     config::{
-        AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config, DiagnosticsConfig, HttpConfig,
+        AuthConfig, Bitrate, CodecConfig, CodecPreferences, Config,
+        DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
+        DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN, DiagnosticsConfig, HttpConfig,
         MediaCodecFlags, RoomMediaLimits, RoomWorkerPolicy, RtcUdpIoBackend, RuntimeFeatureFlags,
         TelemetryConfig, TransportConfig, UserConfig, VideoAdaptationTuning, VideoBitrateLimits,
     },
@@ -427,8 +429,9 @@ pub fn test_config(authentication_timeout_ms: u64, room_size: usize) -> Config {
         auth: AuthConfig {
             key: TEST_AUTH_KEY.to_owned(),
             authentication_timeout_ms,
-            max_pre_auth_websocket_sessions: 512,
-            max_pre_auth_websocket_sessions_per_origin: 16,
+            max_pre_auth_websocket_sessions: DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS,
+            max_pre_auth_websocket_sessions_per_origin:
+                DEFAULT_MAX_PRE_AUTH_WEBSOCKET_SESSIONS_PER_ORIGIN,
         },
         http: HttpConfig {
             bind_address: SocketAddr::from(([127, 0, 0, 1], 0)),


### PR DESCRIPTION
clean up hardcoded env vars defaults.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [x] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
