### PR TITLE
[FIX] core: report committed policy changes

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -333,6 +333,20 @@ common fields it needs and tolerate unknown extra keys
 the reviewed event and field catalog lives in `crates/telemetry/src/schema.rs`
 the formatter is in `crates/telemetry/src/setup.rs`
 
+`source_policy.route_changed` reports a receiver video route transition only
+after the media transport and current room topology accept it. `outcome` is
+`degraded`, `paused` or `resumed`. A pause reports the applied policy `reason`.
+A resume reports the policy `reason` that was cleared. Route identity, receiver
+bandwidth, selected budget and selected encoding fields provide the route-level
+context. `planned_active_video_route_count` and
+`planned_selected_video_bitrate_bps` report the final post-hysteresis solver
+snapshot. They can include a sibling route displaced while transport work was
+in flight.
+
+`osfu_budget_solver_outcomes_total` counts the same committed transitions.
+Held hysteresis, pause reason replacements, budget-only updates, initial
+selector resolution and rejected stale work do not increment it.
+
 ## NGINX public edge
 
 ```nginx

--- a/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
@@ -1,21 +1,24 @@
 use std::time::Duration;
 
+use o_sfu_telemetry::schema::event as telemetry_event;
+use serde_json::json;
 use tokio::time::timeout;
 
-use super::support::*;
+use super::{super::tracing as test_tracing, support::*};
 use crate::engine::{
     UserInfo,
     media_transport::{
-        ActiveSpeakerSource, ReceiverBandwidthSnapshot, TransportBitrateSnapshot, TransportMediaId,
-        TransportTeardown,
+        ActiveSpeakerSource, ReceiverBandwidthSnapshot, SourcePolicyUpdateSubscription,
+        TransportBitrateSnapshot, TransportMediaId, TransportTeardown,
     },
+    metrics::{MetricName, test_support::RuntimeMetricsSnapshotLookup},
     room::{
         DeactivateIntentOutcome, media_graph::ReceiverRouteActivity,
         source_policy::SourcePolicyTransaction, state::RoomState,
     },
     source_model::{
-        ConsumerSourceSelection, PublishedSourceId, SourceDeactivateIntent, SourcePolicy,
-        SourcePublishIntent,
+        ConsumerSourceSelection, PolicyPauseReason, PublishedSourceId, SourceDeactivateIntent,
+        SourcePolicy, SourcePublishIntent,
     },
 };
 
@@ -66,12 +69,17 @@ async fn assert_scalable_video_rid_for_publishers(
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn two_party_camera_publish_selects_the_highest_consumer_layer() {
     let (room, adapter, metrics, mut publisher_rx, mut subscriber_rx) =
         setup_two_ready_users_with_media_metrics().await;
 
+    let transitions_before = route_transition_counts(&room);
+    let capture = test_tracing::capture().await;
     publish_simulcast_camera(&room, &UserId::Integer(1), &adapter).await;
+    assert_no_route_change_event(&room, &UserId::Integer(2));
+    drop(capture);
+    assert_eq!(route_transition_counts(&room), transitions_before);
 
     assert!(drain_outbound(&mut publisher_rx).is_empty());
     assert_remote_track_snapshot_for_stream(
@@ -1253,13 +1261,13 @@ async fn audio_only_receiver_reports_its_audio_reserve_as_bwe_demand() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
     // A high multiparty threshold forces each route to start at its top layer, so
     // the aggregate overload loop — not per-route selection — does the stepping.
     let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
         .expect("valid tuning should build");
-    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2], tuning).await;
     // Three layers (lo=150, mid=450, hi=900 kbps) so one down-step lands on the
     // middle layer rather than the cheapest.
     publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
@@ -1273,7 +1281,7 @@ async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
         .transport_user_key(&receiver_user_id, receiver_connection_id)
         .await;
     let receiver_bandwidth_snapshot = ReceiverBandwidthSnapshot {
-        per_session: vec![(receiver_session_key, Bitrate::from_kbps(500))],
+        per_session: vec![(receiver_session_key.clone(), Bitrate::from_kbps(500))],
     };
 
     let tx = {
@@ -1281,6 +1289,15 @@ async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
         plan_policy(&state, &[], &receiver_bandwidth_snapshot)
             .expect("overload should step the thumbnail down")
     };
+    let transitions_before = route_transition_counts(&scenario.room);
+    let selection_updates_before = source_selection_update_count(&scenario.room, "encoding");
+    let source_media = source_media_id(
+        &scenario.room,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+    )
+    .await;
+    let capture = test_tracing::capture().await;
     tx.execute(&scenario.room, &scenario.adapter).await;
 
     // The route survives at the middle layer and stays deliverable (no pause),
@@ -1301,6 +1318,83 @@ async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
         &UserId::Integer(1),
         TestSourceKind::ScalableVideo,
         None,
+    )
+    .await;
+    assert_eq!(
+        route_transition_counts(&scenario.room),
+        RouteTransitionCounts {
+            degraded: transitions_before.degraded + 1,
+            ..transitions_before
+        }
+    );
+    assert_eq!(
+        source_selection_update_count(&scenario.room, "encoding"),
+        selection_updates_before + 1
+    );
+    assert_route_change_event(
+        &scenario,
+        &receiver_user_id,
+        &UserId::Integer(1),
+        &receiver_session_key,
+        source_media,
+        ExpectedRouteChange {
+            outcome: "degraded",
+            reason: None,
+            receiver_bandwidth: Bitrate::from_kbps(500),
+            video_budget: Bitrate::from_kbps(500),
+            active_route_count: 1,
+            selected_video_bitrate: Bitrate::from_kbps(450),
+            selected_estimated_bitrate: Bitrate::from_kbps(450),
+        },
+    )
+    .await;
+    drop(capture);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn inactive_route_does_not_report_an_in_flight_degradation() {
+    let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
+        .expect("valid tuning should build");
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2], tuning).await;
+    let publisher = UserId::Integer(1);
+    let receiver = UserId::Integer(2);
+    publish_three_layer_camera(&scenario.room, &publisher, &scenario.adapter).await;
+    let connection_id = user_connection_id(&scenario.room, &receiver).await;
+    let session_key = scenario
+        .room
+        .transport_user_key(&receiver, connection_id)
+        .await;
+    let bandwidth = ReceiverBandwidthSnapshot {
+        per_session: vec![(session_key, Bitrate::from_kbps(500))],
+    };
+    let tx = {
+        let state = scenario.room.state.read().await;
+        plan_policy(&state, &[], &bandwidth).expect("overload should plan one route degradation")
+    };
+    update_subscription_selection(
+        &scenario.room,
+        &receiver,
+        &publisher,
+        TestSourceKind::ScalableVideo,
+        |selection| selection.set_active(false),
+    )
+    .await;
+    let transitions_before = route_transition_counts(&scenario.room);
+    let capture = test_tracing::capture().await;
+
+    tx.execute(&scenario.room, &scenario.adapter).await;
+
+    assert_no_route_change_event(&scenario.room, &receiver);
+    drop(capture);
+    assert_eq!(route_transition_counts(&scenario.room), transitions_before);
+    assert_receiver_video_allocation(
+        &scenario,
+        &receiver,
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(500),
+        1,
+        0,
+        Bitrate::zero(),
     )
     .await;
 }
@@ -1346,6 +1440,96 @@ async fn overload_steps_hidden_route_before_visible_thumbnail() {
         &UserId::Integer(3),
         TestSourceKind::ScalableVideo,
         "hi",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejected_route_control_reconciles_sibling_budget_to_committed_selection() {
+    let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
+        .expect("valid tuning should build");
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
+    publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
+    publish_three_layer_camera(&scenario.room, &UserId::Integer(3), &scenario.adapter).await;
+    scenario
+        .set_scalable_video_layout(2, 1, VideoLayoutIntent::Hidden)
+        .await;
+    let receiver = UserId::Integer(2);
+    let connection_id = user_connection_id(&scenario.room, &receiver).await;
+    let session_key = scenario
+        .room
+        .transport_user_key(&receiver, connection_id)
+        .await;
+    let first_source_media = source_media_id(
+        &scenario.room,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+    )
+    .await;
+    let third_source_media = source_media_id(
+        &scenario.room,
+        &UserId::Integer(3),
+        TestSourceKind::ScalableVideo,
+    )
+    .await;
+    let first_consumer_media =
+        consumer_destination_identity(&scenario.adapter, first_source_media, &receiver)
+            .await
+            .0;
+    let bandwidth = ReceiverBandwidthSnapshot {
+        per_session: vec![(session_key.clone(), Bitrate::from_kbps(900))],
+    };
+    let tx = {
+        let state = scenario.room.state.read().await;
+        plan_policy(&state, &[], &bandwidth).expect("overload should plan route degradation")
+    };
+    scenario
+        .adapter
+        .teardown([TransportTeardown::RemoveMedia {
+            session_key: session_key.clone(),
+            transport_media_id: first_consumer_media,
+        }])
+        .await;
+    let transitions_before = route_transition_counts(&scenario.room);
+    let capture = test_tracing::capture().await;
+
+    tx.execute(&scenario.room, &scenario.adapter).await;
+
+    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "hi").await;
+    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [3], "mid").await;
+    assert_route_change_event(
+        &scenario,
+        &receiver,
+        &UserId::Integer(3),
+        &session_key,
+        third_source_media,
+        ExpectedRouteChange {
+            outcome: "degraded",
+            reason: None,
+            receiver_bandwidth: Bitrate::from_kbps(900),
+            video_budget: Bitrate::from_kbps(900),
+            active_route_count: 2,
+            selected_video_bitrate: Bitrate::from_kbps(600),
+            selected_estimated_bitrate: Bitrate::from_kbps(450),
+        },
+    )
+    .await;
+    drop(capture);
+    assert_eq!(
+        route_transition_counts(&scenario.room),
+        RouteTransitionCounts {
+            degraded: transitions_before.degraded + 1,
+            ..transitions_before
+        }
+    );
+    assert_receiver_video_allocation(
+        &scenario,
+        &receiver,
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(900),
+        2,
+        2,
+        Bitrate::from_kbps(1_350),
     )
     .await;
 }
@@ -1446,110 +1630,88 @@ async fn video_download_limit_pauses_every_route_beyond_the_limit() {
     assert_receiver_bwe_target(&scenario.room, &scenario.adapter, &receiver, selected_video).await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
+async fn replacing_a_pause_reason_is_not_a_new_pause_transition() {
+    let scenario = SourcePolicyScenario::with_ready_users_and_media_limits(
+        &[1, 2, 3],
+        RoomMediaLimits::try_new(4, 1).unwrap(),
+    )
+    .await;
+    scenario.publish_audio_and_camera_for_users(&[1, 3]).await;
+    scenario
+        .set_scalable_video_layout(2, 3, VideoLayoutIntent::Pinned)
+        .await;
+    scenario.refresh_policy_until_upgrades_settle().await;
+    let receiver = UserId::Integer(2);
+    let publisher = UserId::Integer(1);
+    update_subscription_selection(
+        &scenario.room,
+        &receiver,
+        &publisher,
+        TestSourceKind::ScalableVideo,
+        |selection| {
+            selection.set_policy_pause_reason(Some(PolicyPauseReason::BudgetPressure));
+        },
+    )
+    .await;
+    let transitions_before = route_transition_counts(&scenario.room);
+    let capture = test_tracing::capture().await;
+
+    scenario.refresh_policy().await;
+
+    test_tracing::assert_no_event(
+        telemetry_event::SOURCE_POLICY_ROUTE_CHANGED,
+        &[
+            ("room_id", json!(scenario.room.uuid())),
+            ("user_id", json!("2")),
+            ("producer_user_id", json!("1")),
+        ],
+    );
+    drop(capture);
+    assert_eq!(route_transition_counts(&scenario.room), transitions_before);
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver,
+        &publisher,
+        TestSourceKind::ScalableVideo,
+        Some(DiagnosticsPolicyPauseReason::VideoDownloadLimit),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn constrained_bandwidth_pauses_then_recovers_and_upgrades_a_pinned_route() {
     let scenario = SourcePolicyScenario::three_ready_users().await;
     publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
+    scenario.subscribe_scalable_video(3, 1, false).await;
     scenario
         .set_scalable_video_layout(2, 1, VideoLayoutIntent::Pinned)
         .await;
     let receiver = UserId::Integer(2);
     assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "hi").await;
-    let source_media = source_media_id(
-        &scenario.room,
-        &UserId::Integer(1),
-        TestSourceKind::ScalableVideo,
-    )
-    .await;
     let connection_id = user_connection_id(&scenario.room, &receiver).await;
-    let session_key = scenario
-        .room
-        .transport_user_key(&receiver, connection_id)
-        .await;
-    // The 150 kbps low layer cannot fit, so policy must pause delivery without
-    // removing the demand str0m needs to probe for its recovery.
-    let receiver_bandwidth = ReceiverBandwidthSnapshot {
-        per_session: vec![(session_key.clone(), Bitrate::from_kbps(100))],
+    let route = SingleVideoRoute {
+        receiver,
+        session_key: scenario
+            .room
+            .transport_user_key(&UserId::Integer(2), connection_id)
+            .await,
+        source_media: source_media_id(
+            &scenario.room,
+            &UserId::Integer(1),
+            TestSourceKind::ScalableVideo,
+        )
+        .await,
     };
     let policy_updates = scenario.adapter.source_policy_subscription();
     let _ = policy_updates.take_pending_updates();
-    apply_policy_observations(
-        &scenario,
-        &receiver_bandwidth,
-        VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS,
-    )
-    .await;
-    assert_receiver_bwe_target(
-        &scenario.room,
-        &scenario.adapter,
-        &receiver,
-        Bitrate::from_kbps(900),
-    )
-    .await;
-    let follow_up = timeout(Duration::from_secs(1), policy_updates.wait_for_update())
-        .await
-        .expect("unresolved hysteresis should schedule another policy pass");
-    assert!(follow_up.contains(&scenario.room.instance_id()));
-
-    assert_subscription_policy_pause_reason(
-        &scenario.room,
-        &scenario.adapter,
-        &receiver,
-        &UserId::Integer(1),
-        TestSourceKind::ScalableVideo,
-        Some(DiagnosticsPolicyPauseReason::BudgetPressure),
-    )
-    .await;
-    assert_eq!(
-        receiver_selected_video_bitrate(&scenario.room, &scenario.adapter, &receiver).await,
-        Bitrate::zero()
-    );
-    assert_receiver_bwe_target(
-        &scenario.room,
-        &scenario.adapter,
-        &receiver,
-        Bitrate::from_kbps(900),
-    )
-    .await;
-    assert_eq!(
-        active_destination_receivers(&scenario.adapter, [source_media]).await,
-        vec![UserId::Integer(3)]
-    );
-
-    let recovered_bandwidth = ReceiverBandwidthSnapshot {
-        per_session: vec![(session_key.clone(), Bitrate::from_kbps(200))],
-    };
-    apply_policy_observations(
-        &scenario,
-        &recovered_bandwidth,
-        VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
-    )
-    .await;
-
-    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "lo").await;
-    assert_eq!(
-        active_destination_receivers(&scenario.adapter, [source_media]).await,
-        vec![receiver.clone(), UserId::Integer(3)]
-    );
-
-    let upgraded_bandwidth = ReceiverBandwidthSnapshot {
-        per_session: vec![(session_key, Bitrate::from_kbps(450))],
-    };
-    apply_policy_observations(
-        &scenario,
-        &upgraded_bandwidth,
-        VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
-    )
-    .await;
-
-    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "mid").await;
-    assert_receiver_bwe_target(
-        &scenario.room,
-        &scenario.adapter,
-        &receiver,
-        Bitrate::from_kbps(900),
-    )
-    .await;
+    let transitions_before = route_transition_counts(&scenario.room);
+    assert_pressure_hysteresis_hold(&scenario, &route, transitions_before).await;
+    let paused = assert_budget_pause(&scenario, &route, &policy_updates, transitions_before).await;
+    assert_repeated_pause_is_silent(&scenario, &route, paused).await;
+    let resumed = assert_recovery_hysteresis_and_resume(&scenario, &route, paused).await;
+    assert_upgrade_is_not_degradation(&scenario, &route, resumed).await;
 }
 
 #[tokio::test]
@@ -1689,6 +1851,89 @@ async fn zero_budget_pauses_observed_ridless_readable_video() {
     .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn rejected_ridless_pause_preserves_observed_committed_bitrate() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    let publisher = UserId::Integer(1);
+    let receiver = UserId::Integer(2);
+    publish_track(
+        &scenario.room,
+        &publisher,
+        TestSourceKind::ReadableVideo,
+        MediaKind::Video,
+        test_video_rtp_parameters(),
+        &scenario.adapter,
+    )
+    .await;
+    // Publishing can consume the first pressure observation. Reset the route so
+    // the explicit snapshots straddle the hysteresis threshold.
+    reset_subscription_selection_to_open(
+        &scenario.room,
+        &receiver,
+        &publisher,
+        TestSourceKind::ReadableVideo,
+    )
+    .await;
+    let source_media =
+        source_media_id(&scenario.room, &publisher, TestSourceKind::ReadableVideo).await;
+    let connection_id = user_connection_id(&scenario.room, &receiver).await;
+    let session_key = scenario
+        .room
+        .transport_user_key(&receiver, connection_id)
+        .await;
+    let receiver_bandwidth = ReceiverBandwidthSnapshot {
+        per_session: vec![(session_key.clone(), Bitrate::zero())],
+    };
+    let source_bitrate = TransportBitrateSnapshot {
+        total: Bitrate::from_kbps(500),
+        per_media: vec![(source_media, Bitrate::from_kbps(500))],
+    };
+    for _ in 0..VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS - 1 {
+        let tx = {
+            let state = scenario.room.state.read().await;
+            SourcePolicyTransaction::plan(&state, &[], &receiver_bandwidth, &source_bitrate)
+                .expect("pressure observation should produce a policy update")
+        };
+        tx.execute(&scenario.room, &scenario.adapter).await;
+    }
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan(&state, &[], &receiver_bandwidth, &source_bitrate)
+            .expect("final pressure observation should plan a pause")
+    };
+    scenario
+        .adapter
+        .teardown([TransportTeardown::CloseSession { session_key }])
+        .await;
+    let transitions_before = route_transition_counts(&scenario.room);
+    let capture = test_tracing::capture().await;
+
+    tx.execute(&scenario.room, &scenario.adapter).await;
+
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver,
+        &publisher,
+        TestSourceKind::ReadableVideo,
+        None,
+    )
+    .await;
+    assert_no_route_change_event(&scenario.room, &receiver);
+    drop(capture);
+    assert_eq!(route_transition_counts(&scenario.room), transitions_before);
+    assert_receiver_video_allocation(
+        &scenario,
+        &receiver,
+        TestSourceKind::ReadableVideo,
+        Bitrate::zero(),
+        1,
+        1,
+        Bitrate::from_kbps(500),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn pinned_camera_layout_overrides_active_speaker_bias_for_that_receiver() {
     let scenario = SourcePolicyScenario::three_ready_users().await;
@@ -1739,7 +1984,7 @@ async fn screen_share_layout_uses_screen_specific_priority_in_diagnostics() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn source_policy_replaced_route_does_not_commit_stale_selector_update() {
     let scenario = SourcePolicyScenario::with_ready_users_and_media_limits(
         &[1, 2, 3],
@@ -1765,7 +2010,17 @@ async fn source_policy_replaced_route_does_not_commit_stale_selector_update() {
             .source_selection_for_test(&receiver, third_camera_source_id)
             .expect("replacement route should select the current publication")
     };
+    let transitions_before = route_transition_counts(&scenario.room);
+    let selection_updates_before = source_selection_update_count(&scenario.room, "encoding");
+    let capture = test_tracing::capture().await;
     tx.execute(&scenario.room, &scenario.adapter).await;
+    assert_no_route_change_event(&scenario.room, &receiver);
+    drop(capture);
+    assert_eq!(route_transition_counts(&scenario.room), transitions_before);
+    assert_eq!(
+        source_selection_update_count(&scenario.room, "encoding"),
+        selection_updates_before
+    );
     let current_selection = {
         let state = scenario.room.state.read().await;
         state
@@ -1775,7 +2030,7 @@ async fn source_policy_replaced_route_does_not_commit_stale_selector_update() {
     assert_eq!(current_selection, Some(replacement_selection));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn source_policy_rejected_transport_gate_does_not_commit_selector_update() {
     let scenario = SourcePolicyScenario::with_ready_users_and_media_limits(
         &[1, 2, 3],
@@ -1796,7 +2051,17 @@ async fn source_policy_rejected_transport_gate_does_not_commit_selector_update()
             session_key: receiver_session_key,
         }])
         .await;
+    let transitions_before = route_transition_counts(&scenario.room);
+    let selection_updates_before = source_selection_update_count(&scenario.room, "encoding");
+    let capture = test_tracing::capture().await;
     tx.execute(&scenario.room, &scenario.adapter).await;
+    assert_no_route_change_event(&scenario.room, &UserId::Integer(2));
+    drop(capture);
+    assert_eq!(route_transition_counts(&scenario.room), transitions_before);
+    assert_eq!(
+        source_selection_update_count(&scenario.room, "encoding"),
+        selection_updates_before
+    );
 
     assert_subscription_policy_pause_reason(
         &scenario.room,
@@ -1890,6 +2155,23 @@ async fn reset_subscription_selection_to_open(
     producer_user_id: &UserId,
     stream_type: TestSourceKind,
 ) {
+    update_subscription_selection(
+        room,
+        consumer_user_id,
+        producer_user_id,
+        stream_type,
+        |selection| *selection = ConsumerSourceSelection::open(true),
+    )
+    .await;
+}
+
+async fn update_subscription_selection(
+    room: &Room,
+    consumer_user_id: &UserId,
+    producer_user_id: &UserId,
+    stream_type: TestSourceKind,
+    update: impl FnOnce(&mut ConsumerSourceSelection),
+) {
     let stream_id = stream_id_for_source(stream_type);
     let state = room.state.read().await;
     let route = state
@@ -1907,14 +2189,10 @@ async fn reset_subscription_selection_to_open(
     drop(state);
 
     let mut state = room.state.write().await;
-    let updated = state.topology.update_consumer_source_selection(
-        &key,
-        source_id,
-        &transport_route,
-        |selection| {
-            *selection = ConsumerSourceSelection::open(true);
-        },
-    );
+    let updated =
+        state
+            .topology
+            .update_consumer_source_selection(&key, source_id, &transport_route, update);
     drop(state);
     assert!(updated);
 }
@@ -1922,4 +2200,398 @@ async fn reset_subscription_selection_to_open(
 fn keyframe_request_count(metrics: &RuntimeMetrics) -> u64 {
     let snapshot = metrics.snapshot();
     snapshot.rtc_keyframe_requests_forwarded() + snapshot.rtc_keyframe_requests_absorbed()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RouteTransitionCounts {
+    degraded: u64,
+    paused: u64,
+    resumed: u64,
+}
+
+fn route_transition_counts(room: &Room) -> RouteTransitionCounts {
+    let snapshot = room.metrics.snapshot();
+    let outcome_count = |value| {
+        snapshot.counter_value(MetricName::BudgetSolverOutcomesTotal, &[("outcome", value)])
+    };
+    RouteTransitionCounts {
+        degraded: outcome_count("degraded"),
+        paused: outcome_count("paused"),
+        resumed: outcome_count("resumed"),
+    }
+}
+
+fn source_selection_update_count(room: &Room, selector: &str) -> u64 {
+    room.metrics.snapshot().counter_value(
+        MetricName::SourceSelectionUpdatesTotal,
+        &[("selector", selector)],
+    )
+}
+
+struct SingleVideoRoute {
+    receiver: UserId,
+    session_key: TransportSessionKey,
+    source_media: TransportMediaId,
+}
+
+impl SingleVideoRoute {
+    fn bandwidth(&self, kbps: u64) -> ReceiverBandwidthSnapshot {
+        ReceiverBandwidthSnapshot {
+            per_session: vec![(self.session_key.clone(), Bitrate::from_kbps(kbps))],
+        }
+    }
+}
+
+async fn assert_pressure_hysteresis_hold(
+    scenario: &SourcePolicyScenario,
+    route: &SingleVideoRoute,
+    expected_transitions: RouteTransitionCounts,
+) {
+    let capture = test_tracing::capture().await;
+    apply_policy_observations(
+        scenario,
+        &route.bandwidth(100),
+        VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS - 1,
+    )
+    .await;
+    assert_no_route_change_event(&scenario.room, &route.receiver);
+    drop(capture);
+    assert_scalable_video_rid_for_publishers(scenario, &route.receiver, [1], "hi").await;
+    assert_receiver_video_allocation(
+        scenario,
+        &route.receiver,
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(100),
+        1,
+        1,
+        Bitrate::from_kbps(900),
+    )
+    .await;
+    assert_eq!(
+        route_transition_counts(&scenario.room),
+        expected_transitions
+    );
+}
+
+async fn assert_budget_pause(
+    scenario: &SourcePolicyScenario,
+    route: &SingleVideoRoute,
+    policy_updates: &SourcePolicyUpdateSubscription,
+    previous_transitions: RouteTransitionCounts,
+) -> RouteTransitionCounts {
+    let capture = test_tracing::capture().await;
+    apply_policy_observations(scenario, &route.bandwidth(100), 1).await;
+    assert_receiver_bwe_target(
+        &scenario.room,
+        &scenario.adapter,
+        &route.receiver,
+        Bitrate::from_kbps(900),
+    )
+    .await;
+    let follow_up = timeout(Duration::from_secs(1), policy_updates.wait_for_update())
+        .await
+        .expect("unresolved hysteresis should schedule another policy pass");
+    assert!(follow_up.contains(&scenario.room.instance_id()));
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &route.receiver,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+        Some(DiagnosticsPolicyPauseReason::BudgetPressure),
+    )
+    .await;
+    assert_receiver_video_allocation(
+        scenario,
+        &route.receiver,
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(100),
+        1,
+        0,
+        Bitrate::zero(),
+    )
+    .await;
+    let transitions = RouteTransitionCounts {
+        paused: previous_transitions.paused + 1,
+        ..previous_transitions
+    };
+    assert_eq!(route_transition_counts(&scenario.room), transitions);
+    assert_route_change_event(
+        scenario,
+        &route.receiver,
+        &UserId::Integer(1),
+        &route.session_key,
+        route.source_media,
+        ExpectedRouteChange {
+            outcome: "paused",
+            reason: Some("budget_pressure"),
+            receiver_bandwidth: Bitrate::from_kbps(100),
+            video_budget: Bitrate::from_kbps(100),
+            active_route_count: 0,
+            selected_video_bitrate: Bitrate::zero(),
+            selected_estimated_bitrate: Bitrate::from_kbps(900),
+        },
+    )
+    .await;
+    drop(capture);
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [route.source_media]).await,
+        Vec::<UserId>::new()
+    );
+    transitions
+}
+
+async fn assert_repeated_pause_is_silent(
+    scenario: &SourcePolicyScenario,
+    route: &SingleVideoRoute,
+    expected_transitions: RouteTransitionCounts,
+) {
+    let capture = test_tracing::capture().await;
+    apply_policy_observations(scenario, &route.bandwidth(90), 1).await;
+    assert_no_route_change_event(&scenario.room, &route.receiver);
+    drop(capture);
+    assert_receiver_video_allocation(
+        scenario,
+        &route.receiver,
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(90),
+        1,
+        0,
+        Bitrate::zero(),
+    )
+    .await;
+    assert_eq!(
+        route_transition_counts(&scenario.room),
+        expected_transitions
+    );
+}
+
+async fn assert_recovery_hysteresis_and_resume(
+    scenario: &SourcePolicyScenario,
+    route: &SingleVideoRoute,
+    paused_transitions: RouteTransitionCounts,
+) -> RouteTransitionCounts {
+    let recovered_bandwidth = route.bandwidth(200);
+    let held_capture = test_tracing::capture().await;
+    apply_policy_observations(
+        scenario,
+        &recovered_bandwidth,
+        VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS - 1,
+    )
+    .await;
+    assert_no_route_change_event(&scenario.room, &route.receiver);
+    drop(held_capture);
+    assert_eq!(route_transition_counts(&scenario.room), paused_transitions);
+    assert_receiver_video_allocation(
+        scenario,
+        &route.receiver,
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(200),
+        1,
+        0,
+        Bitrate::zero(),
+    )
+    .await;
+
+    let resume_capture = test_tracing::capture().await;
+    apply_policy_observations(scenario, &recovered_bandwidth, 1).await;
+    assert_scalable_video_rid_for_publishers(scenario, &route.receiver, [1], "lo").await;
+    let resumed_transitions = RouteTransitionCounts {
+        resumed: paused_transitions.resumed + 1,
+        ..paused_transitions
+    };
+    assert_eq!(route_transition_counts(&scenario.room), resumed_transitions);
+    assert_receiver_video_allocation(
+        scenario,
+        &route.receiver,
+        TestSourceKind::ScalableVideo,
+        Bitrate::from_kbps(200),
+        1,
+        1,
+        Bitrate::from_kbps(150),
+    )
+    .await;
+    assert_route_change_event(
+        scenario,
+        &route.receiver,
+        &UserId::Integer(1),
+        &route.session_key,
+        route.source_media,
+        ExpectedRouteChange {
+            outcome: "resumed",
+            reason: Some("budget_pressure"),
+            receiver_bandwidth: Bitrate::from_kbps(200),
+            video_budget: Bitrate::from_kbps(200),
+            active_route_count: 1,
+            selected_video_bitrate: Bitrate::from_kbps(150),
+            selected_estimated_bitrate: Bitrate::from_kbps(150),
+        },
+    )
+    .await;
+    drop(resume_capture);
+    assert_eq!(
+        active_destination_receivers(&scenario.adapter, [route.source_media]).await,
+        vec![route.receiver.clone()]
+    );
+    resumed_transitions
+}
+
+async fn assert_upgrade_is_not_degradation(
+    scenario: &SourcePolicyScenario,
+    route: &SingleVideoRoute,
+    expected_transitions: RouteTransitionCounts,
+) {
+    let capture = test_tracing::capture().await;
+    apply_policy_observations(
+        scenario,
+        &route.bandwidth(450),
+        VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
+    )
+    .await;
+    assert_no_route_change_event(&scenario.room, &route.receiver);
+    drop(capture);
+    assert_scalable_video_rid_for_publishers(scenario, &route.receiver, [1], "mid").await;
+    assert_eq!(
+        route_transition_counts(&scenario.room),
+        expected_transitions
+    );
+    assert_receiver_bwe_target(
+        &scenario.room,
+        &scenario.adapter,
+        &route.receiver,
+        Bitrate::from_kbps(900),
+    )
+    .await;
+}
+
+fn assert_no_route_change_event(room: &Room, receiver: &UserId) {
+    test_tracing::assert_no_event(
+        telemetry_event::SOURCE_POLICY_ROUTE_CHANGED,
+        &[
+            ("room_id", json!(room.uuid())),
+            ("user_id", json!(receiver.path_segment())),
+        ],
+    );
+}
+
+async fn assert_receiver_video_allocation(
+    scenario: &SourcePolicyScenario,
+    receiver: &UserId,
+    stream_type: TestSourceKind,
+    video_budget: Bitrate,
+    subscription_count: usize,
+    active_route_count: usize,
+    selected_video_bitrate: Bitrate,
+) {
+    let (users, _) = diagnostics_room_views(&scenario.room, &scenario.adapter).await;
+    let stream_id = stream_id_for_source(stream_type);
+    let subscriptions = users
+        .iter()
+        .find(|user| &user.user_id == receiver)
+        .expect("diagnostics should include the receiver")
+        .subscriptions
+        .iter()
+        .filter(|subscription| subscription.stream_id == stream_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(subscriptions.len(), subscription_count);
+    for subscription in subscriptions {
+        assert_eq!(
+            subscription
+                .selection
+                .latest_receiver_bandwidth_estimate_bps,
+            Some(video_budget.as_bps())
+        );
+        assert_eq!(
+            subscription.selection.selected_video_budget_bps,
+            Some(video_budget.as_bps())
+        );
+        assert_eq!(
+            subscription.selection.active_video_route_count,
+            active_route_count
+        );
+        assert_eq!(
+            subscription.selection.selected_video_bitrate_bps,
+            selected_video_bitrate.as_bps()
+        );
+    }
+}
+
+struct ExpectedRouteChange<'a> {
+    outcome: &'a str,
+    reason: Option<&'a str>,
+    receiver_bandwidth: Bitrate,
+    video_budget: Bitrate,
+    active_route_count: usize,
+    selected_video_bitrate: Bitrate,
+    selected_estimated_bitrate: Bitrate,
+}
+
+async fn assert_route_change_event(
+    scenario: &SourcePolicyScenario,
+    receiver: &UserId,
+    publisher: &UserId,
+    session_key: &TransportSessionKey,
+    source_media_id: TransportMediaId,
+    expected: ExpectedRouteChange<'_>,
+) {
+    let (users, _) = diagnostics_room_views(&scenario.room, &scenario.adapter).await;
+    let stream_id = stream_id_for_source(TestSourceKind::ScalableVideo);
+    let subscription = users
+        .iter()
+        .find(|user| &user.user_id == receiver)
+        .and_then(|user| {
+            user.subscriptions.iter().find(|subscription| {
+                subscription.producer_user_id == *publisher
+                    && subscription.stream_id == stream_id.as_str()
+            })
+        })
+        .expect("diagnostics should include the subscription");
+    let selection = &subscription.selection;
+    let receiver_id = receiver.path_segment();
+    let consumer_media_id = subscription
+        .consumer_transport_media_id
+        .expect("committed subscription should have a transport media id");
+    let encoding_id = selection
+        .selected_encoding_id
+        .expect("scalable route should select an encoding");
+    let mut fields = vec![
+        ("transport_media_id", json!(consumer_media_id)),
+        ("producer_user_id", json!(publisher.path_segment())),
+        ("source_transport_media_id", json!(source_media_id.as_u64())),
+        ("stream_id", json!(stream_id)),
+        ("outcome", json!(expected.outcome)),
+        (
+            "latest_receiver_bandwidth_estimate_bps",
+            json!(expected.receiver_bandwidth.as_bps()),
+        ),
+        (
+            "selected_video_budget_bps",
+            json!(expected.video_budget.as_bps()),
+        ),
+        (
+            "planned_active_video_route_count",
+            json!(expected.active_route_count),
+        ),
+        (
+            "planned_selected_video_bitrate_bps",
+            json!(expected.selected_video_bitrate.as_bps()),
+        ),
+        ("selector", json!("encoding")),
+        ("selected_encoding_id", json!(encoding_id)),
+        (
+            "selected_estimated_bitrate_bps",
+            json!(expected.selected_estimated_bitrate.as_bps()),
+        ),
+    ];
+    if let Some(reason) = expected.reason {
+        fields.push(("reason", json!(reason)));
+    }
+    test_tracing::assert_user_exact(
+        telemetry_event::SOURCE_POLICY_ROUTE_CHANGED,
+        scenario.room.uuid(),
+        receiver_id.as_ref(),
+        session_key.connection_id().as_u64(),
+        session_key.media_worker_id().as_usize(),
+        &fields,
+    );
 }

--- a/crates/core/src/engine/room/TESTS/tracing.rs
+++ b/crates/core/src/engine/room/TESTS/tracing.rs
@@ -100,6 +100,24 @@ pub(crate) fn assert_exact(name: &str, fields: &[(&str, Value)]) {
     );
 }
 
+pub(crate) fn assert_no_event(name: &str, fields: &[(&str, Value)]) {
+    let events = EVENTS.lock().unwrap_or_else(PoisonError::into_inner);
+    for line in events
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+    {
+        let event: Value = serde_json::from_slice(line).expect("tracing event should be JSON");
+        let event_fields = event["fields"]
+            .as_object()
+            .expect("tracing event should contain fields");
+        let matches = event_fields.get("event").and_then(Value::as_str) == Some(name)
+            && fields
+                .iter()
+                .all(|(field, value)| event_fields.get(*field) == Some(value));
+        assert!(!matches, "unexpected tracing event {name}: {event:?}");
+    }
+}
+
 pub(crate) fn assert_user_exact(
     name: &str,
     room_id: &str,

--- a/crates/core/src/engine/room/media_graph/topology.rs
+++ b/crates/core/src/engine/room/media_graph/topology.rs
@@ -52,6 +52,8 @@ pub struct RoomTopology {
     route_graph: RouteGraph,
     router: Router,
     next_producer_id: u64,
+    // Revision of committed video allocation inputs across transport awaits.
+    video_allocation_revision: u64,
 }
 
 /// Receipt acknowledging that [`RoomTopology`] committed a session placement.
@@ -122,7 +124,16 @@ impl RoomTopology {
             route_graph: RouteGraph::default(),
             router,
             next_producer_id: 1,
+            video_allocation_revision: 0,
         }
+    }
+
+    pub(in crate::engine::room) const fn video_allocation_revision(&self) -> u64 {
+        self.video_allocation_revision
+    }
+
+    fn invalidate_video_allocation(&mut self) {
+        self.video_allocation_revision = self.video_allocation_revision.wrapping_add(1);
     }
 
     pub(in crate::engine::room) fn router(&self) -> &Router {
@@ -349,6 +360,9 @@ impl RoomTopology {
             .route_graph
             .detach_declined_consumers(session, declined);
         let detached = !routes.is_empty();
+        if detached {
+            self.invalidate_video_allocation();
+        }
         let relays = self.resolve_relay_effects(relays);
         for consumer in consumers {
             if let Some(error) = self.router.remove_consumer(consumer).err() {
@@ -391,7 +405,11 @@ impl RoomTopology {
         key: SubscriptionKey,
         intent: SourceSubscriptionIntent,
     ) {
+        if intent.is_empty() {
+            return;
+        }
         self.route_graph.merge_intent(key, intent);
+        self.invalidate_video_allocation();
     }
 
     /// Returns merged receiver intent or the default for a missing subscription.
@@ -516,8 +534,13 @@ impl RoomTopology {
         route: &TransportConsumerRoute,
         update: impl FnOnce(&mut ConsumerSourceSelection),
     ) -> bool {
-        self.route_graph
-            .update_selection(key, source_id, route, update)
+        let updated = self
+            .route_graph
+            .update_selection(key, source_id, route, update);
+        if updated {
+            self.invalidate_video_allocation();
+        }
+        updated
     }
 
     fn detach_user_sources(
@@ -542,6 +565,7 @@ impl RoomTopology {
     ) -> Option<(PublishedSource, RemovedRoutes)> {
         let source = self.sources.remove(source_id)?;
         let routes = self.route_graph.detach_source(source_id);
+        self.invalidate_video_allocation();
         Some((source, routes))
     }
 
@@ -687,7 +711,9 @@ impl RoomTopology {
         }
         source.active = active;
         source.activity_revision = source.activity_revision.next();
-        Some(source.activity_revision)
+        let revision = source.activity_revision;
+        self.invalidate_video_allocation();
+        Some(revision)
     }
 
     pub(super) fn source_activity_effects(
@@ -772,6 +798,9 @@ impl RoomTopology {
                 RoomTransportPlan::from_relays_and_teardown(relay_effects, teardown)
             },
         );
+        if previous_session_key.is_some() {
+            self.invalidate_video_allocation();
+        }
         Ok(SessionPlacementCommit {
             receipt,
             replacement_transport_plan,
@@ -786,6 +815,7 @@ impl RoomTopology {
     pub fn remove_session(&mut self, user_id: &UserId) -> RoomTransportPlan {
         let (sources, mut removed) = self.detach_user_sources(user_id);
         removed.extend(self.route_graph.remove_receiver(user_id));
+        self.invalidate_video_allocation();
         let teardown = Self::media_teardowns(sources, removed.routes);
         // Resolve relay keys before router removal makes source placement unavailable.
         let relay_effects = self.resolve_relay_effects(removed.relays);
@@ -847,6 +877,7 @@ impl RoomTopology {
         if let Err(relays) = result {
             return Err((route, self.resolve_relay_effects(relays)));
         }
+        self.invalidate_video_allocation();
         Ok(CommittedConsumerSetup {
             target,
             route,
@@ -929,6 +960,7 @@ impl RoomTopology {
             active,
             policy_pause_reason,
         )?;
+        self.invalidate_video_allocation();
         let relay_effects = self.resolve_relay_effects(relay_effects);
         let update = self
             .committed_consumer_route_for_key(&key)

--- a/crates/core/src/engine/room/source_policy/action.rs
+++ b/crates/core/src/engine/room/source_policy/action.rs
@@ -1,20 +1,54 @@
 use super::super::media_graph::SubscriptionKey;
-use crate::engine::{
-    ConnectionId, UserId,
-    media_transport::{
-        ConsumerActivity, ConsumerRouteControl, SourcePacketGate, TransportConsumerRoute,
-    },
-    source_model::{
-        ConsumerSourceSelection, PolicyPauseReason, PublishedSourceId,
-        ReceiverVideoBudgetDiagnostics, SourceSelector,
+use crate::{
+    Bitrate,
+    engine::{
+        ConnectionId, UserId,
+        media_transport::{
+            ConsumerActivity, ConsumerRouteControl, SourcePacketGate, TransportConsumerRoute,
+        },
+        source_model::{
+            ConsumerSourceSelection, PolicyPauseReason, PublishedSourceId,
+            ReceiverVideoBudgetDiagnostics, SourceSelector,
+        },
     },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum RouteBudgetOutcome {
+pub(super) enum VideoRouteTransition {
     Degraded,
-    Paused,
-    Resumed,
+    Paused { reason: PolicyPauseReason },
+    Resumed { cleared_reason: PolicyPauseReason },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct VideoRouteAllocationState {
+    pub(super) selector: SourceSelector,
+    pub(super) policy_pause_reason: Option<PolicyPauseReason>,
+    pub(super) selected_bitrate: Bitrate,
+}
+
+impl VideoRouteAllocationState {
+    pub(super) fn matches_selection(self, selection: ConsumerSourceSelection) -> bool {
+        self.selector == selection.selector()
+            && self.policy_pause_reason == selection.policy_pause_reason()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct VideoRouteAllocation {
+    pub(super) key: SubscriptionKey,
+    pub(super) source_id: PublishedSourceId,
+    pub(super) route: TransportConsumerRoute,
+    pub(super) captured: VideoRouteAllocationState,
+    pub(super) planned: Option<VideoRouteAllocationState>,
+}
+
+#[derive(Debug)]
+pub(super) struct ReceiverVideoBudgetPlan {
+    pub(super) receiver: UserId,
+    pub(super) planned_budget: ReceiverVideoBudgetDiagnostics,
+    /// Ordered by [`SubscriptionKey`] for linear reconciliation after transport work.
+    pub(super) routes: Vec<VideoRouteAllocation>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -24,8 +58,9 @@ pub(in crate::engine::room) struct ConsumerPacketSelectionUpdate {
     pub(in crate::engine::room) route: TransportConsumerRoute,
     pub(super) selector: SourceSelector,
     pub(super) policy_pause_reason: Option<PolicyPauseReason>,
-    pub(super) budget: ReceiverVideoBudgetDiagnostics,
-    pub(super) outcome: Option<RouteBudgetOutcome>,
+    pub(super) planned_budget: ReceiverVideoBudgetDiagnostics,
+    pub(super) transition: Option<VideoRouteTransition>,
+    pub(super) selected_estimated_bitrate: Option<Bitrate>,
     pub(super) pressure_observations: u8,
     pub(super) upgrade_observations: u8,
     pub(super) packet_gate: Option<SourcePacketGate>,
@@ -47,8 +82,9 @@ impl ConsumerPacketSelectionUpdate {
             route,
             selector: current_selection.selector(),
             policy_pause_reason,
-            budget: current_selection.budget(),
-            outcome: None,
+            planned_budget: current_selection.budget(),
+            transition: None,
+            selected_estimated_bitrate: None,
             pressure_observations: current_selection.pressure_observations(),
             upgrade_observations: current_selection.upgrade_observations(),
             packet_gate: None,

--- a/crates/core/src/engine/room/source_policy/turn.rs
+++ b/crates/core/src/engine/room/source_policy/turn.rs
@@ -2,8 +2,15 @@
 
 use std::{borrow::Cow, mem};
 
+use o_sfu_router::MediaKind;
+use o_sfu_telemetry::schema::event as telemetry_event;
+use tracing::info;
+
 use super::{
-    action::{ConsumerPacketSelectionUpdate, FeaturedUserUpdate, RouteBudgetOutcome},
+    action::{
+        ConsumerPacketSelectionUpdate, FeaturedUserUpdate, ReceiverVideoBudgetPlan,
+        VideoRouteTransition,
+    },
     audio,
     input::SourcePolicySnapshot,
     video,
@@ -17,6 +24,10 @@ use crate::engine::{
     room::{
         Room, RoomEventMessage, effects::transport::RoomRouteEffects, outbound::MessageFanout,
         state::RoomState,
+    },
+    source_model::{
+        PolicyPauseReason, ReceiverVideoBudgetDiagnostics, SourceAdaptationPolicy,
+        SourceEncodingId, SourceSelector,
     },
 };
 
@@ -132,6 +143,7 @@ async fn run_packet_selection(
 pub(in crate::engine::room) struct SourcePolicyTransaction {
     route_effects: RoomRouteEffects,
     state_updates: Vec<ConsumerPacketSelectionUpdate>,
+    receiver_video_budget_plans: Vec<ReceiverVideoBudgetPlan>,
     featured_users: Vec<FeaturedUserUpdate>,
 }
 
@@ -164,24 +176,36 @@ impl SourcePolicyTransaction {
         self.route_effects.source_policy_update(update);
     }
 
+    pub(super) fn push_receiver_video_budget_plan(&mut self, plan: ReceiverVideoBudgetPlan) {
+        self.receiver_video_budget_plans.push(plan);
+    }
+
     pub(super) fn set_receiver_bwe_targets(&mut self, targets: Vec<ReceiverBweTargetUpdate>) {
         self.route_effects.set_receiver_bwe_targets(targets);
     }
 
     async fn commit(self, room: &Room, media_transport: &MediaTransport) {
-        let mut state_updates = self.state_updates;
-        if !self.route_effects.is_empty() {
+        let Self {
+            route_effects,
+            mut state_updates,
+            receiver_video_budget_plans,
+            featured_users,
+        } = self;
+        if !route_effects.is_empty() {
             // Only accepted transport controls join state-only updates. Room
             // state must not claim a selection that its worker rejected.
-            state_updates.extend(
-                self.route_effects
-                    .execute(room.uuid(), media_transport)
-                    .await,
-            );
+            state_updates.extend(route_effects.execute(room.uuid(), media_transport).await);
         }
         // Only committed nonzero counters schedule another observation. Rejected
         // or topology-stale work must not advance adaptation hysteresis.
-        if commit_accepted_updates(room, &state_updates, &self.featured_users).await {
+        if commit_accepted_updates(
+            room,
+            state_updates,
+            &receiver_video_budget_plans,
+            &featured_users,
+        )
+        .await
+        {
             media_transport.schedule_source_policy_follow_up(room.instance_id());
         }
     }
@@ -198,51 +222,126 @@ impl SourcePolicyTransaction {
     fn is_empty(&self) -> bool {
         self.state_updates.is_empty()
             && self.route_effects.is_empty()
+            && self.receiver_video_budget_plans.is_empty()
             && self.featured_users.is_empty()
     }
 }
 
 async fn commit_accepted_updates(
     room: &Room,
-    state_updates: &[ConsumerPacketSelectionUpdate],
+    state_updates: Vec<ConsumerPacketSelectionUpdate>,
+    receiver_video_budget_plans: &[ReceiverVideoBudgetPlan],
     featured_users: &[FeaturedUserUpdate],
 ) -> bool {
-    if state_updates.is_empty() && featured_users.is_empty() {
+    if state_updates.is_empty()
+        && receiver_video_budget_plans.is_empty()
+        && featured_users.is_empty()
+    {
         return false;
     }
-    record_source_selection_metrics(room, state_updates);
-    let (info_fanout, requires_follow_up) = {
+    let (committed_updates, info_fanout, requires_follow_up) = {
         let mut state = room.state.write().await;
-        let requires_follow_up = commit_packet_updates(&mut state, state_updates);
+        let (committed_updates, requires_follow_up) =
+            commit_packet_updates(&mut state, state_updates, receiver_video_budget_plans);
         let info_fanout = commit_featured_user_updates(&mut state, featured_users);
         drop(state);
-        (info_fanout, requires_follow_up)
+        (committed_updates, info_fanout, requires_follow_up)
     };
+    record_committed_selection_updates(room, &committed_updates);
     if let Some(info_fanout) = info_fanout {
         info_fanout.emit();
     }
     requires_follow_up
 }
 
-fn record_source_selection_metrics(room: &Room, updates: &[ConsumerPacketSelectionUpdate]) {
+fn record_committed_selection_updates(room: &Room, updates: &[ConsumerPacketSelectionUpdate]) {
     for update in updates {
         if update.packet_gate.is_some() {
             room.metrics
                 .record_source_selection_update(metrics::source_selection_kind(update.selector));
         }
-        if let Some(outcome) = update.outcome {
-            room.metrics.record_budget_solver_outcome(match outcome {
-                RouteBudgetOutcome::Degraded => BudgetSolverOutcome::Degraded,
-                RouteBudgetOutcome::Paused => BudgetSolverOutcome::Paused,
-                RouteBudgetOutcome::Resumed => BudgetSolverOutcome::Resumed,
-            });
-        }
+        let Some(transition) = update.transition else {
+            continue;
+        };
+        let (metric_outcome, outcome, reason) = match transition {
+            VideoRouteTransition::Degraded => (BudgetSolverOutcome::Degraded, "degraded", None),
+            VideoRouteTransition::Paused { reason } => {
+                (BudgetSolverOutcome::Paused, "paused", Some(reason))
+            }
+            VideoRouteTransition::Resumed { cleared_reason } => (
+                BudgetSolverOutcome::Resumed,
+                "resumed",
+                Some(cleared_reason),
+            ),
+        };
+        room.metrics.record_budget_solver_outcome(metric_outcome);
+        let consumer = update.route.consumer_session_key();
+        let source = update.route.source_session_key();
+        info!(
+            event = telemetry_event::SOURCE_POLICY_ROUTE_CHANGED,
+            room_id = room.uuid(),
+            user_id = %consumer.user_id().path_segment(),
+            connection_id = consumer.connection_id().as_u64(),
+            media_worker_id = consumer.media_worker_id().as_usize(),
+            transport_media_id = update.route.consumer_transport_media_id().as_u64(),
+            producer_user_id = %source.user_id().path_segment(),
+            source_transport_media_id = update.route.source_transport_media_id().as_u64(),
+            stream_id = %update.key.stream,
+            outcome,
+            reason = reason.map(policy_pause_reason_name),
+            latest_receiver_bandwidth_estimate_bps = update
+                .planned_budget
+                .latest_receiver_bandwidth()
+                .map(crate::Bitrate::as_bps),
+            selected_video_budget_bps = update
+                .planned_budget
+                .selected_video_budget()
+                .map(crate::Bitrate::as_bps),
+            planned_active_video_route_count = update.planned_budget.active_video_route_count(),
+            planned_selected_video_bitrate_bps = update
+                .planned_budget
+                .selected_video_bitrate()
+                .as_bps(),
+            selector = source_selector_name(update.selector),
+            selected_encoding_id = update
+                .selector
+                .selected_encoding()
+                .map(SourceEncodingId::as_u64),
+            selected_estimated_bitrate_bps = update
+                .selected_estimated_bitrate
+                .map(crate::Bitrate::as_bps),
+            "source policy route changed"
+        );
     }
 }
 
-fn commit_packet_updates(state: &mut RoomState, updates: &[ConsumerPacketSelectionUpdate]) -> bool {
+const fn source_selector_name(selector: SourceSelector) -> &'static str {
+    match selector {
+        SourceSelector::Open => "open",
+        SourceSelector::Encoding(_) => "encoding",
+    }
+}
+
+const fn policy_pause_reason_name(reason: PolicyPauseReason) -> &'static str {
+    match reason {
+        PolicyPauseReason::BudgetPressure => "budget_pressure",
+        PolicyPauseReason::HiddenTile => "hidden_tile",
+        PolicyPauseReason::OverflowTile => "overflow_tile",
+        PolicyPauseReason::MissingUsableLayer => "missing_usable_layer",
+        PolicyPauseReason::AudioSpeakerLimit => "audio_speaker_limit",
+        PolicyPauseReason::ReceiverDeafened => "receiver_deafened",
+        PolicyPauseReason::VideoDownloadLimit => "video_download_limit",
+        PolicyPauseReason::SourceBitrateLimit => "source_bitrate_limit",
+    }
+}
+
+fn commit_packet_updates(
+    state: &mut RoomState,
+    mut updates: Vec<ConsumerPacketSelectionUpdate>,
+    receiver_video_budget_plans: &[ReceiverVideoBudgetPlan],
+) -> (Vec<ConsumerPacketSelectionUpdate>, bool) {
     let mut requires_follow_up = false;
-    for update in updates {
+    updates.retain_mut(|update| {
         let committed = state.topology.update_consumer_source_selection(
             &update.key,
             update.source_id,
@@ -250,16 +349,131 @@ fn commit_packet_updates(state: &mut RoomState, updates: &[ConsumerPacketSelecti
             |selection| {
                 selection.set_selector(update.selector);
                 selection.set_policy_pause_reason(update.policy_pause_reason);
-                selection.set_budget(update.budget);
                 selection.set_adaptation_observations(
                     update.pressure_observations,
                     update.upgrade_observations,
                 );
             },
         );
+        if committed
+            && update.transition.is_some()
+            && !route_transition_remains_observable(state, update)
+        {
+            update.transition = None;
+        }
         requires_follow_up |= committed && update.requires_follow_up();
+        committed
+    });
+    for plan in receiver_video_budget_plans {
+        reconcile_receiver_video_budget(state, plan);
     }
-    requires_follow_up
+    (updates, requires_follow_up)
+}
+
+fn route_transition_remains_observable(
+    state: &RoomState,
+    update: &ConsumerPacketSelectionUpdate,
+) -> bool {
+    state.user_connection_id(&update.key.receiver)
+        == Some(update.route.consumer_session_key().connection_id())
+        && state
+            .topology
+            .committed_consumer_route_for_key(&update.key)
+            .is_some_and(|route| {
+                route.source.descriptor.source_id() == update.source_id
+                    && route.route == &update.route
+                    && route.source.active
+                    && route.selection.active()
+            })
+}
+
+fn reconcile_receiver_video_budget(state: &mut RoomState, plan: &ReceiverVideoBudgetPlan) {
+    let receiver = &plan.receiver;
+    let receiver_connection_id = state.user_connection_id(receiver);
+    // Async route controls may accept only part of a receiver plan. Rebuild the
+    // shared diagnostics from captured route bitrates because ridless source
+    // observations are unavailable after the transport await.
+    let mut active_route_count = 0;
+    let mut selected_video_bitrate = crate::Bitrate::zero();
+    let mut update_targets = Vec::with_capacity(plan.routes.len());
+    let mut plan_index = 0;
+    for route in state
+        .topology
+        .committed_consumer_routes_for_user(receiver)
+        .filter(|route| {
+            receiver_connection_id == Some(route.route.consumer_session_key().connection_id())
+        })
+    {
+        let policy = route.source.descriptor.policy();
+        if route.source.descriptor.media_kind() != MediaKind::Video
+            || (policy.adaptation() == SourceAdaptationPolicy::None
+                && policy.video_bitrate_cap().is_none())
+        {
+            continue;
+        }
+        while plan
+            .routes
+            .get(plan_index)
+            .is_some_and(|planned| &planned.key < route.key)
+        {
+            plan_index += 1;
+        }
+        let participating = route.source.active && route.selection.active();
+        let Some(planned) = plan
+            .routes
+            .get(plan_index)
+            .filter(|planned| &planned.key == route.key)
+        else {
+            if participating {
+                return;
+            }
+            continue;
+        };
+        plan_index += 1;
+        if planned.source_id != route.source.descriptor.source_id() || planned.route != *route.route
+        {
+            if participating {
+                return;
+            }
+            continue;
+        }
+        let Some(planned_state) = planned.planned else {
+            continue;
+        };
+        let selected_bitrate = if planned_state.matches_selection(route.selection) {
+            planned_state.selected_bitrate
+        } else if planned.captured.matches_selection(route.selection) {
+            planned.captured.selected_bitrate
+        } else {
+            if participating {
+                return;
+            }
+            continue;
+        };
+        update_targets.push(planned);
+        if participating && route.selection.policy_pause_reason().is_none() {
+            active_route_count += 1;
+            selected_video_bitrate = selected_video_bitrate.saturating_add(selected_bitrate);
+        }
+    }
+    let budget = ReceiverVideoBudgetDiagnostics::new(
+        plan.planned_budget.latest_receiver_bandwidth(),
+        plan.planned_budget.selected_video_budget(),
+        active_route_count,
+        selected_video_bitrate,
+    );
+    for target in update_targets {
+        let updated = state.topology.update_consumer_source_selection(
+            &target.key,
+            target.source_id,
+            &target.route,
+            |selection| selection.set_budget(budget),
+        );
+        debug_assert!(
+            updated,
+            "validated route should remain committed under the lock"
+        );
+    }
 }
 
 fn commit_featured_user_updates(

--- a/crates/core/src/engine/room/source_policy/turn.rs
+++ b/crates/core/src/engine/room/source_policy/turn.rs
@@ -145,6 +145,8 @@ pub(in crate::engine::room) struct SourcePolicyTransaction {
     state_updates: Vec<ConsumerPacketSelectionUpdate>,
     receiver_video_budget_plans: Vec<ReceiverVideoBudgetPlan>,
     featured_users: Vec<FeaturedUserUpdate>,
+    video_allocation_revision: u64,
+    expected_route_update_count: usize,
 }
 
 impl SourcePolicyTransaction {
@@ -160,7 +162,10 @@ impl SourcePolicyTransaction {
             receiver_bandwidth,
             source_bitrate,
         );
-        let mut tx = Self::default();
+        let mut tx = Self {
+            video_allocation_revision: state.topology.video_allocation_revision(),
+            ..Self::default()
+        };
         audio::append_audio_route_activity(&mut tx, &input);
         let receiver_bwe_targets = mem::take(&mut input.receiver_bwe_targets);
         video::append_receiver_video_policy(&mut tx, state, &input, receiver_bwe_targets);
@@ -173,7 +178,12 @@ impl SourcePolicyTransaction {
     }
 
     pub(super) fn push_route_update(&mut self, update: ConsumerPacketSelectionUpdate) {
+        self.expect_route_update();
         self.route_effects.source_policy_update(update);
+    }
+
+    pub(super) fn expect_route_update(&mut self) {
+        self.expected_route_update_count += 1;
     }
 
     pub(super) fn push_receiver_video_budget_plan(&mut self, plan: ReceiverVideoBudgetPlan) {
@@ -190,12 +200,21 @@ impl SourcePolicyTransaction {
             mut state_updates,
             receiver_video_budget_plans,
             featured_users,
+            video_allocation_revision,
+            expected_route_update_count,
         } = self;
-        if !route_effects.is_empty() {
+        let accepted_route_updates = if route_effects.is_empty() {
+            Vec::new()
+        } else {
             // Only accepted transport controls join state-only updates. Room
             // state must not claim a selection that its worker rejected.
-            state_updates.extend(route_effects.execute(room.uuid(), media_transport).await);
-        }
+            route_effects.execute(room.uuid(), media_transport).await
+        };
+        // Unprojectable route controls increment only the expected count. `execute`
+        // returns every submitted source-policy update except rejected controls.
+        let all_route_controls_accepted =
+            accepted_route_updates.len() == expected_route_update_count;
+        state_updates.extend(accepted_route_updates);
         // Only committed nonzero counters schedule another observation. Rejected
         // or topology-stale work must not advance adaptation hysteresis.
         if commit_accepted_updates(
@@ -203,6 +222,8 @@ impl SourcePolicyTransaction {
             state_updates,
             &receiver_video_budget_plans,
             &featured_users,
+            video_allocation_revision,
+            all_route_controls_accepted,
         )
         .await
         {
@@ -232,6 +253,8 @@ async fn commit_accepted_updates(
     state_updates: Vec<ConsumerPacketSelectionUpdate>,
     receiver_video_budget_plans: &[ReceiverVideoBudgetPlan],
     featured_users: &[FeaturedUserUpdate],
+    video_allocation_revision: u64,
+    all_route_controls_accepted: bool,
 ) -> bool {
     if state_updates.is_empty()
         && receiver_video_budget_plans.is_empty()
@@ -241,8 +264,13 @@ async fn commit_accepted_updates(
     }
     let (committed_updates, info_fanout, requires_follow_up) = {
         let mut state = room.state.write().await;
-        let (committed_updates, requires_follow_up) =
-            commit_packet_updates(&mut state, state_updates, receiver_video_budget_plans);
+        let (committed_updates, requires_follow_up) = commit_packet_updates(
+            &mut state,
+            state_updates,
+            receiver_video_budget_plans,
+            video_allocation_revision,
+            all_route_controls_accepted,
+        );
         let info_fanout = commit_featured_user_updates(&mut state, featured_users);
         drop(state);
         (committed_updates, info_fanout, requires_follow_up)
@@ -339,9 +367,19 @@ fn commit_packet_updates(
     state: &mut RoomState,
     mut updates: Vec<ConsumerPacketSelectionUpdate>,
     receiver_video_budget_plans: &[ReceiverVideoBudgetPlan],
+    video_allocation_revision: u64,
+    all_route_controls_accepted: bool,
 ) -> (Vec<ConsumerPacketSelectionUpdate>, bool) {
-    let mut requires_follow_up = false;
+    let allocation_plan_is_current =
+        state.topology.video_allocation_revision() == video_allocation_revision;
+    let reconcile_planned_budgets = !allocation_plan_is_current || !all_route_controls_accepted;
+    let mut requires_follow_up = !allocation_plan_is_current && !updates.is_empty();
     updates.retain_mut(|update| {
+        let commit_planned_budget = allocation_plan_is_current
+            && (!reconcile_planned_budgets
+                || !receiver_video_budget_plans
+                    .iter()
+                    .any(|plan| plan.receiver == update.key.receiver));
         let committed = state.topology.update_consumer_source_selection(
             &update.key,
             update.source_id,
@@ -349,6 +387,9 @@ fn commit_packet_updates(
             |selection| {
                 selection.set_selector(update.selector);
                 selection.set_policy_pause_reason(update.policy_pause_reason);
+                if commit_planned_budget {
+                    selection.set_budget(update.planned_budget);
+                }
                 selection.set_adaptation_observations(
                     update.pressure_observations,
                     update.upgrade_observations,
@@ -357,6 +398,7 @@ fn commit_packet_updates(
         );
         if committed
             && update.transition.is_some()
+            && !commit_planned_budget
             && !route_transition_remains_observable(state, update)
         {
             update.transition = None;
@@ -364,8 +406,10 @@ fn commit_packet_updates(
         requires_follow_up |= committed && update.requires_follow_up();
         committed
     });
-    for plan in receiver_video_budget_plans {
-        reconcile_receiver_video_budget(state, plan);
+    if reconcile_planned_budgets {
+        for plan in receiver_video_budget_plans {
+            reconcile_receiver_video_budget(state, plan);
+        }
     }
     (updates, requires_follow_up)
 }
@@ -390,9 +434,11 @@ fn route_transition_remains_observable(
 fn reconcile_receiver_video_budget(state: &mut RoomState, plan: &ReceiverVideoBudgetPlan) {
     let receiver = &plan.receiver;
     let receiver_connection_id = state.user_connection_id(receiver);
-    // Async route controls may accept only part of a receiver plan. Rebuild the
-    // shared diagnostics from captured route bitrates because ridless source
-    // observations are unavailable after the transport await.
+    // Async route controls may accept only part of `plan`. Rebuild shared
+    // diagnostics from captured bitrates because ridless observations are
+    // unavailable after the transport await. If any participating route no longer
+    // matches its captured or planned allocation, retain the previous diagnostics
+    // rather than publish a partial receiver-wide view.
     let mut active_route_count = 0;
     let mut selected_video_bitrate = crate::Bitrate::zero();
     let mut update_targets = Vec::with_capacity(plan.routes.len());

--- a/crates/core/src/engine/room/source_policy/video/projection.rs
+++ b/crates/core/src/engine/room/source_policy/video/projection.rs
@@ -1,8 +1,8 @@
 use o_sfu_router::MediaKind;
 
 use super::{
-    super::action::{ConsumerPacketSelectionUpdate, RouteBudgetOutcome},
-    solver::{AdaptationCounts, PlannedReceiverRoute, ReceiverRouteSelection, RouteOutcome},
+    super::action::{ConsumerPacketSelectionUpdate, VideoRouteTransition},
+    solver::{AdaptationCounts, PlannedReceiverRoute, selector_bitrate},
 };
 use crate::engine::{
     media_transport::SourcePacketGate,
@@ -30,14 +30,13 @@ pub(super) fn source_packet_gate_for_selector(
 
 pub(super) fn consumer_packet_selection_update(
     planned_route: &PlannedReceiverRoute<'_>,
-    selection: ReceiverRouteSelection,
-    budget: ReceiverVideoBudgetDiagnostics,
+    planned_budget: ReceiverVideoBudgetDiagnostics,
 ) -> Option<ConsumerPacketSelectionUpdate> {
     let input = planned_route.input;
+    let selection = planned_route.selection;
     let current_selection = input.current_selection;
     if selection.selector == current_selection.selector()
         && selection.policy_pause_reason == current_selection.policy_pause_reason()
-        && budget == current_selection.budget()
         && selection.counts == AdaptationCounts::from_current(current_selection)
     {
         return None;
@@ -58,15 +57,18 @@ pub(super) fn consumer_packet_selection_update(
         && (selection.request_keyframe
             || selection.selector != current_selection.selector()
             || !current_selection.policy_allows_delivery());
-    let outcome = route_outcome(planned_route, selection);
+    let transition = route_transition(planned_route);
+    let selected_estimated_bitrate =
+        transition.and_then(|_| selector_bitrate(input, selection.selector));
     Some(ConsumerPacketSelectionUpdate {
         key: input.key.clone(),
         source_id: input.source.source_id(),
         route: input.route.clone(),
         selector: selection.selector,
         policy_pause_reason: selection.policy_pause_reason,
-        budget,
-        outcome,
+        planned_budget,
+        transition,
+        selected_estimated_bitrate,
         pressure_observations: selection.counts.pressure,
         upgrade_observations: selection.counts.upgrade,
         packet_gate,
@@ -75,22 +77,28 @@ pub(super) fn consumer_packet_selection_update(
     })
 }
 
-fn route_outcome(
-    route: &PlannedReceiverRoute<'_>,
-    selection: ReceiverRouteSelection,
-) -> Option<RouteBudgetOutcome> {
+fn route_transition(route: &PlannedReceiverRoute<'_>) -> Option<VideoRouteTransition> {
+    let selection = route.selection;
     match (
         selection.policy_pause_reason,
         route.input.current_selection.policy_pause_reason(),
     ) {
-        (None, Some(_reason)) => Some(RouteBudgetOutcome::Resumed),
-        (Some(reason), current_reason) if current_reason != Some(reason) => {
-            Some(RouteBudgetOutcome::Paused)
+        (None, Some(cleared_reason)) => Some(VideoRouteTransition::Resumed { cleared_reason }),
+        (Some(reason), None) => Some(VideoRouteTransition::Paused { reason }),
+        (Some(_), Some(_)) => None,
+        (None, None) if selection.selector == route.input.current_selection.selector() => None,
+        (None, None) => {
+            let current_selector @ SourceSelector::Encoding(_) =
+                route.input.current_selection.selector()
+            else {
+                return None;
+            };
+            let selected_selector @ SourceSelector::Encoding(_) = selection.selector else {
+                return None;
+            };
+            let current_bitrate = selector_bitrate(route.input, current_selector)?;
+            let selected_bitrate = selector_bitrate(route.input, selected_selector)?;
+            (selected_bitrate < current_bitrate).then_some(VideoRouteTransition::Degraded)
         }
-        _ => match route.outcome {
-            RouteOutcome::Neutral => None,
-            RouteOutcome::Degraded => Some(RouteBudgetOutcome::Degraded),
-            RouteOutcome::Paused => Some(RouteBudgetOutcome::Paused),
-        },
     }
 }

--- a/crates/core/src/engine/room/source_policy/video/projection.rs
+++ b/crates/core/src/engine/room/source_policy/video/projection.rs
@@ -37,6 +37,7 @@ pub(super) fn consumer_packet_selection_update(
     let current_selection = input.current_selection;
     if selection.selector == current_selection.selector()
         && selection.policy_pause_reason == current_selection.policy_pause_reason()
+        && planned_budget == current_selection.budget()
         && selection.counts == AdaptationCounts::from_current(current_selection)
     {
         return None;

--- a/crates/core/src/engine/room/source_policy/video/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/solver.rs
@@ -344,7 +344,7 @@ fn append_receiver_policy_updates<'a>(
     }
     let planned_budget =
         receiver_video_budget_diagnostics(&planned_routes, receiver_bandwidth, video_budget);
-    if requires_budget_reconciliation(&planned_routes, planned_budget) {
+    if planned_routes.iter().any(route_controls_changed) {
         let mut planned_index = 0;
         let routes = receiver_routes
             .iter()
@@ -369,6 +369,9 @@ fn append_receiver_policy_updates<'a>(
         let Some(update) =
             projection::consumer_packet_selection_update(&planned_route, planned_budget)
         else {
+            if route_controls_changed(&planned_route) {
+                tx.expect_route_update();
+            }
             continue;
         };
         if update.requires_media_transport_effect() {
@@ -380,16 +383,10 @@ fn append_receiver_policy_updates<'a>(
     eventual_admitted_video_bitrate.max(planned_budget.selected_video_bitrate())
 }
 
-fn requires_budget_reconciliation(
-    routes: &[PlannedReceiverRoute<'_>],
-    planned_budget: ReceiverVideoBudgetDiagnostics,
-) -> bool {
-    routes.iter().any(|route| {
-        let current = route.input.current_selection;
-        current.budget() != planned_budget
-            || current.selector() != route.selection.selector
-            || current.policy_pause_reason() != route.selection.policy_pause_reason
-    })
+fn route_controls_changed(route: &PlannedReceiverRoute<'_>) -> bool {
+    let current = route.input.current_selection;
+    current.selector() != route.selection.selector
+        || current.policy_pause_reason() != route.selection.policy_pause_reason
 }
 
 fn video_route_allocation(

--- a/crates/core/src/engine/room/source_policy/video/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/solver.rs
@@ -8,7 +8,11 @@ use std::{cmp::Reverse, collections::BTreeMap};
 use itertools::Itertools;
 
 use super::{
-    super::{input::SourcePolicySnapshot, turn::SourcePolicyTransaction},
+    super::{
+        action::{ReceiverVideoBudgetPlan, VideoRouteAllocation, VideoRouteAllocationState},
+        input::SourcePolicySnapshot,
+        turn::SourcePolicyTransaction,
+    },
     input::{ReceiverVideoRouteInput, receiver_video_routes},
     projection,
 };
@@ -160,21 +164,10 @@ impl ReceiverRouteSelection {
     }
 }
 
-/// metric outcome produced by budget and admission decisions
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum RouteOutcome {
-    /// no downgrade or pause recorded by the video solver
-    Neutral,
-    /// selected layer is lower than the previous committed selector
-    Degraded,
-    /// route is paused by video policy
-    Paused,
-}
-
 /// planned receiver route passed to [`projection`] after admission and budget pressure
 ///
-/// `selected_bitrate`, `selection` and `outcome` must change together through
-/// [`Self::send`] or [`Self::pause`]
+/// `selected_bitrate` and `selection` must change together through
+/// [`Self::apply_resolved_selection`], [`Self::send`] or [`Self::pause`]
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PlannedReceiverRoute<'a> {
     /// immutable route facts captured before policy mutation
@@ -183,8 +176,6 @@ pub(super) struct PlannedReceiverRoute<'a> {
     pub(super) selected_bitrate: Bitrate,
     /// candidate selector, pause state and hysteresis state
     pub(super) selection: ReceiverRouteSelection,
-    /// diagnostic outcome attached to projection
-    pub(super) outcome: RouteOutcome,
 }
 
 impl<'a> PlannedReceiverRoute<'a> {
@@ -194,39 +185,33 @@ impl<'a> PlannedReceiverRoute<'a> {
         } else {
             selector_bitrate(input, selection.selector).unwrap_or_default()
         };
-        let current_bitrate =
-            selector_bitrate(input, input.current_selection.selector()).unwrap_or_default();
-        let outcome = if selected_bitrate < current_bitrate {
-            RouteOutcome::Degraded
-        } else {
-            RouteOutcome::Neutral
-        };
         Self {
             input,
             selected_bitrate,
             selection,
-            outcome,
         }
     }
 
-    fn send(&mut self, selector: SourceSelector, selected_bitrate: Bitrate, outcome: RouteOutcome) {
+    fn apply_resolved_selection(&mut self, selection: ReceiverRouteSelection) {
+        *self = Self::new(self.input, selection);
+    }
+
+    fn send(&mut self, selector: SourceSelector, selected_bitrate: Bitrate) {
         self.selected_bitrate = selected_bitrate;
         self.selection = ReceiverRouteSelection::send(
             selector,
             self.selection.counts,
             self.selection.request_keyframe,
         );
-        self.outcome = outcome;
     }
 
-    fn pause(&mut self, reason: PolicyPauseReason, outcome: RouteOutcome) {
+    fn pause(&mut self, reason: PolicyPauseReason) {
         self.selected_bitrate = Bitrate::zero();
         self.selection = ReceiverRouteSelection::pause(
             self.input.current_selection,
             reason,
             self.selection.counts,
         );
-        self.outcome = outcome;
     }
 }
 
@@ -329,20 +314,21 @@ fn append_receiver_policy_updates<'a>(
     max_video_downloads_per_receiver: usize,
     tuning: VideoAdaptationTuning,
 ) -> Bitrate {
+    let Some(first_route) = receiver_routes.first() else {
+        return Bitrate::zero();
+    };
     let receiver_bandwidth = receiver_routes
         .iter()
         .find_map(|route| route.receiver_bandwidth);
-    let audio_reserve = receiver_routes
-        .first()
-        .map_or_else(Bitrate::zero, |route| route.audio_budget_reserve);
+    let audio_reserve = first_route.audio_budget_reserve;
     let video_budget = receiver_bandwidth
         .map(|bandwidth| effective_video_budget(bandwidth, tuning, audio_reserve));
-    let mut planned_routes = receiver_routes
-        .iter()
-        .filter_map(|route| {
-            route_plan(route, tuning).map(|selection| PlannedReceiverRoute::new(route, selection))
-        })
-        .collect::<Vec<_>>();
+    let mut planned_routes = Vec::with_capacity(receiver_routes.len());
+    for route in receiver_routes {
+        if let Some(selection) = route_plan(route, tuning) {
+            planned_routes.push(PlannedReceiverRoute::new(route, selection));
+        }
+    }
     // Apply the hard route count before sharing bandwidth. Rejected routes must
     // not consume receiver budget or force admitted routes down.
     apply_video_download_limit(&mut planned_routes, max_video_downloads_per_receiver);
@@ -352,21 +338,37 @@ fn append_receiver_policy_updates<'a>(
     if let Some(video_budget) = video_budget {
         apply_overload_policy(&mut planned_routes, video_budget);
     }
-    let budget_diagnostics =
+    for route in &mut planned_routes {
+        let selection = resolve_hysteresis(route, tuning);
+        route.apply_resolved_selection(selection);
+    }
+    let planned_budget =
         receiver_video_budget_diagnostics(&planned_routes, receiver_bandwidth, video_budget);
-    let mut routed_video_bitrate = Bitrate::zero();
+    if requires_budget_reconciliation(&planned_routes, planned_budget) {
+        let mut planned_index = 0;
+        let routes = receiver_routes
+            .iter()
+            .map(|input| {
+                let resolved = planned_routes
+                    .get(planned_index)
+                    .filter(|route| route.input.key == input.key);
+                if resolved.is_some() {
+                    planned_index += 1;
+                }
+                video_route_allocation(input, resolved)
+            })
+            .collect();
+        debug_assert_eq!(planned_index, planned_routes.len());
+        tx.push_receiver_video_budget_plan(ReceiverVideoBudgetPlan {
+            receiver: first_route.key.receiver.clone(),
+            planned_budget,
+            routes,
+        });
+    }
     for planned_route in planned_routes {
-        let selection = resolve_hysteresis(&planned_route, tuning);
-        if selection.policy_pause_reason.is_none() {
-            routed_video_bitrate = routed_video_bitrate.saturating_add(
-                selector_bitrate(planned_route.input, selection.selector).unwrap_or_default(),
-            );
-        }
-        let Some(update) = projection::consumer_packet_selection_update(
-            &planned_route,
-            selection,
-            budget_diagnostics,
-        ) else {
+        let Some(update) =
+            projection::consumer_packet_selection_update(&planned_route, planned_budget)
+        else {
             continue;
         };
         if update.requires_media_transport_effect() {
@@ -375,8 +377,46 @@ fn append_receiver_policy_updates<'a>(
             tx.push_state_update(update);
         }
     }
-    // Hysteresis can keep a higher current selector routed for this turn.
-    eventual_admitted_video_bitrate.max(routed_video_bitrate)
+    eventual_admitted_video_bitrate.max(planned_budget.selected_video_bitrate())
+}
+
+fn requires_budget_reconciliation(
+    routes: &[PlannedReceiverRoute<'_>],
+    planned_budget: ReceiverVideoBudgetDiagnostics,
+) -> bool {
+    routes.iter().any(|route| {
+        let current = route.input.current_selection;
+        current.budget() != planned_budget
+            || current.selector() != route.selection.selector
+            || current.policy_pause_reason() != route.selection.policy_pause_reason
+    })
+}
+
+fn video_route_allocation(
+    input: &ReceiverVideoRouteInput<'_>,
+    resolved: Option<&PlannedReceiverRoute<'_>>,
+) -> VideoRouteAllocation {
+    let captured = input.current_selection;
+    let captured_selected_bitrate = if captured.policy_pause_reason().is_some() {
+        Bitrate::zero()
+    } else {
+        selector_bitrate(input, captured.selector()).unwrap_or_default()
+    };
+    VideoRouteAllocation {
+        key: input.key.clone(),
+        source_id: input.source.source_id(),
+        route: input.route.clone(),
+        captured: VideoRouteAllocationState {
+            selector: captured.selector(),
+            policy_pause_reason: captured.policy_pause_reason(),
+            selected_bitrate: captured_selected_bitrate,
+        },
+        planned: resolved.map(|route| VideoRouteAllocationState {
+            selector: route.selection.selector,
+            policy_pause_reason: route.selection.policy_pause_reason,
+            selected_bitrate: route.selected_bitrate,
+        }),
+    }
 }
 
 fn route_plan(
@@ -442,7 +482,7 @@ fn source_exceeds_bitrate_cap(route: &ReceiverVideoRouteInput<'_>, cap: Bitrate)
     )
 }
 
-fn selector_bitrate(
+pub(super) fn selector_bitrate(
     route: &ReceiverVideoRouteInput<'_>,
     selector: SourceSelector,
 ) -> Option<Bitrate> {
@@ -735,7 +775,7 @@ fn apply_video_download_limit(
         .k_largest_by_key(routes_to_pause, |(rank_key, _route)| *rank_key)
         .rev()
     {
-        route.pause(PolicyPauseReason::VideoDownloadLimit, RouteOutcome::Paused);
+        route.pause(PolicyPauseReason::VideoDownloadLimit);
     }
 }
 
@@ -774,7 +814,7 @@ fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], video_budget: 
             break;
         }
         let selected_bitrate = route.selected_bitrate;
-        route.pause(PolicyPauseReason::MissingUsableLayer, RouteOutcome::Neutral);
+        route.pause(PolicyPauseReason::MissingUsableLayer);
         total_bitrate = total_bitrate.saturating_sub(selected_bitrate);
     }
     // Step the least important downgradable route down one layer at a time.
@@ -797,7 +837,7 @@ fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], video_budget: 
         total_bitrate = total_bitrate
             .saturating_sub(selected_bitrate)
             .saturating_add(bitrate);
-        route.send(selector, bitrate, RouteOutcome::Degraded);
+        route.send(selector, bitrate);
     }
     if total_bitrate <= video_budget {
         return;
@@ -816,7 +856,7 @@ fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], video_budget: 
         }
         let selected_bitrate = route.selected_bitrate;
         let pause_reason = pause_reason_for_route(route);
-        route.pause(pause_reason, RouteOutcome::Paused);
+        route.pause(pause_reason);
         total_bitrate = total_bitrate.saturating_sub(selected_bitrate);
     }
 }

--- a/crates/telemetry/src/metrics/descriptor.rs
+++ b/crates/telemetry/src/metrics/descriptor.rs
@@ -883,7 +883,7 @@ metric_catalog! {
     },
     BudgetSolverOutcomesTotal {
         name: "osfu_budget_solver_outcomes_total",
-        help: "Total receiver video budget solver outcomes accepted by room policy.",
+        help: "Total committed receiver video route degradation, pause and resume transitions.",
         kind: Counter,
         samples: |metrics, capture, output| write_counter_family(output, &metrics.budget_solver_outcomes, "outcome")
     },

--- a/crates/telemetry/src/schema.rs
+++ b/crates/telemetry/src/schema.rs
@@ -26,6 +26,7 @@ pub mod event {
     pub const SUBSCRIBE_REJECTED: &str = "subscribe.rejected";
     pub const SUBSCRIPTION_ACTIVITY_CHANGED: &str = "subscription.activity_changed";
     pub const PUBLICATION_ACTIVITY_CHANGED: &str = "publication.activity_changed";
+    pub const SOURCE_POLICY_ROUTE_CHANGED: &str = "source_policy.route_changed";
     pub const TRANSPORT_HEALTH_CHANGED: &str = "transport.health.changed";
 }
 


### PR DESCRIPTION
Source policy metrics record provisional solver decisions before hysteresis, transport acceptance and topology validation. This overcounts policy pauses and leaves allocation diagnostics inconsistent after partial route-control failure.

Classify transitions from the final selection, record them only after exact route commit and reconcile receiver budgets from committed route state. Add route-correlated logging for pause, resume and degradation.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check both -->
- [x] I read CONTRIBUTING.md
- [x] I will not use AI to fabricate answsers to comments in this PR

#### AI
<!-- if no checkbox is closed, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate trivial and/or sporadic changes (comment formatting, autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If checkbox 2 or 3 is checked,
write a summary explaining the extent involvement of AI
-->
