### PR TITLE
[IMP] set clear codec defaults

### DIFF
--- a/crates/core/src/options/codecs.rs
+++ b/crates/core/src/options/codecs.rs
@@ -49,6 +49,13 @@ macro_rules! media_codec_accessors {
 
 impl MediaCodecFlags {
     #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            enabled: MediaCodecSet::empty(),
+        }
+    }
+
+    #[must_use]
     fn with_flag(mut self, flag: MediaCodecSet, enabled: bool) -> Self {
         if enabled {
             self.enabled.insert(flag);

--- a/src/config/codec_flags.rs
+++ b/src/config/codec_flags.rs
@@ -4,16 +4,15 @@ use o_sfu_core::prelude::MediaCodecFlags;
 use super::env::Env;
 
 pub(super) fn load_media_codec_flags(env: &Env<'_>) -> Result<MediaCodecFlags> {
-    let defaults = MediaCodecFlags::default();
-    Ok(defaults
-        .with_opus(env.var("CODEC_OPUS").default(defaults.opus_enabled())?)
-        .with_pcmu(env.var("CODEC_PCMU").default(defaults.pcmu_enabled())?)
-        .with_pcma(env.var("CODEC_PCMA").default(defaults.pcma_enabled())?)
-        .with_vp8(env.var("CODEC_VP8").default(defaults.vp8_enabled())?)
-        .with_h264(env.var("CODEC_H264").default(defaults.h264_enabled())?)
-        .with_h265(env.var("CODEC_H265").default(defaults.h265_enabled())?)
-        .with_vp9(env.var("CODEC_VP9").default(defaults.vp9_enabled())?)
-        .with_av1(env.var("CODEC_AV1").default(defaults.av1_enabled())?))
+    Ok(MediaCodecFlags::empty()
+        .with_opus(env.var("CODEC_OPUS").default(true)?)
+        .with_pcmu(env.var("CODEC_PCMU").default(false)?)
+        .with_pcma(env.var("CODEC_PCMA").default(false)?)
+        .with_vp8(env.var("CODEC_VP8").default(true)?)
+        .with_h264(env.var("CODEC_H264").default(false)?)
+        .with_h265(env.var("CODEC_H265").default(false)?)
+        .with_vp9(env.var("CODEC_VP9").default(false)?)
+        .with_av1(env.var("CODEC_AV1").default(false)?))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Before this commit, we used the default of the mediacodecflags struct, which added an indirection and made it less obvious which codecs were enabled.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check all -->
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [coding_guidelines.md](coding_guidelines.md)
- [x] I will not use AI to fabricate answers to comments in this PR

#### AI
<!-- if no checkbox is checked, the PR will be closed without a review -->

- [x] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate text (comments, documentation, commit message,...)
- [ ] AI was used to generate trivial and/or sporadic changes (autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If something else than checkbox "No AI involvement" is checked, write a summary explaining the extent involvement of AI.
-->
