### PR TITLE
[FIX] core: smooth startup video policy

### DIFF
--- a/.github/workflows/client-browser.yml
+++ b/.github/workflows/client-browser.yml
@@ -69,5 +69,5 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: playwright-report-${{ matrix.browser }}
-          path: crates/client/playwright-report
+          path: crates/client/output/playwright/results
           retention-days: 14

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -344,12 +344,12 @@ after the media transport and current room topology accept it. `outcome` is
 A resume reports the policy `reason` that was cleared. Route identity, receiver
 bandwidth, selected budget and selected encoding fields provide the route-level
 context. `planned_active_video_route_count` and
-`planned_selected_video_bitrate_bps` report the final post-hysteresis solver
+`planned_selected_video_bitrate_bps` report the final post-dwell solver
 snapshot. They can include a sibling route displaced while transport work was
 in flight.
 
 `osfu_budget_solver_outcomes_total` counts the same committed transitions.
-Held hysteresis, pause reason replacements, budget-only updates, initial
+Pending dwell, pause reason replacements, budget-only updates, initial
 selector resolution and rejected stale work do not increment it.
 
 ## NGINX public edge
@@ -582,10 +582,19 @@ receiver video adaptation tuning:
 | --- | --- | --- |
 | `ROOM_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD` | `3` | receiver count at or above which scalable video is layer-selected per receiver instead of forwarded at full quality |
 | `ROOM_THUMBNAIL_BUDGET_DIVISOR` | `2` | divisor applied to the per-source budget when a source is shown as a thumbnail |
-| `ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS` | `2` | consecutive over-budget observations required before dropping a receiver to a lower layer |
-| `ROOM_UPSWITCH_STABLE_OBSERVATIONS` | `3` | consecutive within-budget observations required before raising a receiver to a higher layer |
+| `ROOM_SOFT_PAUSE_DWELL_MS` | `750` | positive duration of continuous receiver pressure before soft policy pauses |
+| `ROOM_UPGRADE_DWELL_MS` | `750` | positive duration of continuous eligibility for the exact post-fit upgrade or soft-resume target |
 | `ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT` | `0` | percent of the receiver bandwidth estimate held back from the video budget for RTP, RTX and FEC overhead, from `0` to `100` |
 | `ROOM_AUDIO_RESERVE_PER_SPEAKER_BPS` | `0` | fixed bitrate in bps held back from each receiver's video budget for every admitted audio speaker that receiver consumes; a receiver with audio disabled reserves nothing; `0` disables audio reservation |
+
+Eligible layer downsteps are immediate. Soft pauses may keep the selected video
+bitrate above the receiver budget until `ROOM_SOFT_PAUSE_DWELL_MS` expires.
+Hard media limits remain immediate. Both dwells are bounded to
+`3153600000000` ms to keep deadline addition within the portable `Instant`
+range. The legacy
+`ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS` and
+`ROOM_UPSWITCH_STABLE_OBSERVATIONS` variables now reject startup with an error
+naming the corresponding duration variable. Replace them before upgrading.
 
 telemetry:
 

--- a/crates/client/playwright.config.mjs
+++ b/crates/client/playwright.config.mjs
@@ -19,7 +19,17 @@ export default defineConfig({
         },
         {
             name: "firefox",
-            use: { browserName: "firefox" }
+            use: {
+                browserName: "firefox",
+                launchOptions: {
+                    // Firefox needs camera permission to gather loopback candidates
+                    // for the synthetic canvas fixtures.
+                    firefoxUserPrefs: {
+                        "media.peerconnection.ice.loopback": true,
+                        "permissions.default.camera": 1
+                    }
+                }
+            }
         }
     ],
     webServer: [

--- a/crates/client/playwright/live_server.spec.js
+++ b/crates/client/playwright/live_server.spec.js
@@ -927,3 +927,149 @@ function parseFmtpParameters(formatParams) {
             })
     );
 }
+
+test("startup pressure holds the thumbnail through the soft pause dwell", async ({
+    browserName,
+    context
+}) => {
+    test.setTimeout(60_000);
+    // PR3 must recalibrate this band when the generated upload ladder changes.
+    const maxVideoBitrate = 200_000;
+    const server = await spawnLiveServer({
+        bindPort: browserName === "firefox" ? 18086 : 18085,
+        rtcMinPort: browserName === "firefox" ? 58328 : 58296,
+        rtcMaxPort: browserName === "firefox" ? 58359 : 58327,
+        maxBitrateOut: maxVideoBitrate,
+        maxVideoBitrate
+    });
+    try {
+        const channelUuid = await createChannel({
+            authKey: server.authKey,
+            httpBaseUrl: server.httpBaseUrl
+        });
+        const pinned = await createPeerPage(context);
+        const receiver = await createPeerPage(context);
+        const firstThumbnail = await createPeerPage(context);
+        const thumbnail = await createPeerPage(context);
+        const connect = async (page, sessionId) => {
+            await connectPeer(page, {
+                channelUuid,
+                jwt: createConnectToken(channelUuid, sessionId),
+                url: server.wsUrl
+            });
+            await expect.poll(async () => (await peerSnapshot(page)).state).toBe("connected");
+        };
+        const diagnostics = (producerSessionId) =>
+            streamDiagnostics({
+                consumerSessionId: 42,
+                httpBaseUrl: server.httpBaseUrl,
+                producerSessionId,
+                roomId: channelUuid,
+                streamType: "camera"
+            });
+        await connect(pinned, 41);
+        await connect(receiver, 42);
+        await connect(firstThumbnail, 44);
+        await connect(thumbnail, 43);
+        // Chromium limits tiny capture surfaces to one simulcast layer. Motion
+        // keeps real throughput high enough for BWE to sustain the test band.
+        await publishSyntheticCamera(pinned, "startup-pinned", {
+            width: 480,
+            height: 270,
+            frameRate: 30,
+            movingPattern: true
+        });
+        await setStreamDownload(receiver, 41, "camera", true, "pinned");
+        // Establish high quality before adding pressure so recovery timing cannot
+        // consume the thumbnail's grace before an over-budget sample is visible.
+        let initial;
+        try {
+            await expect
+                .poll(
+                    async () => {
+                        initial = await diagnostics(41);
+                        const selection = initial.subscription?.selection;
+                        return (
+                            initial.source?.currentIncomingBitrateBps > 0 &&
+                            selection?.latestReceiverBandwidthEstimateBps >= maxVideoBitrate &&
+                            selection.selectedRid === "hi"
+                        );
+                    },
+                    { intervals: [20, 50, 100], timeout: 15_000 }
+                )
+                .toBeTruthy();
+        } finally {
+            await test.info().attach("initial-camera-diagnostics", {
+                body: JSON.stringify(initial),
+                contentType: "application/json"
+            });
+        }
+        // Probes can reach twice the outgoing target. Two thumbnail floors
+        // keep the receiver over budget throughout that probe range.
+        await publishSyntheticCamera(firstThumbnail, "startup-first-thumbnail");
+        await setStreamDownload(receiver, 44, "camera", true, "visible_thumbnail");
+        // Committed publication order breaks ties between thumbnail priorities.
+        await expect.poll(async () => (await diagnostics(44)).publication?.active).toBe(true);
+        await publishSyntheticCamera(thumbnail, "startup-thumbnail");
+        await setStreamDownload(receiver, 43, "camera", true, "visible_thumbnail");
+        let grace;
+        await expect
+            .poll(
+                async () => {
+                    const sample = await diagnostics(43);
+                    const selection = sample.subscription?.selection;
+                    if (
+                        selection?.latestReceiverBandwidthEstimateBps >= maxVideoBitrate &&
+                        selection.selectedVideoBitrateBps > selection.selectedVideoBudgetBps &&
+                        sample.subscription.state === "active" &&
+                        sample.transport?.videoSoftPauseRemainingMs > 0
+                    ) {
+                        grace = sample;
+                    }
+                    return Boolean(grace);
+                },
+                { intervals: [10, 20, 50], timeout: 15_000 }
+            )
+            .toBeTruthy();
+        expect(grace.subscription.selection.selectedVideoBudgetBps).toBeGreaterThanOrEqual(
+            maxVideoBitrate
+        );
+        expect(grace.subscription.selection.selectedVideoBudgetBps).toBeLessThan(
+            maxVideoBitrate + 2 * 150_000
+        );
+        await test.info().attach("soft-pause-grace", {
+            body: JSON.stringify(grace),
+            contentType: "application/json"
+        });
+        await expect
+            .poll(async () => (await diagnostics(43)).subscription)
+            .toMatchObject({
+                state: "inactive",
+                selection: { policyPauseReason: "budget_pressure" }
+            });
+        await expectCameraTrackUpdate(receiver, 41, true);
+        if (browserName === "chromium") {
+            await waitForDecodedRemoteVideoFrame(receiver, 41, "camera");
+        }
+        // A BWE change during grace can restart the high-layer upgrade dwell.
+        try {
+            await expect
+                .poll(() =>
+                    cameraSubscriptionRid({
+                        consumerSessionId: 42,
+                        httpBaseUrl: server.httpBaseUrl,
+                        producerSessionId: 41,
+                        roomId: channelUuid
+                    })
+                )
+                .toBe("hi");
+        } finally {
+            await test.info().attach("final-camera-diagnostics", {
+                body: JSON.stringify(await diagnostics(41)),
+                contentType: "application/json"
+            });
+        }
+    } finally {
+        await server.stop();
+    }
+});

--- a/crates/client/playwright/live_server_helpers.mjs
+++ b/crates/client/playwright/live_server_helpers.mjs
@@ -199,8 +199,8 @@ export async function connectPeer(page, { channelUuid, iceServers, jwt, url = TE
     );
 }
 
-export async function publishSyntheticCamera(page, label) {
-    return publishSyntheticVideo(page, "camera", label);
+export async function publishSyntheticCamera(page, label, options) {
+    return publishSyntheticVideo(page, "camera", label, options);
 }
 
 export async function publishSyntheticScreen(page, label) {
@@ -237,12 +237,26 @@ export async function publishSyntheticAudio(page, label) {
     }, label);
 }
 
-export async function publishSyntheticVideo(page, streamType, label) {
+export async function publishSyntheticVideo(
+    page,
+    streamType,
+    label,
+    { width = 96, height = 96, frameRate = 10, movingPattern = false } = {}
+) {
     assertStreamType(streamType);
     const colors = syntheticVideoColors(streamType, label);
     const fillPixel = pixelFromHex(colors[0]);
     return page.evaluate(
-        async ({ colors, fillPixel, label, streamType }) => {
+        async ({
+            colors,
+            fillPixel,
+            label,
+            streamType,
+            width,
+            height,
+            frameRate,
+            movingPattern
+        }) => {
             const harness = globalThis.__liveHarness;
             if (!harness.client) {
                 throw new Error("browser harness client is not connected");
@@ -250,8 +264,8 @@ export async function publishSyntheticVideo(page, streamType, label) {
             await globalThis.__liveHarnessStopLocalMedia(harness, streamType);
 
             const canvas = document.createElement("canvas");
-            canvas.width = 96;
-            canvas.height = 96;
+            canvas.width = width;
+            canvas.height = height;
             const context = canvas.getContext("2d");
             if (!context) {
                 throw new Error("expected 2D canvas context for synthetic video track");
@@ -265,11 +279,20 @@ export async function publishSyntheticVideo(page, streamType, label) {
                 context.fillText(label, 8, 28);
                 context.fillText(streamType, 8, 42);
                 context.fillText(String(frame), 8, 56);
+                if (movingPattern) {
+                    const palette = [...colors, "#f3f4f6"];
+                    for (let y = 0; y < canvas.height; y += 12) {
+                        for (let x = 0; x < canvas.width; x += 12) {
+                            context.fillStyle = palette[(x / 12 + y / 12 + frame) % palette.length];
+                            context.fillRect(x, y, 10, 10);
+                        }
+                    }
+                }
                 frame += 1;
             };
             draw();
-            const ticker = window.setInterval(draw, 100);
-            const stream = canvas.captureStream(10);
+            const ticker = window.setInterval(draw, 1000 / frameRate);
+            const stream = canvas.captureStream(frameRate);
             const [track] = stream.getVideoTracks();
             if (!track) {
                 throw new Error("expected synthetic canvas capture to expose a video track");
@@ -288,7 +311,7 @@ export async function publishSyntheticVideo(page, streamType, label) {
                 trackId: track.id
             };
         },
-        { colors, fillPixel, label, streamType }
+        { colors, fillPixel, label, streamType, width, height, frameRate, movingPattern }
     );
 }
 
@@ -554,7 +577,8 @@ export async function streamDiagnostics({
     return {
         publication,
         source,
-        subscription
+        subscription,
+        transport: consumer?.transport ?? null
     };
 }
 
@@ -729,6 +753,8 @@ export async function spawnLiveServer({
     announcedIp = host,
     rtcMaxPort,
     rtcMinPort,
+    maxBitrateOut,
+    maxVideoBitrate,
     codecFlags = {}
 }) {
     const env = {
@@ -743,6 +769,12 @@ export async function spawnLiveServer({
     };
     if (Object.hasOwn(codecFlags, "vp8")) {
         env.CODEC_VP8 = String(Boolean(codecFlags.vp8));
+    }
+    if (maxBitrateOut !== undefined) {
+        env.MAX_BITRATE_OUT = String(maxBitrateOut);
+    }
+    if (maxVideoBitrate !== undefined) {
+        env.MAX_VIDEO_BITRATE = String(maxVideoBitrate);
     }
     const child = spawn(
         "cargo",

--- a/crates/core/src/engine/media_transport/TESTS/policy_invalidation.rs
+++ b/crates/core/src/engine/media_transport/TESTS/policy_invalidation.rs
@@ -1,124 +1,128 @@
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeSet,
+    future::{Future, poll_fn},
+    pin::Pin,
+    task::Poll,
+    time::Duration,
+};
 
-use tokio::{sync::Barrier, time::timeout};
+use tokio::time::{Instant, advance};
 
 use super::SourcePolicySignal;
 use crate::RoomInstanceId;
 
-fn scheduled_token(signal: &SourcePolicySignal, room: RoomInstanceId) -> Option<u64> {
-    signal.0.pending.lock().ok()?.scheduled.get(&room).copied()
+async fn assert_pending(future: Pin<&mut impl Future>) {
+    let mut future = future;
+    poll_fn(|cx| {
+        assert!(future.as_mut().poll(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
 }
 
-#[tokio::test]
-async fn wait_for_update_observes_dirty_state_marked_before_wait() {
+#[tokio::test(start_paused = true)]
+async fn dirty_marks_coalesce_without_consuming_the_deadline() {
     let signal = SourcePolicySignal::default();
     let subscription = signal.subscribe();
-    signal.mark_dirty(RoomInstanceId::from_raw(7));
-
-    let updates = timeout(Duration::from_secs(1), subscription.wait_for_update()).await;
-    assert_eq!(
-        updates.ok(),
-        Some(BTreeSet::from([RoomInstanceId::from_raw(7)]))
-    );
+    let room = RoomInstanceId::from_raw(7);
+    let deadline = Instant::now() + Duration::from_millis(750);
+    signal.set_deadline(room, Some(deadline.into_std()));
+    signal.mark_dirty_rooms([room, room]);
+    assert_eq!(subscription.wait_for_update().await, BTreeSet::from([room]));
+    let wait = subscription.wait_for_update();
+    tokio::pin!(wait);
+    assert_pending(wait.as_mut()).await;
+    advance(Duration::from_millis(749)).await;
+    assert_pending(wait.as_mut()).await;
+    // Repeating the deadline cannot restart its dwell.
+    signal.set_deadline(room, Some(deadline.into_std()));
+    advance(Duration::from_millis(1)).await;
+    assert_eq!(wait.await, BTreeSet::from([room]));
+    assert!(subscription.take_pending_updates().is_empty());
 }
 
-#[tokio::test]
-async fn delayed_marks_coalesce_per_room() {
+#[tokio::test(start_paused = true)]
+async fn sleeping_consumer_observes_earlier_and_later_replacements() {
     let signal = SourcePolicySignal::default();
     let subscription = signal.subscribe();
     let room = RoomInstanceId::from_raw(12);
-    signal.mark_dirty_after(room, Duration::from_millis(10));
-    signal.mark_dirty_after(room, Duration::from_millis(10));
-
-    let updates = timeout(Duration::from_secs(1), subscription.wait_for_update()).await;
-    assert_eq!(updates.ok(), Some(BTreeSet::from([room])));
+    let now = Instant::now();
+    signal.set_deadline(room, Some((now + Duration::from_millis(500)).into_std()));
+    let wait = subscription.wait_for_update();
+    tokio::pin!(wait);
+    assert_pending(wait.as_mut()).await;
+    signal.set_deadline(room, Some((now + Duration::from_millis(900)).into_std()));
+    assert_pending(wait.as_mut()).await;
+    advance(Duration::from_millis(500)).await;
+    assert_pending(wait.as_mut()).await;
+    signal.set_deadline(room, Some((now + Duration::from_millis(750)).into_std()));
+    assert_pending(wait.as_mut()).await;
+    advance(Duration::from_millis(249)).await;
+    assert_pending(wait.as_mut()).await;
+    advance(Duration::from_millis(1)).await;
+    assert_eq!(wait.await, BTreeSet::from([room]));
+    advance(Duration::from_secs(1)).await;
     assert!(subscription.take_pending_updates().is_empty());
 }
 
-#[tokio::test]
-async fn stale_delayed_mark_does_not_publish_a_newer_schedule() {
+#[tokio::test(start_paused = true)]
+async fn cancellation_removes_sleep_and_wait_cancellation_preserves_work() {
     let signal = SourcePolicySignal::default();
     let subscription = signal.subscribe();
     let room = RoomInstanceId::from_raw(14);
-
-    signal.mark_dirty_after(room, Duration::from_mins(1));
-    let stale_token = scheduled_token(&signal, room);
-    assert!(stale_token.is_some());
-    signal.mark_dirty(room);
-    assert_eq!(subscription.take_pending_updates(), BTreeSet::from([room]));
-    signal.mark_dirty_after(room, Duration::from_mins(1));
-    let current_token = scheduled_token(&signal, room);
-    assert!(current_token.is_some());
-
-    signal.0.publish(room, stale_token.unwrap_or_default());
-    assert!(subscription.take_pending_updates().is_empty());
-
-    signal.0.publish(room, current_token.unwrap_or_default());
-    assert_eq!(subscription.take_pending_updates(), BTreeSet::from([room]));
+    let now = Instant::now();
+    signal.set_deadline(room, Some((now + Duration::from_millis(750)).into_std()));
+    {
+        let wait = subscription.wait_for_update();
+        tokio::pin!(wait);
+        assert_pending(wait.as_mut()).await;
+        signal.set_deadline(room, None);
+        assert_pending(wait.as_mut()).await;
+        advance(Duration::from_secs(1)).await;
+        assert_pending(wait.as_mut()).await;
+        signal.mark_dirty(room);
+    }
+    assert_eq!(subscription.wait_for_update().await, BTreeSet::from([room]));
 }
 
-#[tokio::test]
-async fn wait_for_update_merges_mark_after_first_drain() {
+#[tokio::test(start_paused = true)]
+async fn equal_room_deadlines_and_same_poll_dirty_notification_are_drained() {
     let signal = SourcePolicySignal::default();
     let subscription = signal.subscribe();
-    let after_first_drain = Arc::new(Barrier::new(2));
-    let producer_barrier = Arc::clone(&after_first_drain);
-    let producer_signal = signal.clone();
-    let producer = tokio::spawn(async move {
-        producer_barrier.wait().await;
-        producer_signal
-            .mark_dirty_rooms([RoomInstanceId::from_raw(9), RoomInstanceId::from_raw(10)]);
-    });
-
-    signal.mark_dirty(RoomInstanceId::from_raw(9));
-    let first_update = timeout(Duration::from_secs(1), subscription.wait_for_update()).await;
-    assert!(first_update.is_ok());
-    let Ok(mut woke) = first_update else {
-        return;
-    };
-    after_first_drain.wait().await;
-    assert!(producer.await.is_ok());
+    let rooms = [
+        RoomInstanceId::from_raw(1),
+        RoomInstanceId::from_raw(2),
+        RoomInstanceId::from_raw(3),
+    ];
+    let deadline = Instant::now() + Duration::from_millis(750);
+    for room in &rooms[..2] {
+        signal.set_deadline(*room, Some(deadline.into_std()));
+    }
+    let wait = subscription.wait_for_update();
+    tokio::pin!(wait);
+    assert_pending(wait.as_mut()).await;
+    advance(Duration::from_millis(750)).await;
+    signal.mark_dirty(rooms[2]);
+    let mut woke = wait.await;
     woke.extend(subscription.take_pending_updates());
-    assert_eq!(
-        woke,
-        BTreeSet::from([RoomInstanceId::from_raw(9), RoomInstanceId::from_raw(10)])
-    );
+    assert_eq!(woke, BTreeSet::from(rooms));
 }
 
-#[tokio::test]
-async fn wait_for_update_coalesces_multiple_dirty_marks_per_channel() {
+#[tokio::test(start_paused = true)]
+async fn cancelling_earliest_room_preserves_other_rooms() {
     let signal = SourcePolicySignal::default();
     let subscription = signal.subscribe();
-    signal.mark_dirty(RoomInstanceId::from_raw(4));
-    signal.mark_dirty(RoomInstanceId::from_raw(4));
-    signal.mark_dirty(RoomInstanceId::from_raw(6));
-
-    let updates = timeout(Duration::from_secs(1), subscription.wait_for_update()).await;
-    assert_eq!(
-        updates.ok(),
-        Some(BTreeSet::from([
-            RoomInstanceId::from_raw(4),
-            RoomInstanceId::from_raw(6),
-        ]))
-    );
-}
-
-#[tokio::test]
-async fn wait_for_update_observes_batch_dirty_marks() {
-    let signal = SourcePolicySignal::default();
-    let subscription = signal.subscribe();
-    signal.mark_dirty_rooms([
-        RoomInstanceId::from_raw(8),
-        RoomInstanceId::from_raw(8),
-        RoomInstanceId::from_raw(10),
-    ]);
-
-    let updates = timeout(Duration::from_secs(1), subscription.wait_for_update()).await;
-    assert_eq!(
-        updates.ok(),
-        Some(BTreeSet::from([
-            RoomInstanceId::from_raw(8),
-            RoomInstanceId::from_raw(10),
-        ]))
-    );
+    let first = RoomInstanceId::from_raw(1);
+    let second = RoomInstanceId::from_raw(2);
+    let now = Instant::now();
+    signal.set_deadline(first, Some((now + Duration::from_millis(500)).into_std()));
+    signal.set_deadline(second, Some((now + Duration::from_millis(750)).into_std()));
+    signal.set_deadline(first, None);
+    let wait = subscription.wait_for_update();
+    tokio::pin!(wait);
+    assert_pending(wait.as_mut()).await;
+    advance(Duration::from_millis(749)).await;
+    assert_pending(wait.as_mut()).await;
+    advance(Duration::from_millis(1)).await;
+    assert_eq!(wait.await, BTreeSet::from([second]));
 }

--- a/crates/core/src/engine/media_transport/policy_invalidation.rs
+++ b/crates/core/src/engine/media_transport/policy_invalidation.rs
@@ -1,24 +1,43 @@
-//! Coalesces transport observations into room source-policy wakeups.
+//! Coalesces transport observations and absolute policy deadlines into room wakeups.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    iter, mem,
+    mem,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::Instant,
 };
 
-use tokio::{sync::Notify, time::sleep};
+use tokio::{
+    sync::Notify,
+    time::{Instant as TokioInstant, sleep_until},
+};
 
 use super::MediaTransport;
 use crate::{RoomInstanceId, engine::sync::lock_unpoisoned};
 
-const SOURCE_POLICY_FOLLOW_UP_DELAY: Duration = Duration::from_millis(250);
-
 #[derive(Debug, Default)]
 struct PendingSourcePolicyUpdates {
     rooms: BTreeSet<RoomInstanceId>,
-    scheduled: BTreeMap<RoomInstanceId, u64>,
-    next_schedule_token: u64,
+    scheduled_by_room: BTreeMap<RoomInstanceId, Instant>,
+    deadlines: BTreeSet<(Instant, RoomInstanceId)>,
+}
+
+impl PendingSourcePolicyUpdates {
+    fn next_deadline(&self) -> Option<Instant> {
+        self.deadlines.first().map(|(deadline, _)| *deadline)
+    }
+
+    fn take(&mut self, now: Instant) -> BTreeSet<RoomInstanceId> {
+        while let Some(&(deadline, room)) = self.deadlines.first() {
+            if deadline > now {
+                break;
+            }
+            self.deadlines.pop_first();
+            self.scheduled_by_room.remove(&room);
+            self.rooms.insert(room);
+        }
+        mem::take(&mut self.rooms)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -27,49 +46,43 @@ struct SourcePolicyUpdates {
     notify: Notify,
 }
 
-impl SourcePolicyUpdates {
-    fn take(&self) -> BTreeSet<RoomInstanceId> {
-        mem::take(&mut lock_unpoisoned(&self.pending).rooms)
-    }
-
-    fn publish(&self, room: RoomInstanceId, token: u64) {
-        let mut pending = lock_unpoisoned(&self.pending);
-        if pending.scheduled.get(&room) != Some(&token) {
-            return;
-        }
-        pending.scheduled.remove(&room);
-        let notify = pending.rooms.is_empty();
-        pending.rooms.insert(room);
-        drop(pending);
-        if notify {
-            self.notify.notify_one();
-        }
-    }
-}
-
 /// Shared drain for coalesced room source-policy invalidations.
 ///
 /// Clones share one drain. The runtime must assign all clones to a single
-/// consumer task.
+/// consumer task. Dropping a wait leaves room work and deadlines in the drain.
 #[derive(Debug, Clone)]
 pub struct SourcePolicyUpdateSubscription(Arc<SourcePolicyUpdates>);
 
 impl SourcePolicyUpdateSubscription {
-    /// Waits until at least one room needs a source-policy pass.
+    /// Waits until immediate work or an absolute deadline requires a policy pass.
     pub async fn wait_for_update(&self) -> BTreeSet<RoomInstanceId> {
         loop {
-            let rooms = self.0.take();
-            if !rooms.is_empty() {
-                return rooms;
+            // Retain the notification across the timer race and drain again
+            // before waiting. A timer winner must not consume an unseen dirty wake.
+            let notified = self.0.notify.notified();
+            let deadline = {
+                let mut pending = lock_unpoisoned(&self.0.pending);
+                let rooms = pending.take(TokioInstant::now().into_std());
+                if !rooms.is_empty() {
+                    return rooms;
+                }
+                pending.next_deadline()
+            };
+            if let Some(deadline) = deadline {
+                tokio::select! {
+                    () = notified => {},
+                    () = sleep_until(deadline.into()) => {},
+                }
+            } else {
+                notified.await;
             }
-            self.0.notify.notified().await;
         }
     }
 
-    /// Drains updates published after the previous wait completed.
+    /// Drains immediate updates and expired deadlines after the previous wait.
     #[must_use]
     pub fn take_pending_updates(&self) -> BTreeSet<RoomInstanceId> {
-        self.0.take()
+        lock_unpoisoned(&self.0.pending).take(TokioInstant::now().into_std())
     }
 }
 
@@ -89,61 +102,53 @@ impl SourcePolicySignal {
         self.mark_dirty_rooms([room_instance_id]);
     }
 
-    /// Marks rooms as needing a source-policy pass.
+    /// Marks rooms dirty without changing their independently scheduled deadlines.
+    /// Empty input from packet-pump turns does not acquire the shared lock.
     pub fn mark_dirty_rooms(&self, room_instance_ids: impl IntoIterator<Item = RoomInstanceId>) {
         let mut room_instance_ids = room_instance_ids.into_iter();
         let Some(first) = room_instance_ids.next() else {
             return;
         };
         let mut pending = lock_unpoisoned(&self.0.pending);
-        // The single consumer drains `pending.rooms`, so only its
-        // empty-to-nonempty transition needs a wake.
         let notify = pending.rooms.is_empty();
-        if pending.scheduled.is_empty() {
-            pending.rooms.insert(first);
-            pending.rooms.extend(room_instance_ids);
-        } else {
-            for room in iter::once(first).chain(room_instance_ids) {
-                pending.scheduled.remove(&room);
-                pending.rooms.insert(room);
-            }
-        }
+        pending.rooms.insert(first);
+        pending.rooms.extend(room_instance_ids);
         drop(pending);
         if notify {
             self.0.notify.notify_one();
         }
     }
 
-    /// Schedules one room wake unless current work makes it immediately dirty.
-    ///
-    /// Tokens prevent stale spawned tasks from publishing after an immediate
-    /// wake cancels then reschedules the same room.
-    fn mark_dirty_after(&self, room: RoomInstanceId, delay: Duration) {
-        let token = {
-            let mut pending = lock_unpoisoned(&self.0.pending);
-            if pending.rooms.contains(&room) || pending.scheduled.contains_key(&room) {
-                return;
-            }
-            let token = pending.next_schedule_token;
-            pending.next_schedule_token = pending.next_schedule_token.wrapping_add(1);
-            pending.scheduled.insert(room, token);
-            token
-        };
-        let updates = Arc::clone(&self.0);
-        tokio::spawn(async move {
-            sleep(delay).await;
-            updates.publish(room, token);
-        });
+    /// Replaces or cancels a room's earliest deadline. Equal deadlines are a no-op.
+    fn set_deadline(&self, room: RoomInstanceId, deadline: Option<Instant>) {
+        let mut pending = lock_unpoisoned(&self.0.pending);
+        if pending.scheduled_by_room.get(&room).copied() == deadline {
+            return;
+        }
+        let previous_earliest = pending.next_deadline();
+        if let Some(previous) = pending.scheduled_by_room.remove(&room) {
+            pending.deadlines.remove(&(previous, room));
+        }
+        if let Some(deadline) = deadline {
+            pending.scheduled_by_room.insert(room, deadline);
+            pending.deadlines.insert((deadline, room));
+        }
+        let notify = previous_earliest != pending.next_deadline();
+        drop(pending);
+        if notify {
+            self.0.notify.notify_one();
+        }
     }
 }
 
 impl MediaTransport {
-    /// Schedules another policy pass when adaptation hysteresis remains unresolved.
-    pub(in crate::engine) fn schedule_source_policy_follow_up(&self, room: RoomInstanceId) {
-        // Delay prevents one transport wake from consuming several consecutive
-        // observation thresholds. Per-room follow-ups coalesce.
-        self.source_policy_signal
-            .mark_dirty_after(room, SOURCE_POLICY_FOLLOW_UP_DELAY);
+    /// Replaces or cancels the room deadline recomputed by its ordered policy turn.
+    pub(in crate::engine) fn set_source_policy_deadline(
+        &self,
+        room: RoomInstanceId,
+        deadline: Option<Instant>,
+    ) {
+        self.source_policy_signal.set_deadline(room, deadline);
     }
 }
 

--- a/crates/core/src/engine/room/TESTS/fixtures.rs
+++ b/crates/core/src/engine/room/TESTS/fixtures.rs
@@ -1,3 +1,4 @@
+use std::{cell::Cell, time::Duration};
 pub(super) use std::{sync::Arc, time::Instant};
 
 use o_sfu_router::test_support::rtp_samples::{
@@ -20,7 +21,8 @@ pub(super) use crate::{
     engine::{
         ConnectionId, TestSourceKind, UserId, UserInfo, UserPermissions, VideoLayoutIntent,
         media_transport::{
-            AppliedSessionAnswer, MediaTransport, TransportMediaId, TransportSessionHealth,
+            AppliedSessionAnswer, MediaTransport, ReceiverBandwidthSnapshot,
+            TransportBitrateSnapshot, TransportMediaId, TransportSessionHealth,
             test_support::{
                 test_media_transport_config, test_media_transport_deps, test_rtc_port_range,
             },
@@ -451,6 +453,7 @@ pub(super) async fn setup_three_ready_users_with_transport()
 }
 
 pub(super) struct SourcePolicyScenario {
+    pub(super) policy_now: Cell<Instant>,
     pub(super) room: Arc<super::super::Room>,
     pub(super) adapter: MediaTransport,
 }
@@ -458,7 +461,11 @@ pub(super) struct SourcePolicyScenario {
 impl SourcePolicyScenario {
     pub(super) async fn with_ready_users(user_ids: &[i64]) -> Self {
         let (room, adapter) = setup_ready_users_with_transport(user_ids).await;
-        Self { room, adapter }
+        Self {
+            room,
+            adapter,
+            policy_now: Cell::new(Instant::now()),
+        }
     }
 
     pub(super) async fn with_ready_users_and_media_limits(
@@ -467,7 +474,11 @@ impl SourcePolicyScenario {
     ) -> Self {
         let (room, adapter) =
             setup_ready_users_with_transport_and_media_limits(user_ids, media_limits).await;
-        Self { room, adapter }
+        Self {
+            room,
+            adapter,
+            policy_now: Cell::new(Instant::now()),
+        }
     }
 
     pub(super) async fn with_ready_users_and_tuning(
@@ -475,7 +486,11 @@ impl SourcePolicyScenario {
         tuning: VideoAdaptationTuning,
     ) -> Self {
         let (room, adapter) = setup_ready_users_with_transport_and_tuning(user_ids, tuning).await;
-        Self { room, adapter }
+        Self {
+            room,
+            adapter,
+            policy_now: Cell::new(Instant::now()),
+        }
     }
 
     pub(super) async fn three_ready_users() -> Self {
@@ -544,9 +559,25 @@ impl SourcePolicyScenario {
     }
 
     pub(super) async fn refresh_policy_until_upgrades_settle(&self) {
-        for _ in 0..3 {
-            self.refresh_policy().await;
+        let sources = self.adapter.active_speaker_source_snapshot().await;
+        let now = self.policy_now.get().max(Instant::now());
+        for elapsed in [Duration::ZERO, VideoAdaptationTuning::DEFAULT_UPGRADE_DWELL] {
+            let tx = {
+                let state = self.room.state.read().await;
+                super::super::source_policy::SourcePolicyTransaction::plan(
+                    &state,
+                    &sources,
+                    &ReceiverBandwidthSnapshot::default(),
+                    &TransportBitrateSnapshot::default(),
+                    now + elapsed,
+                )
+            };
+            if let Some(tx) = tx {
+                tx.execute(&self.room, &self.adapter).await;
+            }
         }
+        self.policy_now
+            .set(now + VideoAdaptationTuning::DEFAULT_UPGRADE_DWELL);
     }
 
     pub(super) async fn set_deaf(&self, raw_user_id: i64, is_deaf: bool) {

--- a/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
@@ -1,8 +1,12 @@
-use std::time::Duration;
+use std::{
+    cell::Cell,
+    collections::BTreeSet,
+    time::{Duration, Instant},
+};
 
 use o_sfu_telemetry::schema::event as telemetry_event;
 use serde_json::json;
-use tokio::time::timeout;
+use tokio::time::{Instant as TokioInstant, advance, pause, resume, timeout};
 
 use super::{super::tracing as test_tracing, support::*};
 use crate::engine::{
@@ -13,12 +17,14 @@ use crate::engine::{
     },
     metrics::{MetricName, test_support::RuntimeMetricsSnapshotLookup},
     room::{
-        DeactivateIntentOutcome, media_graph::ReceiverRouteActivity,
-        source_policy::SourcePolicyTransaction, state::RoomState,
+        DeactivateIntentOutcome,
+        media_graph::{PendingUpgrade, ReceiverRouteActivity, SubscriptionKey},
+        source_policy::SourcePolicyTransaction,
+        state::RoomState,
     },
     source_model::{
         ConsumerSourceSelection, PolicyPauseReason, PublishedSourceId, SourceDeactivateIntent,
-        SourcePolicy, SourcePublishIntent,
+        SourcePolicy, SourcePublishIntent, SourceSubscriptionIntent,
     },
 };
 
@@ -32,21 +38,31 @@ fn plan_policy(
         speakers,
         bandwidth,
         &TransportBitrateSnapshot::default(),
+        Instant::now(),
     )
 }
 
-async fn apply_policy_observations(
+async fn apply_policy_turns(
     scenario: &SourcePolicyScenario,
     bandwidth: &ReceiverBandwidthSnapshot,
-    observations: u8,
+    turns: u8,
 ) {
-    for _ in 0..observations {
+    for _ in 0..turns {
         let tx = {
             let state = scenario.room.state.read().await;
-            plan_policy(&state, &[], bandwidth)
-                .expect("bandwidth observation should produce a policy update")
+            SourcePolicyTransaction::plan(
+                &state,
+                &[],
+                bandwidth,
+                &TransportBitrateSnapshot::default(),
+                scenario.policy_now.get(),
+            )
+            .expect("bandwidth turn should produce a policy update")
         };
         tx.execute(&scenario.room, &scenario.adapter).await;
+        scenario
+            .policy_now
+            .set(scenario.policy_now.get() + Duration::from_millis(750));
     }
 }
 
@@ -230,6 +246,7 @@ async fn observed_ridless_source_above_cap_is_paused() {
             &[],
             &ReceiverBandwidthSnapshot::default(),
             &source_bitrate,
+            Instant::now(),
         )
         .expect("observed cap violation should produce a policy update")
     };
@@ -384,6 +401,15 @@ async fn source_policy_ignores_receiver_bandwidth_from_replaced_connection() {
         .transport_user_key(&receiver_user_id, old_connection_id)
         .await;
 
+    scenario
+        .room
+        .state
+        .write()
+        .await
+        .users
+        .get_mut(&receiver_user_id)
+        .unwrap()
+        .video_soft_pause_deadline = Some(Instant::now() + Duration::from_millis(750));
     let (replacement_tx, _replacement_rx) = test_sender();
     join_user_without_transport_teardown(
         &scenario.room,
@@ -392,6 +418,7 @@ async fn source_policy_ignores_receiver_bandwidth_from_replaced_connection() {
         replacement_tx,
     )
     .await;
+    assert_eq!(soft_pause_deadline(&scenario, 2).await, None);
     make_session_ready_with_transport(&scenario.room, &receiver_user_id, &scenario.adapter).await;
     let receiver_bandwidth_snapshot = ReceiverBandwidthSnapshot {
         per_session: vec![(old_session_key, Bitrate::from_kbps(100))],
@@ -446,7 +473,11 @@ async fn active_speaker_camera_policy_selects_the_observed_speaker() {
 #[tokio::test]
 async fn active_speaker_camera_policy_tracks_camera_activity() {
     let (room, adapter, _owner_rx, mut observer_rx) = setup_two_ready_users().await;
-    let scenario = SourcePolicyScenario { room, adapter };
+    let scenario = SourcePolicyScenario {
+        room,
+        adapter,
+        policy_now: Cell::new(Instant::now()),
+    };
     let owner_id = UserId::Integer(1);
     publish_track(
         &scenario.room,
@@ -994,8 +1025,15 @@ async fn a_deaf_receiver_keeps_its_video_subscription_deliverable() {
 
 #[tokio::test]
 async fn deafening_releases_the_receivers_audio_budget_reserve() {
-    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 0, Bitrate::from_kbps(40))
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        3,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        0,
+        Bitrate::from_kbps(40),
+    )
+    .expect("valid tuning should build");
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
     for user_id in [UserId::Integer(1), UserId::Integer(3)] {
         publish_track(
@@ -1159,8 +1197,15 @@ async fn deafen_from_a_stale_connection_keeps_audio_flowing() {
 async fn per_receiver_audio_reserve_excludes_own_and_counts_only_consumed_audio() {
     // Reserve 40 kbps of video budget per admitted audio speaker the receiver
     // actually consumes; no headroom so the arithmetic is exact.
-    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 0, Bitrate::from_kbps(40))
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        3,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        0,
+        Bitrate::from_kbps(40),
+    )
+    .expect("valid tuning should build");
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
     scenario
         .publish_audio_and_camera_for_users(&[1, 2, 3])
@@ -1205,7 +1250,7 @@ async fn per_receiver_audio_reserve_excludes_own_and_counts_only_consumed_audio(
     )
     .await;
 
-    // Pressure hysteresis still routes both 900 kbps selectors this turn. The
+    // Eventual admitted demand includes both 900 kbps sources. The
     // desired bitrate must cover that 1.8 Mbps plus the 80 kbps audio reserve.
     assert_receiver_bwe_target(
         &scenario.room,
@@ -1218,8 +1263,15 @@ async fn per_receiver_audio_reserve_excludes_own_and_counts_only_consumed_audio(
 
 #[tokio::test]
 async fn audio_only_receiver_reports_its_audio_reserve_as_bwe_demand() {
-    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 0, Bitrate::from_kbps(40))
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        3,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        0,
+        Bitrate::from_kbps(40),
+    )
+    .expect("valid tuning should build");
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
     // Only audio is published, so receiver user 2 has audio routes but no video
     // routes — the case where the last video route was dropped while audio keeps
@@ -1265,8 +1317,15 @@ async fn audio_only_receiver_reports_its_audio_reserve_as_bwe_demand() {
 async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
     // A high multiparty threshold forces each route to start at its top layer, so
     // the aggregate overload loop — not per-route selection — does the stepping.
-    let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        99,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        0,
+        Bitrate::zero(),
+    )
+    .expect("valid tuning should build");
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2], tuning).await;
     // Three layers (lo=150, mid=450, hi=900 kbps) so one down-step lands on the
     // middle layer rather than the cheapest.
@@ -1353,8 +1412,15 @@ async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn inactive_route_does_not_report_an_in_flight_degradation() {
-    let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        99,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        0,
+        Bitrate::zero(),
+    )
+    .expect("valid tuning should build");
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2], tuning).await;
     let publisher = UserId::Integer(1);
     let receiver = UserId::Integer(2);
@@ -1401,8 +1467,15 @@ async fn inactive_route_does_not_report_an_in_flight_degradation() {
 
 #[tokio::test]
 async fn overload_steps_hidden_route_before_visible_thumbnail() {
-    let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        99,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        0,
+        Bitrate::zero(),
+    )
+    .expect("valid tuning should build");
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
     publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
     publish_three_layer_camera(&scenario.room, &UserId::Integer(3), &scenario.adapter).await;
@@ -1446,8 +1519,15 @@ async fn overload_steps_hidden_route_before_visible_thumbnail() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn rejected_route_control_reconciles_sibling_budget_to_committed_selection() {
-    let tuning = VideoAdaptationTuning::try_new(99, 2, 2, 3, 0, Bitrate::zero())
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        99,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        0,
+        Bitrate::zero(),
+    )
+    .expect("valid tuning should build");
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
     publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
     publish_three_layer_camera(&scenario.room, &UserId::Integer(3), &scenario.adapter).await;
@@ -1707,10 +1787,10 @@ async fn constrained_bandwidth_pauses_then_recovers_and_upgrades_a_pinned_route(
     let policy_updates = scenario.adapter.source_policy_subscription();
     let _ = policy_updates.take_pending_updates();
     let transitions_before = route_transition_counts(&scenario.room);
-    assert_pressure_hysteresis_hold(&scenario, &route, transitions_before).await;
+    assert_soft_pause_grace(&scenario, &route, transitions_before).await;
     let paused = assert_budget_pause(&scenario, &route, &policy_updates, transitions_before).await;
     assert_repeated_pause_is_silent(&scenario, &route, paused).await;
-    let resumed = assert_recovery_hysteresis_and_resume(&scenario, &route, paused).await;
+    let resumed = assert_resume_dwell(&scenario, &route, paused).await;
     assert_upgrade_is_not_degradation(&scenario, &route, resumed).await;
 }
 
@@ -1741,12 +1821,7 @@ async fn constrained_bandwidth_preserves_demand_for_two_paused_routes() {
     let constrained_bandwidth = ReceiverBandwidthSnapshot {
         per_session: vec![(session_key.clone(), Bitrate::from_kbps(100))],
     };
-    apply_policy_observations(
-        &scenario,
-        &constrained_bandwidth,
-        VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS,
-    )
-    .await;
+    apply_policy_turns(&scenario, &constrained_bandwidth, 2).await;
 
     for publisher in [UserId::Integer(1), UserId::Integer(3)] {
         assert_subscription_policy_pause_reason(
@@ -1782,12 +1857,7 @@ async fn constrained_bandwidth_preserves_demand_for_two_paused_routes() {
     let recovered_bandwidth = ReceiverBandwidthSnapshot {
         per_session: vec![(session_key, Bitrate::from_kbps(300))],
     };
-    apply_policy_observations(
-        &scenario,
-        &recovered_bandwidth,
-        VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
-    )
-    .await;
+    apply_policy_turns(&scenario, &recovered_bandwidth, 2).await;
 
     assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1, 3], "lo").await;
     assert_receiver_bwe_target(
@@ -1831,11 +1901,18 @@ async fn zero_budget_pauses_observed_ridless_readable_video() {
         total: Bitrate::from_kbps(500),
         per_media: vec![(source_media, Bitrate::from_kbps(500))],
     };
-    for _ in 0..VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS {
+    let now = Instant::now();
+    for elapsed in [Duration::ZERO, Duration::from_millis(750)] {
         let tx = {
             let state = room.state.read().await;
-            SourcePolicyTransaction::plan(&state, &[], &receiver_bandwidth, &source_bitrate)
-                .expect("observed source bitrate should produce a budget update")
+            SourcePolicyTransaction::plan(
+                &state,
+                &[],
+                &receiver_bandwidth,
+                &source_bitrate,
+                now + elapsed,
+            )
+            .expect("observed source bitrate should produce a budget update")
         };
         tx.execute(&room, &adapter).await;
     }
@@ -1865,8 +1942,7 @@ async fn rejected_ridless_pause_preserves_observed_committed_bitrate() {
         &scenario.adapter,
     )
     .await;
-    // Publishing can consume the first pressure observation. Reset the route so
-    // the explicit snapshots straddle the hysteresis threshold.
+    // Reset delivery before measuring the explicit pressure dwell.
     reset_subscription_selection_to_open(
         &scenario.room,
         &receiver,
@@ -1888,18 +1964,31 @@ async fn rejected_ridless_pause_preserves_observed_committed_bitrate() {
         total: Bitrate::from_kbps(500),
         per_media: vec![(source_media, Bitrate::from_kbps(500))],
     };
-    for _ in 0..VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS - 1 {
-        let tx = {
-            let state = scenario.room.state.read().await;
-            SourcePolicyTransaction::plan(&state, &[], &receiver_bandwidth, &source_bitrate)
-                .expect("pressure observation should produce a policy update")
-        };
-        tx.execute(&scenario.room, &scenario.adapter).await;
-    }
     let tx = {
         let state = scenario.room.state.read().await;
-        SourcePolicyTransaction::plan(&state, &[], &receiver_bandwidth, &source_bitrate)
-            .expect("final pressure observation should plan a pause")
+        SourcePolicyTransaction::plan(
+            &state,
+            &[],
+            &receiver_bandwidth,
+            &source_bitrate,
+            scenario.policy_now.get(),
+        )
+        .expect("pressure observation should produce a policy update")
+    };
+    tx.execute(&scenario.room, &scenario.adapter).await;
+    scenario
+        .policy_now
+        .set(scenario.policy_now.get() + Duration::from_millis(750));
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan(
+            &state,
+            &[],
+            &receiver_bandwidth,
+            &source_bitrate,
+            scenario.policy_now.get(),
+        )
+        .expect("expired dwell should plan a pause")
     };
     scenario
         .adapter
@@ -1994,6 +2083,11 @@ async fn source_policy_replaced_route_does_not_commit_stale_selector_update() {
     scenario.publish_audio_and_camera_for_users(&[1, 3]).await;
     let (tx, third_camera_source_id) = third_camera_policy_transaction(&scenario).await;
     let receiver = UserId::Integer(2);
+    let bandwidth = bandwidth_for(&scenario, 2, 100).await;
+    let pressure_tx = {
+        let state = scenario.room.state.read().await;
+        plan_policy(&state, &[], &bandwidth).unwrap()
+    };
     let (replacement_tx, _replacement_rx) = test_sender();
     join_user_without_transport_teardown(
         &scenario.room,
@@ -2028,6 +2122,8 @@ async fn source_policy_replaced_route_does_not_commit_stale_selector_update() {
             .source_selection_for_test(&receiver, third_camera_source_id)
     };
     assert_eq!(current_selection, Some(replacement_selection));
+    pressure_tx.execute(&scenario.room, &scenario.adapter).await;
+    assert_eq!(soft_pause_deadline(&scenario, 2).await, None);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -2242,21 +2338,14 @@ impl SingleVideoRoute {
     }
 }
 
-async fn assert_pressure_hysteresis_hold(
+async fn assert_soft_pause_grace(
     scenario: &SourcePolicyScenario,
     route: &SingleVideoRoute,
     expected_transitions: RouteTransitionCounts,
 ) {
-    let capture = test_tracing::capture().await;
-    apply_policy_observations(
-        scenario,
-        &route.bandwidth(100),
-        VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS - 1,
-    )
-    .await;
-    assert_no_route_change_event(&scenario.room, &route.receiver);
-    drop(capture);
-    assert_scalable_video_rid_for_publishers(scenario, &route.receiver, [1], "hi").await;
+    apply_policy_turns(scenario, &route.bandwidth(100), 1).await;
+
+    assert_scalable_video_rid_for_publishers(scenario, &route.receiver, [1], "lo").await;
     assert_receiver_video_allocation(
         scenario,
         &route.receiver,
@@ -2264,12 +2353,15 @@ async fn assert_pressure_hysteresis_hold(
         Bitrate::from_kbps(100),
         1,
         1,
-        Bitrate::from_kbps(900),
+        Bitrate::from_kbps(150),
     )
     .await;
     assert_eq!(
         route_transition_counts(&scenario.room),
-        expected_transitions
+        RouteTransitionCounts {
+            degraded: expected_transitions.degraded + 1,
+            ..expected_transitions
+        }
     );
 }
 
@@ -2280,7 +2372,7 @@ async fn assert_budget_pause(
     previous_transitions: RouteTransitionCounts,
 ) -> RouteTransitionCounts {
     let capture = test_tracing::capture().await;
-    apply_policy_observations(scenario, &route.bandwidth(100), 1).await;
+    apply_policy_turns(scenario, &route.bandwidth(100), 1).await;
     assert_receiver_bwe_target(
         &scenario.room,
         &scenario.adapter,
@@ -2288,10 +2380,7 @@ async fn assert_budget_pause(
         Bitrate::from_kbps(900),
     )
     .await;
-    let follow_up = timeout(Duration::from_secs(1), policy_updates.wait_for_update())
-        .await
-        .expect("unresolved hysteresis should schedule another policy pass");
-    assert!(follow_up.contains(&scenario.room.instance_id()));
+    assert!(policy_updates.take_pending_updates().is_empty());
     assert_subscription_policy_pause_reason(
         &scenario.room,
         &scenario.adapter,
@@ -2313,6 +2402,7 @@ async fn assert_budget_pause(
     .await;
     let transitions = RouteTransitionCounts {
         paused: previous_transitions.paused + 1,
+        degraded: previous_transitions.degraded + 1,
         ..previous_transitions
     };
     assert_eq!(route_transition_counts(&scenario.room), transitions);
@@ -2329,7 +2419,7 @@ async fn assert_budget_pause(
             video_budget: Bitrate::from_kbps(100),
             active_route_count: 0,
             selected_video_bitrate: Bitrate::zero(),
-            selected_estimated_bitrate: Bitrate::from_kbps(900),
+            selected_estimated_bitrate: Bitrate::from_kbps(150),
         },
     )
     .await;
@@ -2347,7 +2437,7 @@ async fn assert_repeated_pause_is_silent(
     expected_transitions: RouteTransitionCounts,
 ) {
     let capture = test_tracing::capture().await;
-    apply_policy_observations(scenario, &route.bandwidth(90), 1).await;
+    apply_policy_turns(scenario, &route.bandwidth(90), 1).await;
     assert_no_route_change_event(&scenario.room, &route.receiver);
     drop(capture);
     assert_receiver_video_allocation(
@@ -2366,19 +2456,14 @@ async fn assert_repeated_pause_is_silent(
     );
 }
 
-async fn assert_recovery_hysteresis_and_resume(
+async fn assert_resume_dwell(
     scenario: &SourcePolicyScenario,
     route: &SingleVideoRoute,
     paused_transitions: RouteTransitionCounts,
 ) -> RouteTransitionCounts {
     let recovered_bandwidth = route.bandwidth(200);
     let held_capture = test_tracing::capture().await;
-    apply_policy_observations(
-        scenario,
-        &recovered_bandwidth,
-        VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS - 1,
-    )
-    .await;
+    apply_policy_turns(scenario, &recovered_bandwidth, 1).await;
     assert_no_route_change_event(&scenario.room, &route.receiver);
     drop(held_capture);
     assert_eq!(route_transition_counts(&scenario.room), paused_transitions);
@@ -2394,7 +2479,7 @@ async fn assert_recovery_hysteresis_and_resume(
     .await;
 
     let resume_capture = test_tracing::capture().await;
-    apply_policy_observations(scenario, &recovered_bandwidth, 1).await;
+    apply_policy_turns(scenario, &recovered_bandwidth, 1).await;
     assert_scalable_video_rid_for_publishers(scenario, &route.receiver, [1], "lo").await;
     let resumed_transitions = RouteTransitionCounts {
         resumed: paused_transitions.resumed + 1,
@@ -2442,12 +2527,7 @@ async fn assert_upgrade_is_not_degradation(
     expected_transitions: RouteTransitionCounts,
 ) {
     let capture = test_tracing::capture().await;
-    apply_policy_observations(
-        scenario,
-        &route.bandwidth(450),
-        VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
-    )
-    .await;
+    apply_policy_turns(scenario, &route.bandwidth(450), 2).await;
     assert_no_route_change_event(&scenario.room, &route.receiver);
     drop(capture);
     assert_scalable_video_rid_for_publishers(scenario, &route.receiver, [1], "mid").await;
@@ -2594,4 +2674,694 @@ async fn assert_route_change_event(
         session_key.media_worker_id().as_usize(),
         &fields,
     );
+}
+
+async fn policy_at(
+    scenario: &SourcePolicyScenario,
+    speakers: &[ActiveSpeakerSource],
+    bandwidth: &ReceiverBandwidthSnapshot,
+    now: Instant,
+) {
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan(
+            &state,
+            speakers,
+            bandwidth,
+            &TransportBitrateSnapshot::default(),
+            now,
+        )
+    };
+    if let Some(tx) = tx {
+        tx.execute(&scenario.room, &scenario.adapter).await;
+    }
+}
+
+async fn bandwidth_for(
+    scenario: &SourcePolicyScenario,
+    receiver: i64,
+    kbps: u64,
+) -> ReceiverBandwidthSnapshot {
+    let receiver = UserId::Integer(receiver);
+    let connection = user_connection_id(&scenario.room, &receiver).await;
+    ReceiverBandwidthSnapshot {
+        per_session: vec![(
+            scenario
+                .room
+                .transport_user_key(&receiver, connection)
+                .await,
+            Bitrate::from_kbps(kbps),
+        )],
+    }
+}
+
+async fn soft_pause_deadline(scenario: &SourcePolicyScenario, receiver: i64) -> Option<Instant> {
+    scenario
+        .room
+        .state
+        .read()
+        .await
+        .users
+        .get(&UserId::Integer(receiver))
+        .and_then(|user| user.video_soft_pause_deadline)
+}
+
+#[tokio::test]
+async fn continuous_pressure_downsteps_then_pauses_the_current_victim_at_750_ms() {
+    let scenario = SourcePolicyScenario::three_ready_users().await;
+    scenario.publish_audio_and_camera_for_users(&[1, 3]).await;
+    let receiver = UserId::Integer(2);
+    let bandwidth = bandwidth_for(&scenario, 2, 200).await;
+    let now = scenario.policy_now.get().max(Instant::now());
+    policy_at(&scenario, &[], &bandwidth, now).await;
+    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1, 3], "lo").await;
+    assert_eq!(
+        soft_pause_deadline(&scenario, 2).await,
+        Some(now + Duration::from_millis(750))
+    );
+    // Speaker rotation changes the victim, not the duration of receiver overload.
+    scenario
+        .mark_active_speaker(scenario.audio_media_id(3).await)
+        .await;
+    let speakers = scenario.adapter.active_speaker_source_snapshot().await;
+    policy_at(
+        &scenario,
+        &speakers,
+        &bandwidth,
+        now + Duration::from_millis(749),
+    )
+    .await;
+    assert_eq!(
+        soft_pause_deadline(&scenario, 2).await,
+        Some(now + Duration::from_millis(750))
+    );
+    for publisher in [1, 3] {
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &receiver,
+            &UserId::Integer(publisher),
+            TestSourceKind::ScalableVideo,
+            None,
+        )
+        .await;
+    }
+    policy_at(
+        &scenario,
+        &speakers,
+        &bandwidth,
+        now + Duration::from_millis(750),
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver,
+        &UserId::Integer(1),
+        TestSourceKind::ScalableVideo,
+        Some(DiagnosticsPolicyPauseReason::BudgetPressure),
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver,
+        &UserId::Integer(3),
+        TestSourceKind::ScalableVideo,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn pressure_at_unchanged_floors_arms_and_recovery_restarts_the_full_dwell() {
+    let scenario = SourcePolicyScenario::three_ready_users().await;
+    scenario.publish_audio_and_camera_for_users(&[1, 3]).await;
+    let bandwidth = bandwidth_for(&scenario, 2, 200).await;
+    let now = scenario.policy_now.get().max(Instant::now());
+    policy_at(&scenario, &[], &bandwidth, now).await;
+    // Preserve every selector and diagnostic value while removing only timing.
+    scenario
+        .room
+        .state
+        .write()
+        .await
+        .users
+        .get_mut(&UserId::Integer(2))
+        .unwrap()
+        .video_soft_pause_deadline = None;
+    let transitions = route_transition_counts(&scenario.room);
+    let selection_updates = source_selection_update_count(&scenario.room, "encoding");
+    policy_at(&scenario, &[], &bandwidth, now).await;
+    assert_eq!(
+        soft_pause_deadline(&scenario, 2).await,
+        Some(now + Duration::from_millis(750))
+    );
+    assert_eq!(
+        source_selection_update_count(&scenario.room, "encoding"),
+        selection_updates
+    );
+    assert_eq!(route_transition_counts(&scenario.room), transitions);
+    let (views, _) = diagnostics_room_views(&scenario.room, &scenario.adapter).await;
+    let receiver = views
+        .iter()
+        .find(|view| view.user_id == UserId::Integer(2))
+        .unwrap();
+    let serialized = serde_json::to_value(&receiver.transport).unwrap();
+    assert!(
+        serialized["videoSoftPauseRemainingMs"]
+            .as_u64()
+            .is_some_and(|remaining| remaining > 0 && remaining <= 750)
+    );
+    policy_at(
+        &scenario,
+        &[],
+        &bandwidth_for(&scenario, 2, 400).await,
+        now + Duration::from_millis(300),
+    )
+    .await;
+    assert_eq!(soft_pause_deadline(&scenario, 2).await, None);
+    policy_at(&scenario, &[], &bandwidth, now + Duration::from_millis(400)).await;
+    assert_eq!(
+        soft_pause_deadline(&scenario, 2).await,
+        Some(now + Duration::from_millis(1150))
+    );
+    policy_at(
+        &scenario,
+        &[],
+        &bandwidth,
+        now + Duration::from_millis(1149),
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(3),
+        TestSourceKind::ScalableVideo,
+        None,
+    )
+    .await;
+    policy_at(
+        &scenario,
+        &[],
+        &bandwidth,
+        now + Duration::from_millis(1150),
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &UserId::Integer(2),
+        &UserId::Integer(3),
+        TestSourceKind::ScalableVideo,
+        Some(DiagnosticsPolicyPauseReason::BudgetPressure),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn exact_upgrade_target_restarts_and_aggregate_fit_cancels_it() {
+    let scenario = SourcePolicyScenario::three_ready_users().await;
+    publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
+    scenario.subscribe_scalable_video(3, 1, false).await;
+    scenario
+        .set_scalable_video_layout(2, 1, VideoLayoutIntent::Pinned)
+        .await;
+    let receiver = UserId::Integer(2);
+    let now = scenario.policy_now.get().max(Instant::now());
+    policy_at(&scenario, &[], &bandwidth_for(&scenario, 2, 150).await, now).await;
+    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "lo").await;
+    policy_at(&scenario, &[], &bandwidth_for(&scenario, 2, 450).await, now).await;
+    let (views, _) = diagnostics_room_views(&scenario.room, &scenario.adapter).await;
+    let receiver_view = views.iter().find(|view| view.user_id == receiver).unwrap();
+    let camera = receiver_view
+        .subscriptions
+        .iter()
+        .find(|subscription| {
+            subscription.producer_user_id == UserId::Integer(1)
+                && subscription.stream_id
+                    == stream_id_for_source(TestSourceKind::ScalableVideo).as_str()
+        })
+        .unwrap();
+    let serialized = serde_json::to_value(&camera.selection).unwrap();
+    let pending = &serialized["pendingUpgrade"];
+    assert_eq!(pending["selector"], "encoding");
+    assert_eq!(
+        pending["encodingId"],
+        route_upgrade(&scenario, 1)
+            .await
+            .unwrap()
+            .selector
+            .selected_encoding()
+            .unwrap()
+            .as_u64()
+    );
+    assert!(
+        pending["remainingMs"]
+            .as_u64()
+            .is_some_and(|remaining| remaining > 0 && remaining <= 750)
+    );
+    assert!(serialized.get("pressureObservations").is_none());
+    assert!(serialized.get("upgradeObservations").is_none());
+    policy_at(
+        &scenario,
+        &[],
+        &bandwidth_for(&scenario, 2, 900).await,
+        now + Duration::from_millis(400),
+    )
+    .await;
+    policy_at(
+        &scenario,
+        &[],
+        &bandwidth_for(&scenario, 2, 900).await,
+        now + Duration::from_millis(1149),
+    )
+    .await;
+    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "lo").await;
+    policy_at(
+        &scenario,
+        &[],
+        &bandwidth_for(&scenario, 2, 900).await,
+        now + Duration::from_millis(1150),
+    )
+    .await;
+    assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "hi").await;
+
+    // A two-party target always asks for hi, but fitting returns mid at 500 kbps.
+    let fitted = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    publish_three_layer_camera(&fitted.room, &UserId::Integer(1), &fitted.adapter).await;
+    let bandwidth = bandwidth_for(&fitted, 2, 500).await;
+    for elapsed in [0, 749, 750, 1500] {
+        policy_at(
+            &fitted,
+            &[],
+            &bandwidth,
+            now + Duration::from_millis(elapsed),
+        )
+        .await;
+        assert_scalable_video_rid_for_publishers(&fitted, &receiver, [1], "mid").await;
+        let state = fitted.room.state.read().await;
+        assert!(
+            state
+                .topology
+                .committed_consumer_routes_for_user(&receiver)
+                .all(|route| route.pending_upgrade.is_none())
+        );
+        drop(state);
+    }
+}
+
+#[tokio::test]
+async fn readable_detail_holds_high_quality_until_pause_and_resume_expire() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    let publisher = UserId::Integer(1);
+    let receiver = UserId::Integer(2);
+    publish_track(
+        &scenario.room,
+        &publisher,
+        TestSourceKind::ReadableVideo,
+        MediaKind::Video,
+        test_simulcast_video_rtp_parameters(),
+        &scenario.adapter,
+    )
+    .await;
+    let now = scenario.policy_now.get().max(Instant::now());
+    let pressure = bandwidth_for(&scenario, 2, 100).await;
+    for elapsed in [0, 749] {
+        policy_at(
+            &scenario,
+            &[],
+            &pressure,
+            now + Duration::from_millis(elapsed),
+        )
+        .await;
+        assert_subscription_selected_rid(
+            &scenario.room,
+            &scenario.adapter,
+            &receiver,
+            &publisher,
+            TestSourceKind::ReadableVideo,
+            "hi",
+        )
+        .await;
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &receiver,
+            &publisher,
+            TestSourceKind::ReadableVideo,
+            None,
+        )
+        .await;
+    }
+    policy_at(&scenario, &[], &pressure, now + Duration::from_millis(750)).await;
+    let recovered = bandwidth_for(&scenario, 2, 2000).await;
+    for elapsed in [800, 1549] {
+        policy_at(
+            &scenario,
+            &[],
+            &recovered,
+            now + Duration::from_millis(elapsed),
+        )
+        .await;
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &receiver,
+            &publisher,
+            TestSourceKind::ReadableVideo,
+            Some(DiagnosticsPolicyPauseReason::BudgetPressure),
+        )
+        .await;
+    }
+    policy_at(
+        &scenario,
+        &[],
+        &recovered,
+        now + Duration::from_millis(1550),
+    )
+    .await;
+    assert_subscription_selected_rid(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver,
+        &publisher,
+        TestSourceKind::ReadableVideo,
+        "hi",
+    )
+    .await;
+    assert_subscription_policy_pause_reason(
+        &scenario.room,
+        &scenario.adapter,
+        &receiver,
+        &publisher,
+        TestSourceKind::ReadableVideo,
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn rejected_receiver_controls_do_not_block_another_receivers_deadline() {
+    let scenario = SourcePolicyScenario::three_ready_users().await;
+    publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
+    let mut bandwidth = bandwidth_for(&scenario, 2, 100).await;
+    bandwidth
+        .per_session
+        .extend(bandwidth_for(&scenario, 3, 100).await.per_session);
+    let now = scenario.policy_now.get().max(Instant::now());
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan(
+            &state,
+            &[],
+            &bandwidth,
+            &TransportBitrateSnapshot::default(),
+            now,
+        )
+        .unwrap()
+    };
+    remove_consumer_transport(&scenario, 1).await;
+    tx.execute(&scenario.room, &scenario.adapter).await;
+    assert_eq!(soft_pause_deadline(&scenario, 2).await, None);
+    assert_eq!(
+        soft_pause_deadline(&scenario, 3).await,
+        Some(now + Duration::from_millis(750))
+    );
+}
+
+async fn route_upgrade(scenario: &SourcePolicyScenario, publisher: i64) -> Option<PendingUpgrade> {
+    scenario
+        .room
+        .state
+        .read()
+        .await
+        .topology
+        .committed_consumer_routes_for_user(&UserId::Integer(2))
+        .find(|route| {
+            route.key.publisher == UserId::Integer(publisher)
+                && route.source.descriptor.media_kind() == MediaKind::Video
+        })
+        .and_then(|route| route.pending_upgrade)
+        .copied()
+}
+
+async fn remove_consumer_transport(scenario: &SourcePolicyScenario, publisher: i64) {
+    let route = {
+        let state = scenario.room.state.read().await;
+        state
+            .topology
+            .committed_consumer_routes_for_user(&UserId::Integer(2))
+            .find(|route| {
+                route.key.publisher == UserId::Integer(publisher)
+                    && route.source.descriptor.media_kind() == MediaKind::Video
+            })
+            .unwrap()
+            .route
+            .clone()
+    };
+    scenario
+        .adapter
+        .teardown([TransportTeardown::RemoveMedia {
+            session_key: route.consumer_session_key().clone(),
+            transport_media_id: route.consumer_transport_media_id(),
+        }])
+        .await;
+}
+
+#[tokio::test]
+async fn rejected_controls_cancel_interrupted_upgrades_but_preserve_due_eligibility() {
+    for interrupt in [false, true] {
+        let scenario = SourcePolicyScenario::three_ready_users().await;
+        publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
+        scenario.subscribe_scalable_video(3, 1, false).await;
+        scenario
+            .set_scalable_video_layout(2, 1, VideoLayoutIntent::Pinned)
+            .await;
+        scenario.refresh_policy_until_upgrades_settle().await;
+        let now = scenario.policy_now.get().max(Instant::now());
+        policy_at(&scenario, &[], &bandwidth_for(&scenario, 2, 450).await, now).await;
+        let high = bandwidth_for(&scenario, 2, 900).await;
+        policy_at(&scenario, &[], &high, now).await;
+        assert_eq!(
+            route_upgrade(&scenario, 1).await.unwrap().deadline,
+            now + Duration::from_millis(750)
+        );
+        let bandwidth = if interrupt {
+            bandwidth_for(&scenario, 2, 150).await
+        } else {
+            high.clone()
+        };
+        let tx = {
+            let state = scenario.room.state.read().await;
+            SourcePolicyTransaction::plan(
+                &state,
+                &[],
+                &bandwidth,
+                &TransportBitrateSnapshot::default(),
+                now + Duration::from_millis(if interrupt { 500 } else { 750 }),
+            )
+            .unwrap()
+        };
+        remove_consumer_transport(&scenario, 1).await;
+        let subscription = scenario.adapter.source_policy_subscription();
+        let _ = subscription.take_pending_updates();
+        tx.execute(&scenario.room, &scenario.adapter).await;
+        if interrupt {
+            assert!(route_upgrade(&scenario, 1).await.is_none());
+            policy_at(&scenario, &[], &high, now + Duration::from_millis(800)).await;
+            assert_eq!(
+                route_upgrade(&scenario, 1).await.unwrap().deadline,
+                now + Duration::from_millis(1550)
+            );
+        } else {
+            assert_eq!(
+                route_upgrade(&scenario, 1).await.unwrap().deadline,
+                now + Duration::from_millis(750)
+            );
+            assert!(subscription.take_pending_updates().is_empty());
+            assert!(
+                timeout(Duration::from_millis(1), subscription.wait_for_update())
+                    .await
+                    .is_err()
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_rejected_sibling_pause_cannot_extend_upgrade_eligibility() {
+    let tuning = VideoAdaptationTuning::try_new(
+        3,
+        2,
+        Duration::from_millis(250),
+        Duration::from_millis(750),
+        0,
+        Bitrate::zero(),
+    )
+    .unwrap();
+    let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
+    for publisher in [1, 3] {
+        publish_three_layer_camera(
+            &scenario.room,
+            &UserId::Integer(publisher),
+            &scenario.adapter,
+        )
+        .await;
+        scenario
+            .set_scalable_video_layout(2, publisher, VideoLayoutIntent::Pinned)
+            .await;
+    }
+    scenario.refresh_policy_until_upgrades_settle().await;
+    let now = scenario.policy_now.get().max(Instant::now());
+    let low = bandwidth_for(&scenario, 2, 450).await;
+    policy_at(&scenario, &[], &low, now).await;
+    policy_at(&scenario, &[], &bandwidth_for(&scenario, 2, 900).await, now).await;
+    assert!(route_upgrade(&scenario, 1).await.is_some());
+    let tx = {
+        let state = scenario.room.state.read().await;
+        SourcePolicyTransaction::plan(
+            &state,
+            &[],
+            &low,
+            &TransportBitrateSnapshot::default(),
+            now + Duration::from_millis(500),
+        )
+        .unwrap()
+    };
+    remove_consumer_transport(&scenario, 3).await;
+    tx.execute(&scenario.room, &scenario.adapter).await;
+    assert!(route_upgrade(&scenario, 1).await.is_none());
+}
+
+#[tokio::test]
+async fn inactive_sources_and_subscriptions_cancel_route_and_receiver_holds() {
+    for source_inactive in [false, true] {
+        let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+        publish_three_layer_camera(&scenario.room, &UserId::Integer(1), &scenario.adapter).await;
+        let now = scenario.policy_now.get().max(Instant::now());
+        policy_at(&scenario, &[], &bandwidth_for(&scenario, 2, 500).await, now).await;
+        policy_at(
+            &scenario,
+            &[],
+            &bandwidth_for(&scenario, 2, 1000).await,
+            now,
+        )
+        .await;
+        assert!(route_upgrade(&scenario, 1).await.is_some());
+        {
+            let mut state = scenario.room.state.write().await;
+            if source_inactive {
+                let source = state
+                    .topology
+                    .committed_consumer_routes_for_user(&UserId::Integer(2))
+                    .next()
+                    .unwrap()
+                    .source;
+                let id = source.descriptor.source_id();
+                let connection = source.transport.session_key().connection_id();
+                assert!(
+                    state
+                        .topology
+                        .set_published_source_activity(id, connection, false)
+                        .is_some()
+                );
+            } else {
+                let key = SubscriptionKey::new(
+                    &UserId::Integer(2),
+                    &UserId::Integer(1),
+                    &stream_id_for_source(TestSourceKind::ScalableVideo),
+                );
+                state.topology.merge_subscription_intent(
+                    key,
+                    SourceSubscriptionIntent::new(Some(false), None),
+                );
+            }
+            state
+                .users
+                .get_mut(&UserId::Integer(2))
+                .unwrap()
+                .video_soft_pause_deadline = Some(now + Duration::from_millis(750));
+        }
+        assert!(route_upgrade(&scenario, 1).await.is_none());
+        policy_at(&scenario, &[], &ReceiverBandwidthSnapshot::default(), now).await;
+        assert_eq!(soft_pause_deadline(&scenario, 2).await, None);
+    }
+}
+
+#[tokio::test]
+async fn rejected_audio_control_preserves_committed_future_video_deadlines() {
+    for pressure in [false, true] {
+        let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+        scenario.publish_audio_and_camera(1).await;
+        pause();
+        let now = TokioInstant::now().into_std();
+        policy_at(&scenario, &[], &bandwidth_for(&scenario, 2, 200).await, now).await;
+        let bandwidth = bandwidth_for(&scenario, 2, if pressure { 100 } else { 900 }).await;
+        policy_at(&scenario, &[], &bandwidth, now).await;
+        let deadline = if pressure {
+            soft_pause_deadline(&scenario, 2).await.unwrap()
+        } else {
+            route_upgrade(&scenario, 1).await.unwrap().deadline
+        };
+        assert_eq!(deadline, now + Duration::from_millis(750));
+        let audio_route = {
+            let mut state = scenario.room.state.write().await;
+            let receiver = UserId::Integer(2);
+            let connection = state.user_connection_id(&receiver).unwrap();
+            assert!(
+                state
+                    .apply_presence_update(
+                        &receiver,
+                        connection,
+                        &UserInfo {
+                            is_deaf: Some(true),
+                            ..UserInfo::default()
+                        }
+                    )
+                    .is_some()
+            );
+            let route = state
+                .topology
+                .committed_consumer_routes_for_user(&UserId::Integer(2))
+                .find(|route| route.source.descriptor.media_kind() == MediaKind::Audio)
+                .unwrap()
+                .route
+                .clone();
+            drop(state);
+            route
+        };
+        advance(Duration::from_millis(400)).await;
+        let tx = {
+            let state = scenario.room.state.read().await;
+            SourcePolicyTransaction::plan(
+                &state,
+                &[],
+                &bandwidth,
+                &TransportBitrateSnapshot::default(),
+                now + Duration::from_millis(400),
+            )
+            .unwrap()
+        };
+        scenario
+            .adapter
+            .teardown([TransportTeardown::RemoveMedia {
+                session_key: audio_route.consumer_session_key().clone(),
+                transport_media_id: audio_route.consumer_transport_media_id(),
+            }])
+            .await;
+        let subscription = scenario.adapter.source_policy_subscription();
+        let _ = subscription.take_pending_updates();
+        tx.execute(&scenario.room, &scenario.adapter).await;
+        advance(Duration::from_millis(349)).await;
+        assert!(subscription.take_pending_updates().is_empty());
+        advance(Duration::from_millis(1)).await;
+        assert_eq!(
+            subscription.take_pending_updates(),
+            BTreeSet::from([scenario.room.instance_id()])
+        );
+        assert!(subscription.take_pending_updates().is_empty());
+        resume();
+    }
 }

--- a/crates/core/src/engine/room/media_graph/TESTS/route_graph.rs
+++ b/crates/core/src/engine/room/media_graph/TESTS/route_graph.rs
@@ -147,7 +147,6 @@ fn intent_survives_detach_and_resets_source_selection() {
                 2,
                 Bitrate::from_kbps(500),
             ));
-            selection.set_adaptation_observations(3, 4);
         })
     );
     graph.detach_source(SOURCE_ONE);
@@ -251,7 +250,7 @@ fn pending_and_committed_counts_follow_realization_state() {
         .current(&committed_key)
         .and_then(|(_, current)| current.committed())
         .expect("committed realization should be projected");
-    assert_eq!(committed.1, "mid");
+    assert_eq!(committed.mid, "mid");
 
     assert!(graph.release_consumer_setup(pending).is_empty());
     assert_eq!(graph.subscription_count(), 1);

--- a/crates/core/src/engine/room/media_graph/mod.rs
+++ b/crates/core/src/engine/room/media_graph/mod.rs
@@ -32,6 +32,7 @@ pub(super) use self::{
         DeclaredConsumerSetup, PendingConsumerSetup,
     },
     producer::{ProducerActivityCommit, PublishCommit, PublishIntentPlan, ValidatedPublish},
+    route_graph::PendingUpgrade,
     subscription::{ReceiverRouteActivity, ReceiverRouteCommit, ReceiverRouteWork},
     topology::{
         CommittedTransportReceipt, RoomTopology, SessionPlacementCommit, SessionPlacementRejection,
@@ -76,6 +77,8 @@ pub(super) struct ConsumerRouteView<'a> {
     pub key: &'a SubscriptionKey,
     pub route: &'a TransportConsumerRoute,
     pub mid: &'a str,
+    /// Borrow holds so policy snapshots do not copy deadlines for every route.
+    pub pending_upgrade: Option<&'a PendingUpgrade>,
     pub source: &'a PublishedSource,
     pub selection: ConsumerSourceSelection,
 }

--- a/crates/core/src/engine/room/media_graph/route_graph.rs
+++ b/crates/core/src/engine/room/media_graph/route_graph.rs
@@ -48,6 +48,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, btree_map::Entry},
     mem,
+    time::Instant,
 };
 
 use o_sfu_router::topology::RoutedConsumerId;
@@ -62,7 +63,9 @@ use crate::engine::{
         RelayRouteActivity, TransportConsumerRoute, TransportMediaId, TransportRelayRouteAction,
         TransportSessionKey, TransportSourceKey,
     },
-    source_model::{PolicyPauseReason, PublishedSourceId, SourceSubscriptionIntent},
+    source_model::{
+        PolicyPauseReason, PublishedSourceId, SourceSelector, SourceSubscriptionIntent,
+    },
 };
 
 #[derive(Debug, Default)]
@@ -94,12 +97,24 @@ enum ConsumerRealization {
     #[default]
     Absent,
     Pending(RouteReservationId, Option<RouteRelay>),
-    Committed(
-        TransportConsumerRoute,
-        String,
-        RoutedConsumerId,
-        Option<RouteRelay>,
-    ),
+    Committed(CommittedConsumerRoute),
+}
+
+/// Transport realization and adaptation hold share the exact route lifetime.
+#[derive(Debug)]
+pub(super) struct CommittedConsumerRoute {
+    pub route: TransportConsumerRoute,
+    pub mid: String,
+    routed: RoutedConsumerId,
+    relay: Option<RouteRelay>,
+    pub pending_upgrade: Option<PendingUpgrade>,
+}
+
+/// Eligibility must remain continuous for this exact deliverable post-fit target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::engine::room) struct PendingUpgrade {
+    pub selector: SourceSelector,
+    pub deadline: Instant,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -179,7 +194,7 @@ impl RouteGraph {
         let entry = self.entry(key);
         entry.intent.merge(update);
         if let (Some(active), Some(current)) = (update.active(), entry.current.as_mut()) {
-            current.selection.set_active(active);
+            current.set_active(active);
         }
     }
 
@@ -222,12 +237,12 @@ impl RouteGraph {
                 .get_mut(key)
                 .and_then(|entry| entry.current.as_mut())
                 .filter(|current| current.source_id == source_id)?;
-            if let ConsumerRealization::Committed(route, ..) = &current.realization
-                && route.consumer_session_key().connection_id() != connection_id
+            if let ConsumerRealization::Committed(committed) = &current.realization
+                && committed.route.consumer_session_key().connection_id() != connection_id
             {
                 return None;
             }
-            current.selection.set_active(active);
+            current.set_active(active);
             if let Some(reason) = policy_pause_reason {
                 current.selection.set_policy_pause_reason(Some(reason));
             }
@@ -295,7 +310,13 @@ impl RouteGraph {
             return Err(relay.map_or_else(Vec::new, |relay| self.release_relay(&key, &relay)));
         };
         current.selection = selection;
-        current.realization = ConsumerRealization::Committed(route, mid, routed, relay);
+        current.realization = ConsumerRealization::Committed(CommittedConsumerRoute {
+            route,
+            mid,
+            routed,
+            relay,
+            pending_upgrade: None,
+        });
         Ok(())
     }
 
@@ -313,14 +334,49 @@ impl RouteGraph {
         else {
             return false;
         };
-        let ConsumerRealization::Committed(current_route, ..) = &current.realization else {
+        let ConsumerRealization::Committed(committed) = &current.realization else {
             return false;
         };
-        if current.source_id != source_id || current_route != route {
+        if current.source_id != source_id || &committed.route != route {
             return false;
         }
         update(&mut current.selection);
+        if !current.selection.active() {
+            current.clear_upgrade();
+        }
         true
+    }
+
+    pub(super) fn update_upgrade(
+        &mut self,
+        key: &SubscriptionKey,
+        source_id: PublishedSourceId,
+        route: &TransportConsumerRoute,
+        pending_upgrade: Option<PendingUpgrade>,
+    ) -> bool {
+        let Some(current) = self.current_mut(key, source_id) else {
+            return false;
+        };
+        let ConsumerRealization::Committed(committed) = &mut current.realization else {
+            return false;
+        };
+        if &committed.route != route || !current.selection.active() {
+            return false;
+        }
+        committed.pending_upgrade = pending_upgrade;
+        true
+    }
+
+    pub(super) fn clear_source_upgrades(&mut self, source_id: PublishedSourceId) {
+        let (entries, by_source) = (&mut self.entries, &self.by_source);
+        for key in by_source.get(&source_id).into_iter().flatten() {
+            if let Some(current) = entries
+                .get_mut(key)
+                .and_then(|entry| entry.current.as_mut())
+            {
+                current.clear_upgrade();
+            }
+        }
     }
 
     pub(super) fn selection(
@@ -409,8 +465,8 @@ impl RouteGraph {
                     ConsumerSourceSelection::open(entry.intent.active().unwrap_or(true));
                 match mem::take(&mut current.realization) {
                     ConsumerRealization::Absent => None,
-                    ConsumerRealization::Pending(_, relay)
-                    | ConsumerRealization::Committed(_, _, _, relay) => relay,
+                    ConsumerRealization::Pending(_, relay) => relay,
+                    ConsumerRealization::Committed(committed) => committed.relay,
                 }
             };
             if let Some(relay) = relay {
@@ -456,11 +512,11 @@ impl RouteGraph {
                 else {
                     continue;
                 };
-                let ConsumerRealization::Committed(route, ..) = &current.realization else {
+                let ConsumerRealization::Committed(committed) = &current.realization else {
                     continue;
                 };
-                if route.consumer_session_key() != session
-                    || !declined.contains(&route.consumer_transport_media_id())
+                if committed.route.consumer_session_key() != session
+                    || !declined.contains(&committed.route.consumer_transport_media_id())
                 {
                     continue;
                 }
@@ -567,10 +623,10 @@ impl RouteGraph {
         let relay = match realization {
             ConsumerRealization::Absent => None,
             ConsumerRealization::Pending(_, relay) => relay,
-            ConsumerRealization::Committed(route, _, consumer, relay) => {
-                removed.routes.push(route);
-                removed.consumers.push(consumer);
-                relay
+            ConsumerRealization::Committed(committed) => {
+                removed.routes.push(committed.route);
+                removed.consumers.push(committed.routed);
+                committed.relay
             }
         };
         if let Some(relay) = relay {
@@ -650,13 +706,26 @@ impl Subscription {
 }
 
 impl CurrentPublication {
+    fn set_active(&mut self, active: bool) {
+        self.selection.set_active(active);
+        if !active {
+            self.clear_upgrade();
+        }
+    }
+
+    fn clear_upgrade(&mut self) {
+        if let ConsumerRealization::Committed(committed) = &mut self.realization {
+            committed.pending_upgrade = None;
+        }
+    }
+
     pub(super) const fn is_pending(&self) -> bool {
         matches!(self.realization, ConsumerRealization::Pending(..))
     }
 
-    pub(super) fn committed(&self) -> Option<(&TransportConsumerRoute, &str)> {
+    pub(super) fn committed(&self) -> Option<&CommittedConsumerRoute> {
         match &self.realization {
-            ConsumerRealization::Committed(route, mid, ..) => Some((route, mid)),
+            ConsumerRealization::Committed(committed) => Some(committed),
             ConsumerRealization::Absent | ConsumerRealization::Pending(..) => None,
         }
     }
@@ -666,7 +735,8 @@ impl ConsumerRealization {
     fn set_relay_activity(&mut self, activity: RelayRouteActivity) -> Option<RouteRelay> {
         let relay = match self {
             Self::Absent => return None,
-            Self::Pending(_, relay) | Self::Committed(_, _, _, relay) => relay.as_mut()?,
+            Self::Pending(_, relay) => relay.as_mut()?,
+            Self::Committed(committed) => committed.relay.as_mut()?,
         };
         if relay.activity == activity {
             return None;

--- a/crates/core/src/engine/room/media_graph/topology.rs
+++ b/crates/core/src/engine/room/media_graph/topology.rs
@@ -16,7 +16,9 @@ use super::{
     DeclaredConsumerSetup, PendingConsumerRouteView, PendingConsumerSetup, PublishedSource,
     ReceiverRouteActivity, SubscriptionKey, ValidatedPublish,
     producer::{PublicationCommitError, allocate_source_descriptor},
-    route_graph::{CurrentPublication, RelayRouteEffect, RemovedRoutes, RouteGraph},
+    route_graph::{
+        CurrentPublication, PendingUpgrade, RelayRouteEffect, RemovedRoutes, RouteGraph,
+    },
     source_index::PublishedSources,
 };
 use crate::engine::{
@@ -543,6 +545,25 @@ impl RoomTopology {
         updated
     }
 
+    /// Commits a hold only for the active source, subscription and exact route.
+    pub(in crate::engine::room) fn update_consumer_upgrade(
+        &mut self,
+        key: &SubscriptionKey,
+        source_id: PublishedSourceId,
+        route: &TransportConsumerRoute,
+        pending_upgrade: Option<PendingUpgrade>,
+    ) -> bool {
+        if !self
+            .sources
+            .source(source_id)
+            .is_some_and(|source| source.active)
+        {
+            return false;
+        }
+        self.route_graph
+            .update_upgrade(key, source_id, route, pending_upgrade)
+    }
+
     fn detach_user_sources(
         &mut self,
         user_id: &UserId,
@@ -574,12 +595,13 @@ impl RoomTopology {
         key: &'a SubscriptionKey,
         current: &'a CurrentPublication,
     ) -> Option<ConsumerRouteView<'a>> {
-        let (route, mid) = current.committed()?;
+        let committed = current.committed()?;
         let source = self.sources.source(current.source_id)?;
         Some(ConsumerRouteView {
             key,
-            route,
-            mid,
+            route: &committed.route,
+            mid: &committed.mid,
+            pending_upgrade: committed.pending_upgrade.as_ref(),
             source,
             selection: current.selection,
         })
@@ -712,6 +734,9 @@ impl RoomTopology {
         source.active = active;
         source.activity_revision = source.activity_revision.next();
         let revision = source.activity_revision;
+        if !active {
+            self.route_graph.clear_source_upgrades(source_id);
+        }
         self.invalidate_video_allocation();
         Some(revision)
     }

--- a/crates/core/src/engine/room/read_model.rs
+++ b/crates/core/src/engine/room/read_model.rs
@@ -7,22 +7,23 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use o_sfu_rfc::rtp::Ssrc;
 use o_sfu_router::{MediaKind, rtp::MediaFormat};
 use o_sfu_telemetry::diagnostics::{
     DiagnosticsActiveSpeaker, DiagnosticsActiveSpeakerReason, DiagnosticsActiveSpeakerState,
-    DiagnosticsIncomingBitrate, DiagnosticsMediaKind, DiagnosticsPolicyPauseReason,
-    DiagnosticsPublication, DiagnosticsQualitySummary, DiagnosticsRouteState, DiagnosticsSource,
-    DiagnosticsSourceEncoding, DiagnosticsSourceSelection, DiagnosticsSourceSelectionReason,
-    DiagnosticsSourceSelector, DiagnosticsSubscription, DiagnosticsTransportCounts,
-    DiagnosticsUserSummary, DiagnosticsUserTransport, DiagnosticsUserView,
-    DiagnosticsVideoLayoutRole, DiagnosticsVideoRoutePriority, DiagnosticsWorkerSummary,
+    DiagnosticsIncomingBitrate, DiagnosticsMediaKind, DiagnosticsPendingUpgrade,
+    DiagnosticsPolicyPauseReason, DiagnosticsPublication, DiagnosticsQualitySummary,
+    DiagnosticsRouteState, DiagnosticsSource, DiagnosticsSourceEncoding,
+    DiagnosticsSourceSelection, DiagnosticsSourceSelectionReason, DiagnosticsSourceSelector,
+    DiagnosticsSubscription, DiagnosticsTransportCounts, DiagnosticsUserSummary,
+    DiagnosticsUserTransport, DiagnosticsUserView, DiagnosticsVideoLayoutRole,
+    DiagnosticsVideoRoutePriority, DiagnosticsWorkerSummary,
 };
 
-use super::{Room, RoomMediaCounts, state::RoomState};
+use super::{Room, RoomMediaCounts, media_graph::PendingUpgrade, state::RoomState};
 use crate::{
     Bitrate,
     engine::{
@@ -255,6 +256,7 @@ struct CapturedUser {
     subscriptions: Vec<DiagnosticsSubscription>,
     user_id: UserId,
     user_info: UserInfo,
+    video_soft_pause_remaining_ms: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -317,10 +319,11 @@ impl Room {
 
     pub async fn diagnostics_detail_capture(&self) -> RoomDetailCapture {
         let state = self.state.read().await;
+        let now = Instant::now();
         let users = state
             .transport_user_entries()
             .filter_map(|(user_id, connection_id)| {
-                captured_user(&state, user_id.clone(), connection_id)
+                captured_user(&state, user_id.clone(), connection_id, now)
             })
             .collect::<Vec<_>>();
         let session_keys = users.iter().map(|user| user.session_key.clone()).collect();
@@ -344,12 +347,13 @@ impl Room {
 
     pub async fn diagnostics_user_capture(&self, user_key: &str) -> Option<RoomUserCapture> {
         let state = self.state.read().await;
+        let now = Instant::now();
         let (user_id, connection_id) = state
             .transport_user_entries()
             .find(|(user_id, _)| user_id.path_segment().as_ref() == user_key)?;
         Some(RoomUserCapture {
             recording_state: state.recording_state(),
-            user: captured_user(&state, user_id.clone(), connection_id)?,
+            user: captured_user(&state, user_id.clone(), connection_id, now)?,
         })
     }
 }
@@ -405,11 +409,16 @@ fn captured_user(
     state: &RoomState,
     user_id: UserId,
     connection_id: ConnectionId,
+    now: Instant,
 ) -> Option<CapturedUser> {
     Some(CapturedUser {
         publications: diagnostics_publications(state, &user_id, connection_id),
         session_key: state.transport_user_key(&user_id, connection_id),
-        subscriptions: diagnostics_subscriptions(state, &user_id, connection_id),
+        subscriptions: diagnostics_subscriptions(state, &user_id, connection_id, now),
+        video_soft_pause_remaining_ms: state
+            .user_for_connection(&user_id, connection_id)?
+            .video_soft_pause_deadline
+            .map(|deadline| duration_millis(deadline.saturating_duration_since(now))),
         user_info: state.user_info_snapshot(&user_id)?.1,
         user_id,
     })
@@ -448,9 +457,11 @@ fn diagnostics_subscriptions(
     state: &RoomState,
     user_id: &UserId,
     connection_id: ConnectionId,
+    now: Instant,
 ) -> Vec<DiagnosticsSubscription> {
     let project = |source: &PublishedSourceDescriptor,
                    route_selection: ConsumerSourceSelection,
+                   pending_upgrade: Option<PendingUpgrade>,
                    consumer_media: Option<TransportMediaId>,
                    source_media: TransportMediaId,
                    route_state| {
@@ -460,7 +471,7 @@ fn diagnostics_subscriptions(
             layout_priority: layout.map(|role| role.priority().into()),
             layout_role: layout.map(Into::into),
             producer_user_id: source.owner().user_id().clone(),
-            selection: selection(source, route_selection),
+            selection: selection(source, route_selection, pending_upgrade, now),
             source_id: source.source_id().as_u64(),
             source_transport_media_id: Some(source_media.as_u64()),
             state: route_state,
@@ -481,6 +492,7 @@ fn diagnostics_subscriptions(
             project(
                 source,
                 route.selection,
+                route.pending_upgrade.copied(),
                 Some(route.route.consumer_transport_media_id()),
                 route.route.source_transport_media_id(),
                 route_state,
@@ -496,6 +508,7 @@ fn diagnostics_subscriptions(
                 project(
                     source,
                     route.selection,
+                    None,
                     None,
                     route.source.transport.transport_media_id(),
                     DiagnosticsRouteState::Pending,
@@ -564,6 +577,7 @@ fn user_view(
     health: &TransportHealthSnapshot,
 ) -> DiagnosticsUserView {
     let transport = DiagnosticsUserTransport {
+        video_soft_pause_remaining_ms: user.video_soft_pause_remaining_ms,
         connection_id: user.session_key.connection_id().as_u64(),
         health: health
             .get(&user.session_key)
@@ -702,6 +716,8 @@ fn rid_activity<'a>(
 fn selection(
     source: &PublishedSourceDescriptor,
     selection: ConsumerSourceSelection,
+    pending_upgrade: Option<PendingUpgrade>,
+    now: Instant,
 ) -> DiagnosticsSourceSelection {
     let selected_encoding_id = selection.selector().selected_encoding();
     let budget = selection.budget();
@@ -724,7 +740,17 @@ fn selection(
             .map(Bitrate::as_bps),
         policy_allows_delivery: selection.policy_allows_delivery(),
         policy_pause_reason: selection.policy_pause_reason().map(Into::into),
-        pressure_observations: selection.pressure_observations(),
+        pending_upgrade: pending_upgrade.map(|pending| DiagnosticsPendingUpgrade {
+            selector: match pending.selector {
+                SourceSelector::Open => DiagnosticsSourceSelector::Open,
+                SourceSelector::Encoding(_) => DiagnosticsSourceSelector::Encoding,
+            },
+            encoding_id: pending
+                .selector
+                .selected_encoding()
+                .map(SourceEncodingId::as_u64),
+            remaining_ms: duration_millis(pending.deadline.saturating_duration_since(now)),
+        }),
         selection_reason,
         selector,
         selected_estimated_bitrate_bps: selected_encoding
@@ -736,7 +762,6 @@ fn selection(
         selected_rid: selected_encoding
             .and_then(SourceEncodingDescriptor::rid)
             .map(|rid| rid.as_str().to_owned()),
-        upgrade_observations: selection.upgrade_observations(),
     }
 }
 

--- a/crates/core/src/engine/room/source_policy/action.rs
+++ b/crates/core/src/engine/room/source_policy/action.rs
@@ -1,4 +1,6 @@
-use super::super::media_graph::SubscriptionKey;
+use std::time::Instant;
+
+use super::super::media_graph::{PendingUpgrade, SubscriptionKey};
 use crate::{
     Bitrate,
     engine::{
@@ -39,6 +41,7 @@ pub(super) struct VideoRouteAllocation {
     pub(super) key: SubscriptionKey,
     pub(super) source_id: PublishedSourceId,
     pub(super) route: TransportConsumerRoute,
+    pub(super) interrupts_upgrade: bool,
     pub(super) captured: VideoRouteAllocationState,
     pub(super) planned: Option<VideoRouteAllocationState>,
 }
@@ -51,6 +54,24 @@ pub(super) struct ReceiverVideoBudgetPlan {
     pub(super) routes: Vec<VideoRouteAllocation>,
 }
 
+/// Receiver timing captured before transport work, including cancellation.
+#[derive(Debug)]
+pub(super) struct ReceiverPolicyTiming {
+    pub receiver: UserId,
+    pub connection_id: ConnectionId,
+    pub soft_pause_deadline: Option<Instant>,
+    pub next_deadline: Option<Instant>,
+    /// Existing eligible wakeups survive rejection of an unrelated control.
+    pub retained_deadline: Option<Instant>,
+}
+
+/// Only changed upgrade state requires validation and a topology write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UpgradeChange {
+    Unchanged,
+    Set(Option<PendingUpgrade>),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::engine::room) struct ConsumerPacketSelectionUpdate {
     pub(super) key: SubscriptionKey,
@@ -61,8 +82,8 @@ pub(in crate::engine::room) struct ConsumerPacketSelectionUpdate {
     pub(super) planned_budget: ReceiverVideoBudgetDiagnostics,
     pub(super) transition: Option<VideoRouteTransition>,
     pub(super) selected_estimated_bitrate: Option<Bitrate>,
-    pub(super) pressure_observations: u8,
-    pub(super) upgrade_observations: u8,
+    pub(super) upgrade: UpgradeChange,
+    pub(super) interrupts_upgrade: bool,
     pub(super) packet_gate: Option<SourcePacketGate>,
     pub(super) route_activity_changed: bool,
     pub(super) request_keyframe: bool,
@@ -85,8 +106,8 @@ impl ConsumerPacketSelectionUpdate {
             planned_budget: current_selection.budget(),
             transition: None,
             selected_estimated_bitrate: None,
-            pressure_observations: current_selection.pressure_observations(),
-            upgrade_observations: current_selection.upgrade_observations(),
+            upgrade: UpgradeChange::Unchanged,
+            interrupts_upgrade: false,
             packet_gate: None,
             route_activity_changed: true,
             request_keyframe: false,
@@ -95,10 +116,6 @@ impl ConsumerPacketSelectionUpdate {
 
     pub(super) const fn requires_media_transport_effect(&self) -> bool {
         self.packet_gate.is_some() || self.route_activity_changed || self.request_keyframe
-    }
-
-    pub(super) const fn requires_follow_up(&self) -> bool {
-        self.pressure_observations > 0 || self.upgrade_observations > 0
     }
 
     pub(in crate::engine::room) fn route_control(&self) -> ConsumerRouteControl {

--- a/crates/core/src/engine/room/source_policy/mod.rs
+++ b/crates/core/src/engine/room/source_policy/mod.rs
@@ -12,8 +12,8 @@
 //! bandwidth estimates to encoding selectors, route activity and BWE targets.
 //!
 //! Gate and activity controls must be accepted before the matching
-//! [`ConsumerPacketSelectionUpdate`] commits to room state. Committed hysteresis
-//! observations schedule a delayed follow-up turn until the decision settles.
+//! [`ConsumerPacketSelectionUpdate`] commits to room state. Each turn replaces
+//! or cancels its earliest receiver-pressure or exact-target upgrade deadline.
 
 mod action;
 mod audio;

--- a/crates/core/src/engine/room/source_policy/turn.rs
+++ b/crates/core/src/engine/room/source_policy/turn.rs
@@ -1,6 +1,6 @@
 //! source-policy apply ownership without transport awaits under the room lock
 
-use std::{borrow::Cow, mem};
+use std::{borrow::Cow, collections::BTreeMap, mem, time::Instant};
 
 use o_sfu_router::MediaKind;
 use o_sfu_telemetry::schema::event as telemetry_event;
@@ -8,14 +8,15 @@ use tracing::info;
 
 use super::{
     action::{
-        ConsumerPacketSelectionUpdate, FeaturedUserUpdate, ReceiverVideoBudgetPlan,
-        VideoRouteTransition,
+        ConsumerPacketSelectionUpdate, FeaturedUserUpdate, ReceiverPolicyTiming,
+        ReceiverVideoBudgetPlan, UpgradeChange, VideoRouteTransition,
     },
     audio,
     input::SourcePolicySnapshot,
     video,
 };
 use crate::engine::{
+    ConnectionId,
     media_transport::{
         ActiveSpeakerSource, MediaTransport, ReceiverBandwidthSnapshot, ReceiverBweTargetUpdate,
         TransportBitrateSnapshot,
@@ -69,8 +70,14 @@ impl SourcePolicyTurn {
         media_transport: Option<&MediaTransport>,
         active_speaker_sources: Option<&[ActiveSpeakerSource]>,
     ) {
-        self.execute_observed(room, media_transport, active_speaker_sources, None)
-            .await;
+        self.execute_observed(
+            room,
+            media_transport,
+            active_speaker_sources,
+            None,
+            Instant::now(),
+        )
+        .await;
     }
 
     async fn execute_observed(
@@ -79,6 +86,7 @@ impl SourcePolicyTurn {
         media_transport: Option<&MediaTransport>,
         active_speaker_sources: Option<&[ActiveSpeakerSource]>,
         bandwidth: Option<&ReceiverBandwidthSnapshot>,
+        now: Instant,
     ) -> bool {
         if !self.requested {
             return false;
@@ -87,12 +95,13 @@ impl SourcePolicyTurn {
             return false;
         };
         let transaction = if let Some(sources) = active_speaker_sources {
-            run_packet_selection(room, sources, media_transport, bandwidth).await
+            run_packet_selection(room, sources, media_transport, bandwidth, now).await
         } else {
             let sources = media_transport.active_speaker_source_snapshot().await;
-            run_packet_selection(room, &sources, media_transport, bandwidth).await
+            run_packet_selection(room, &sources, media_transport, bandwidth, now).await
         };
         let Some(transaction) = transaction else {
+            media_transport.set_source_policy_deadline(room.instance_id(), None);
             return false;
         };
         transaction.commit(room, media_transport).await;
@@ -105,10 +114,11 @@ pub async fn run_source_policy_turn_for_benchmark(
     room: &Room,
     media_transport: &MediaTransport,
     bandwidth: &ReceiverBandwidthSnapshot,
+    now: Instant,
 ) -> bool {
     let _guard = room.source_policy_turn.lock().await;
     SourcePolicyTurn::packet_selection()
-        .execute_observed(room, Some(media_transport), None, Some(bandwidth))
+        .execute_observed(room, Some(media_transport), None, Some(bandwidth), now)
         .await
 }
 
@@ -117,6 +127,7 @@ async fn run_packet_selection(
     active_speakers: &[ActiveSpeakerSource],
     media_transport: &MediaTransport,
     bandwidth_override: Option<&ReceiverBandwidthSnapshot>,
+    now: Instant,
 ) -> Option<SourcePolicyTransaction> {
     let sessions = {
         let state = room.state.read().await;
@@ -136,17 +147,20 @@ async fn run_packet_selection(
         active_speakers,
         &receiver_bandwidth,
         &source_bitrate,
+        now,
     )
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(in crate::engine::room) struct SourcePolicyTransaction {
     route_effects: RoomRouteEffects,
     state_updates: Vec<ConsumerPacketSelectionUpdate>,
     receiver_video_budget_plans: Vec<ReceiverVideoBudgetPlan>,
     featured_users: Vec<FeaturedUserUpdate>,
     video_allocation_revision: u64,
-    expected_route_update_count: usize,
+    outstanding_controls: BTreeMap<ConnectionId, usize>,
+    receiver_timing: Vec<ReceiverPolicyTiming>,
+    planned_at: Instant,
 }
 
 impl SourcePolicyTransaction {
@@ -155,6 +169,7 @@ impl SourcePolicyTransaction {
         active_speakers: &[ActiveSpeakerSource],
         receiver_bandwidth: &ReceiverBandwidthSnapshot,
         source_bitrate: &TransportBitrateSnapshot,
+        now: Instant,
     ) -> Option<Self> {
         let mut input = SourcePolicySnapshot::from_state(
             state,
@@ -164,11 +179,17 @@ impl SourcePolicyTransaction {
         );
         let mut tx = Self {
             video_allocation_revision: state.topology.video_allocation_revision(),
-            ..Self::default()
+            route_effects: RoomRouteEffects::default(),
+            state_updates: Vec::new(),
+            receiver_video_budget_plans: Vec::new(),
+            featured_users: Vec::new(),
+            outstanding_controls: BTreeMap::new(),
+            receiver_timing: Vec::new(),
+            planned_at: now,
         };
         audio::append_audio_route_activity(&mut tx, &input);
         let receiver_bwe_targets = mem::take(&mut input.receiver_bwe_targets);
-        video::append_receiver_video_policy(&mut tx, state, &input, receiver_bwe_targets);
+        video::append_receiver_video_policy(&mut tx, state, &input, receiver_bwe_targets, now);
         tx.featured_users = input.featured_user_updates;
         (!tx.is_empty()).then_some(tx)
     }
@@ -178,12 +199,16 @@ impl SourcePolicyTransaction {
     }
 
     pub(super) fn push_route_update(&mut self, update: ConsumerPacketSelectionUpdate) {
-        self.expect_route_update();
+        self.expect_route_update(update.route.consumer_session_key().connection_id());
         self.route_effects.source_policy_update(update);
     }
 
-    pub(super) fn expect_route_update(&mut self) {
-        self.expected_route_update_count += 1;
+    pub(super) fn expect_route_update(&mut self, connection: ConnectionId) {
+        *self.outstanding_controls.entry(connection).or_default() += 1;
+    }
+
+    pub(super) fn push_receiver_timing(&mut self, timing: ReceiverPolicyTiming) {
+        self.receiver_timing.push(timing);
     }
 
     pub(super) fn push_receiver_video_budget_plan(&mut self, plan: ReceiverVideoBudgetPlan) {
@@ -201,7 +226,9 @@ impl SourcePolicyTransaction {
             receiver_video_budget_plans,
             featured_users,
             video_allocation_revision,
-            expected_route_update_count,
+            mut outstanding_controls,
+            receiver_timing,
+            planned_at,
         } = self;
         let accepted_route_updates = if route_effects.is_empty() {
             Vec::new()
@@ -210,25 +237,41 @@ impl SourcePolicyTransaction {
             // state must not claim a selection that its worker rejected.
             route_effects.execute(room.uuid(), media_transport).await
         };
-        // Unprojectable route controls increment only the expected count. `execute`
-        // returns every submitted source-policy update except rejected controls.
-        let all_route_controls_accepted =
-            accepted_route_updates.len() == expected_route_update_count;
+        // Rejections gate only their receiver's temporal state. PR1 budget
+        // reconciliation still observes acceptance across the whole transaction.
+        for update in &accepted_route_updates {
+            if let Some(remaining) =
+                outstanding_controls.get_mut(&update.route.consumer_session_key().connection_id())
+            {
+                *remaining -= 1;
+            }
+        }
         state_updates.extend(accepted_route_updates);
-        // Only committed nonzero counters schedule another observation. Rejected
-        // or topology-stale work must not advance adaptation hysteresis.
-        if commit_accepted_updates(
-            room,
+        if state_updates.is_empty()
+            && receiver_video_budget_plans.is_empty()
+            && featured_users.is_empty()
+            && receiver_timing.is_empty()
+        {
+            media_transport.set_source_policy_deadline(room.instance_id(), None);
+            return;
+        }
+        let mut state = room.state.write().await;
+        let (committed_updates, deadline) = commit_packet_updates(
+            &mut state,
             state_updates,
             &receiver_video_budget_plans,
-            &featured_users,
             video_allocation_revision,
-            all_route_controls_accepted,
-        )
-        .await
-        {
-            media_transport.schedule_source_policy_follow_up(room.instance_id());
+            &outstanding_controls,
+            &receiver_timing,
+            planned_at,
+        );
+        let info_fanout = commit_featured_user_updates(&mut state, &featured_users);
+        drop(state);
+        record_committed_selection_updates(room, &committed_updates);
+        if let Some(info_fanout) = info_fanout {
+            info_fanout.emit();
         }
+        media_transport.set_source_policy_deadline(room.instance_id(), deadline);
     }
 
     #[cfg(test)]
@@ -245,41 +288,8 @@ impl SourcePolicyTransaction {
             && self.route_effects.is_empty()
             && self.receiver_video_budget_plans.is_empty()
             && self.featured_users.is_empty()
+            && self.receiver_timing.is_empty()
     }
-}
-
-async fn commit_accepted_updates(
-    room: &Room,
-    state_updates: Vec<ConsumerPacketSelectionUpdate>,
-    receiver_video_budget_plans: &[ReceiverVideoBudgetPlan],
-    featured_users: &[FeaturedUserUpdate],
-    video_allocation_revision: u64,
-    all_route_controls_accepted: bool,
-) -> bool {
-    if state_updates.is_empty()
-        && receiver_video_budget_plans.is_empty()
-        && featured_users.is_empty()
-    {
-        return false;
-    }
-    let (committed_updates, info_fanout, requires_follow_up) = {
-        let mut state = room.state.write().await;
-        let (committed_updates, requires_follow_up) = commit_packet_updates(
-            &mut state,
-            state_updates,
-            receiver_video_budget_plans,
-            video_allocation_revision,
-            all_route_controls_accepted,
-        );
-        let info_fanout = commit_featured_user_updates(&mut state, featured_users);
-        drop(state);
-        (committed_updates, info_fanout, requires_follow_up)
-    };
-    record_committed_selection_updates(room, &committed_updates);
-    if let Some(info_fanout) = info_fanout {
-        info_fanout.emit();
-    }
-    requires_follow_up
 }
 
 fn record_committed_selection_updates(room: &Room, updates: &[ConsumerPacketSelectionUpdate]) {
@@ -368,12 +378,66 @@ fn commit_packet_updates(
     mut updates: Vec<ConsumerPacketSelectionUpdate>,
     receiver_video_budget_plans: &[ReceiverVideoBudgetPlan],
     video_allocation_revision: u64,
-    all_route_controls_accepted: bool,
-) -> (Vec<ConsumerPacketSelectionUpdate>, bool) {
+    outstanding_controls: &BTreeMap<ConnectionId, usize>,
+    receiver_timing: &[ReceiverPolicyTiming],
+    now: Instant,
+) -> (Vec<ConsumerPacketSelectionUpdate>, Option<Instant>) {
     let allocation_plan_is_current =
         state.topology.video_allocation_revision() == video_allocation_revision;
+    let all_route_controls_accepted = outstanding_controls.values().all(|count| *count == 0);
     let reconcile_planned_budgets = !allocation_plan_is_current || !all_route_controls_accepted;
-    let mut requires_follow_up = !allocation_plan_is_current && !updates.is_empty();
+    let receiver_controls_accepted = |connection| {
+        outstanding_controls
+            .get(&connection)
+            .is_none_or(|count| *count == 0)
+    };
+    let mut next_deadline = None;
+    // The allocation revision covers the captured subscriptions, sources and
+    // exact routes. Check it before selection writes advance it within this turn.
+    if allocation_plan_is_current {
+        for timing in receiver_timing {
+            let accepted = receiver_controls_accepted(timing.connection_id);
+            let Some(user) = state.user_mut_for_connection(&timing.receiver, timing.connection_id)
+            else {
+                continue;
+            };
+            // Recovery ends continuity even when a sibling control rejects.
+            if timing.soft_pause_deadline.is_none() || accepted {
+                user.video_soft_pause_deadline = timing.soft_pause_deadline;
+            }
+            // A rejected sibling cannot cancel an already committed future hold.
+            // Newly proposed deadlines still require acceptance and due retries
+            // remain unscheduled.
+            let deadline = if accepted {
+                timing.next_deadline
+            } else {
+                timing.retained_deadline
+            };
+            if let Some(deadline) = deadline.filter(|deadline| *deadline > now) {
+                next_deadline =
+                    Some(next_deadline.map_or(deadline, |next: Instant| next.min(deadline)));
+            }
+        }
+        // Cancellation follows eligibility, not transport acceptance. Rejected
+        // downsteps must not leave an old upgrade eligible through an interruption.
+        for route in receiver_video_budget_plans
+            .iter()
+            .flat_map(|plan| &plan.routes)
+            .filter(|route| route.interrupts_upgrade)
+        {
+            state
+                .topology
+                .update_consumer_upgrade(&route.key, route.source_id, &route.route, None);
+        }
+        for update in updates.iter().filter(|update| update.interrupts_upgrade) {
+            state.topology.update_consumer_upgrade(
+                &update.key,
+                update.source_id,
+                &update.route,
+                None,
+            );
+        }
+    }
     updates.retain_mut(|update| {
         let commit_planned_budget = allocation_plan_is_current
             && (!reconcile_planned_budgets
@@ -390,10 +454,6 @@ fn commit_packet_updates(
                 if commit_planned_budget {
                     selection.set_budget(update.planned_budget);
                 }
-                selection.set_adaptation_observations(
-                    update.pressure_observations,
-                    update.upgrade_observations,
-                );
             },
         );
         if committed
@@ -403,7 +463,20 @@ fn commit_packet_updates(
         {
             update.transition = None;
         }
-        requires_follow_up |= committed && update.requires_follow_up();
+        if let UpgradeChange::Set(pending_upgrade) = update.upgrade
+            && committed
+            && allocation_plan_is_current
+            && receiver_controls_accepted(update.route.consumer_session_key().connection_id())
+            && state.user_connection_id(&update.key.receiver)
+                == Some(update.route.consumer_session_key().connection_id())
+        {
+            state.topology.update_consumer_upgrade(
+                &update.key,
+                update.source_id,
+                &update.route,
+                pending_upgrade,
+            );
+        }
         committed
     });
     if reconcile_planned_budgets {
@@ -411,7 +484,7 @@ fn commit_packet_updates(
             reconcile_receiver_video_budget(state, plan);
         }
     }
-    (updates, requires_follow_up)
+    (updates, next_deadline)
 }
 
 fn route_transition_remains_observable(

--- a/crates/core/src/engine/room/source_policy/video/TESTS/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/TESTS/solver.rs
@@ -4,6 +4,8 @@
     reason = "test assertions use unwrap and expect for clear failure messages"
 )]
 
+use std::time::Duration;
+
 use super::{Bitrate, VideoAdaptationTuning, effective_video_budget};
 
 #[test]
@@ -20,8 +22,15 @@ fn effective_video_budget_no_reserve_returns_full_estimate() {
 #[test]
 fn effective_video_budget_applies_headroom_then_audio() {
     // 20% headroom on 1000 kbps -> 800 kbps, minus a 50 kbps audio reserve -> 750 kbps.
-    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 20, Bitrate::from_kbps(16))
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        3,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        20,
+        Bitrate::from_kbps(16),
+    )
+    .expect("valid tuning should build");
     assert_eq!(
         effective_video_budget(Bitrate::from_kbps(1000), tuning, Bitrate::from_kbps(50)),
         Bitrate::from_kbps(750),
@@ -31,8 +40,15 @@ fn effective_video_budget_applies_headroom_then_audio() {
 #[test]
 fn effective_video_budget_saturates_to_zero_when_over_reserved() {
     // 50% of 100 kbps = 50 kbps, minus a 200 kbps audio reserve saturates to zero.
-    let tuning = VideoAdaptationTuning::try_new(3, 2, 2, 3, 50, Bitrate::zero())
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        3,
+        2,
+        Duration::from_millis(750),
+        Duration::from_millis(750),
+        50,
+        Bitrate::zero(),
+    )
+    .expect("valid tuning should build");
     assert_eq!(
         effective_video_budget(Bitrate::from_kbps(100), tuning, Bitrate::from_kbps(200)),
         Bitrate::zero(),

--- a/crates/core/src/engine/room/source_policy/video/input.rs
+++ b/crates/core/src/engine/room/source_policy/video/input.rs
@@ -8,7 +8,10 @@ use crate::{
     engine::{
         UserId, VideoLayoutIntent,
         media_transport::TransportConsumerRoute,
-        room::{media_graph::SubscriptionKey, state::RoomState},
+        room::{
+            media_graph::{PendingUpgrade, SubscriptionKey},
+            state::RoomState,
+        },
         source_model::{
             ConsumerSourceSelection, PublishedSourceDescriptor, SourceAdaptationPolicy,
             SourceRoomPolicySelector,
@@ -48,6 +51,7 @@ pub(super) fn receiver_video_routes<'a>(
             key: route.key,
             route: route.route,
             current_selection: route.selection,
+            pending_upgrade: route.pending_upgrade,
             layout_role,
             visible_scalable_route_count: 1,
             active_speaker_rank: input
@@ -85,6 +89,7 @@ pub(super) struct ReceiverVideoRouteInput<'a> {
     pub(super) key: &'a SubscriptionKey,
     pub(super) route: &'a TransportConsumerRoute,
     pub(super) current_selection: ConsumerSourceSelection,
+    pub(super) pending_upgrade: Option<&'a PendingUpgrade>,
     pub(super) layout_role: SourceRoomPolicySelector,
     pub(super) visible_scalable_route_count: usize,
     pub(super) active_speaker_rank: Option<usize>,

--- a/crates/core/src/engine/room/source_policy/video/projection.rs
+++ b/crates/core/src/engine/room/source_policy/video/projection.rs
@@ -1,8 +1,8 @@
 use o_sfu_router::MediaKind;
 
 use super::{
-    super::action::{ConsumerPacketSelectionUpdate, VideoRouteTransition},
-    solver::{AdaptationCounts, PlannedReceiverRoute, selector_bitrate},
+    super::action::{ConsumerPacketSelectionUpdate, UpgradeChange, VideoRouteTransition},
+    solver::{PlannedReceiverRoute, selector_bitrate},
 };
 use crate::engine::{
     media_transport::SourcePacketGate,
@@ -38,7 +38,7 @@ pub(super) fn consumer_packet_selection_update(
     if selection.selector == current_selection.selector()
         && selection.policy_pause_reason == current_selection.policy_pause_reason()
         && planned_budget == current_selection.budget()
-        && selection.counts == AdaptationCounts::from_current(current_selection)
+        && selection.pending_upgrade.as_ref() == input.pending_upgrade
     {
         return None;
     }
@@ -70,8 +70,12 @@ pub(super) fn consumer_packet_selection_update(
         planned_budget,
         transition,
         selected_estimated_bitrate,
-        pressure_observations: selection.counts.pressure,
-        upgrade_observations: selection.counts.upgrade,
+        upgrade: if selection.pending_upgrade.as_ref() == input.pending_upgrade {
+            UpgradeChange::Unchanged
+        } else {
+            UpgradeChange::Set(selection.pending_upgrade)
+        },
+        interrupts_upgrade: selection.interrupts_upgrade(input.pending_upgrade),
         packet_gate,
         route_activity_changed,
         request_keyframe: request_keyframe && input.source.media_kind() == MediaKind::Video,

--- a/crates/core/src/engine/room/source_policy/video/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/solver.rs
@@ -1,15 +1,18 @@
 //! receiver-video policy turn
 //!
-//! [`SourcePolicyTransaction`]: filter -> budget -> plan -> admit -> fit -> hysteresis -> projection
+//! [`SourcePolicyTransaction`]: filter -> budget -> plan -> admit -> fit -> dwell -> projection
 //! packet-gate changes stay behind [`projection`] so planning never builds transport gates directly
 
-use std::{cmp::Reverse, collections::BTreeMap};
+use std::{cmp::Reverse, collections::BTreeMap, time::Instant};
 
 use itertools::Itertools;
 
 use super::{
     super::{
-        action::{ReceiverVideoBudgetPlan, VideoRouteAllocation, VideoRouteAllocationState},
+        action::{
+            ReceiverPolicyTiming, ReceiverVideoBudgetPlan, VideoRouteAllocation,
+            VideoRouteAllocationState,
+        },
         input::SourcePolicySnapshot,
         turn::SourcePolicyTransaction,
     },
@@ -21,12 +24,11 @@ use crate::{
     engine::{
         UserId,
         media_transport::ReceiverBweTargetUpdate,
-        room::state::RoomState,
+        room::{media_graph::PendingUpgrade, state::RoomState},
         source_model::{
-            ConsumerSourceSelection, PolicyPauseReason, PublishedSourceDescriptor,
-            PublishedSourceId, ReceiverVideoBudgetDiagnostics, SourceAdaptationPolicy,
-            SourceEncodingDescriptor, SourceRoomPolicySelector, SourceRoutePriority,
-            SourceSelector, UploadLayerPolicyRole,
+            PolicyPauseReason, PublishedSourceDescriptor, PublishedSourceId,
+            ReceiverVideoBudgetDiagnostics, SourceAdaptationPolicy, SourceEncodingDescriptor,
+            SourceRoomPolicySelector, SourceRoutePriority, SourceSelector, UploadLayerPolicyRole,
         },
     },
 };
@@ -65,51 +67,6 @@ impl VideoAdmissionRank {
     }
 }
 
-/// hysteresis counters persisted in [`ConsumerSourceSelection`] between policy turns
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(super) struct AdaptationCounts {
-    /// consecutive pressure observations toward a soft downswitch or pause
-    pub(super) pressure: u8,
-    /// consecutive stable observations toward a soft resume or upswitch
-    pub(super) upgrade: u8,
-}
-
-impl AdaptationCounts {
-    const fn reset() -> Self {
-        Self {
-            pressure: 0,
-            upgrade: 0,
-        }
-    }
-
-    pub(super) fn from_current(selection: ConsumerSourceSelection) -> Self {
-        Self {
-            pressure: selection.pressure_observations(),
-            upgrade: selection.upgrade_observations(),
-        }
-    }
-
-    fn next_pressure(selection: ConsumerSourceSelection, limit: u8) -> Self {
-        Self {
-            pressure: selection
-                .pressure_observations()
-                .saturating_add(1)
-                .min(limit),
-            upgrade: 0,
-        }
-    }
-
-    fn next_upgrade(selection: ConsumerSourceSelection, limit: u8) -> Self {
-        Self {
-            pressure: 0,
-            upgrade: selection
-                .upgrade_observations()
-                .saturating_add(1)
-                .min(limit),
-        }
-    }
-}
-
 /// candidate selector and policy pause state before projection
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ReceiverRouteSelection {
@@ -117,48 +74,35 @@ pub(super) struct ReceiverRouteSelection {
     pub(super) selector: SourceSelector,
     /// policy reason that keeps receiver intent while blocking delivery
     pub(super) policy_pause_reason: Option<PolicyPauseReason>,
-    /// hysteresis state carried into the next policy turn
-    pub(super) counts: AdaptationCounts,
+    pub(super) pending_upgrade: Option<PendingUpgrade>,
     /// decoder refresh requested after selector changes or delivery resumes
     pub(super) request_keyframe: bool,
 }
 
 impl ReceiverRouteSelection {
-    const fn send(
-        selector: SourceSelector,
-        counts: AdaptationCounts,
-        request_keyframe: bool,
-    ) -> Self {
+    pub(super) fn interrupts_upgrade(self, current: Option<&PendingUpgrade>) -> bool {
+        current.is_some_and(|current| {
+            self.pending_upgrade.map_or_else(
+                || self.policy_pause_reason.is_some() || current.selector != self.selector,
+                |pending| current.selector != pending.selector,
+            )
+        })
+    }
+
+    const fn send(selector: SourceSelector, request_keyframe: bool) -> Self {
         Self {
             selector,
             policy_pause_reason: None,
-            counts,
+            pending_upgrade: None,
             request_keyframe,
         }
     }
 
-    const fn pause(
-        current: ConsumerSourceSelection,
-        reason: PolicyPauseReason,
-        counts: AdaptationCounts,
-    ) -> Self {
+    const fn pause(selector: SourceSelector, reason: PolicyPauseReason) -> Self {
         Self {
-            selector: current.selector(),
+            selector,
             policy_pause_reason: Some(reason),
-            counts,
-            request_keyframe: false,
-        }
-    }
-
-    const fn hold(
-        current: ConsumerSourceSelection,
-        policy_pause_reason: Option<PolicyPauseReason>,
-        counts: AdaptationCounts,
-    ) -> Self {
-        Self {
-            selector: current.selector(),
-            policy_pause_reason,
-            counts,
+            pending_upgrade: None,
             request_keyframe: false,
         }
     }
@@ -174,7 +118,7 @@ pub(super) struct PlannedReceiverRoute<'a> {
     pub(super) input: &'a ReceiverVideoRouteInput<'a>,
     /// bitrate counted against receiver budget after this policy step
     pub(super) selected_bitrate: Bitrate,
-    /// candidate selector, pause state and hysteresis state
+    /// candidate selector, pause state and exact upgrade target
     pub(super) selection: ReceiverRouteSelection,
 }
 
@@ -198,20 +142,12 @@ impl<'a> PlannedReceiverRoute<'a> {
 
     fn send(&mut self, selector: SourceSelector, selected_bitrate: Bitrate) {
         self.selected_bitrate = selected_bitrate;
-        self.selection = ReceiverRouteSelection::send(
-            selector,
-            self.selection.counts,
-            self.selection.request_keyframe,
-        );
+        self.selection = ReceiverRouteSelection::send(selector, self.selection.request_keyframe);
     }
 
     fn pause(&mut self, reason: PolicyPauseReason) {
         self.selected_bitrate = Bitrate::zero();
-        self.selection = ReceiverRouteSelection::pause(
-            self.input.current_selection,
-            reason,
-            self.selection.counts,
-        );
+        self.selection = ReceiverRouteSelection::pause(self.selection.selector, reason);
     }
 }
 
@@ -220,6 +156,7 @@ pub(in crate::engine::room::source_policy) fn append_receiver_video_policy(
     state: &RoomState,
     input: &SourcePolicySnapshot<'_>,
     mut receiver_bwe_targets: BTreeMap<UserId, ReceiverBweTargetUpdate>,
+    now: Instant,
 ) {
     let routes = receiver_video_routes(state, input);
     let max_video_downloads_per_receiver = input.media_limits.max_video_downloads_per_receiver();
@@ -227,92 +164,52 @@ pub(in crate::engine::room::source_policy) fn append_receiver_video_policy(
     // `committed_consumer_routes` is ordered by `SubscriptionKey` with
     // `receiver` first. Preserve that order so `chunk_by` sees each complete
     // receiver allocation.
-    for receiver_routes in routes.chunk_by(|left, right| left.key.receiver == right.key.receiver) {
-        let Some(first_route) = receiver_routes.first() else {
-            continue;
-        };
-        let consumer_user_id = &first_route.key.receiver;
-        let video_demand = append_receiver_policy_updates(
-            tx,
-            receiver_routes,
-            max_video_downloads_per_receiver,
-            tuning,
-        );
-        // The target is seeded with this receiver's audio reserve. Add eventual
-        // admitted video demand so str0m can probe while overload pauses routes.
-        if let Some(update) = receiver_bwe_targets.get_mut(consumer_user_id) {
-            update.set_target(update.target().saturating_add(video_demand));
+    let mut receiver_routes = routes
+        .chunk_by(|left, right| left.key.receiver == right.key.receiver)
+        .peekable();
+    for (receiver, user) in &state.users {
+        if let Some(routes) = receiver_routes.next_if(|routes| {
+            routes
+                .first()
+                .is_some_and(|route| &route.key.receiver == receiver)
+        }) {
+            let video_demand = append_receiver_policy_updates(
+                tx,
+                routes,
+                max_video_downloads_per_receiver,
+                tuning,
+                user.video_soft_pause_deadline,
+                now,
+            );
+            // The target includes audio reserve. Add eventual admitted video
+            // demand so str0m can probe while overload pauses routes.
+            if let Some(update) = receiver_bwe_targets.get_mut(receiver) {
+                update.set_target(update.target().saturating_add(video_demand));
+            }
+        } else if user.video_soft_pause_deadline.is_some() {
+            tx.push_receiver_timing(ReceiverPolicyTiming {
+                receiver: receiver.clone(),
+                connection_id: user.connection_id,
+                soft_pause_deadline: None,
+                next_deadline: None,
+                retained_deadline: None,
+            });
         }
     }
     tx.set_receiver_bwe_targets(receiver_bwe_targets.into_values().collect());
 }
 
-/// Solves video subscription quality for a receiver based on layout intent and network capacity.
+/// Fits hard-admitted targets before applying time-based continuity holds.
 ///
-/// [`receiver_video_routes`] first retains video routes with an adaptation policy or source bitrate
-/// cap. This function computes the optional video budget before calling `route_plan` for each
-/// retained route.
-///
-/// Balances visual experience against available bandwidth through a multi-pass allocation:
-///
-/// 1. **Desired Quality Target**: Builds each route's selection from its policy-specific facts.
-///    An unpaused selector with no bitrate is paused as
-///    [`PolicyPauseReason::MissingUsableLayer`].
-/// 2. **Stream Count Capping**: Enforces the receiver download limit across planned routes. Lowest-priority
-///    streams are paused before bandwidth sharing. Equal ranks use active-route position.
-/// 3. **Bandwidth Fitting**: When aggregate bitrate exceeds optional downlink headroom after the
-///    audio reserve, secondary streams are stepped down layer-by-layer. If demand still exceeds
-///    budget after eligible step-downs, the lowest-priority streams are paused. Each pass stops once
-///    demand fits.
-/// 4. **Hysteresis Smoothing**: `scalable_plan` applies selector hysteresis. `resolve_hysteresis`
-///    delays soft pauses and most resumes. New download-limit and source-cap pauses apply
-///    immediately. A route resuming from [`PolicyPauseReason::VideoDownloadLimit`] also resumes
-///    immediately.
-/// 5. **Decision Emission**: Projection returns an optional packet-selection update. The caller
-///    stages it as a transport effect or state-only update.
-///
-/// ```text
-///      Policy-Managed Video Routes                Downlink Bandwidth Estimate
-///                    \                                   /
-///                     v                                 v
-///          +-------------------------------------------------------+
-///          | 1. Desired Quality Target                             |
-///          |    - Multiparty featured --> featured-quality layer   |
-///          |    - Multiparty secondary --> thumbnail-biased layer  |
-///          +-------------------------------------------------------+
-///                                     |
-///                                     v
-///          +-------------------------------------------------------+
-///          | 2. Stream Count Capping (Top-N)                       |
-///          |    - Active planned streams > receiver limit?         |
-///          |      yes -> pause lowest-ranked excess positions      |
-///          |      no  -> keep planned streams active               |
-///          +-------------------------------------------------------+
-///                                     |
-///                                     v
-///          +-------------------------------------------------------+
-///          | 3. Bandwidth Fitting & Degradation                    |
-///          |    - Total bitrate <= bandwidth budget?               |
-///          |      yes -> fit as-is                                 |
-///          |      no  -> step down eligible layers one-by-one      |
-///          |             pause lowest-priority tiles if congested  |
-///          +-------------------------------------------------------+
-///                                     |
-///                                     v
-///          +-------------------------------------------------------+
-///          | 4. Hysteresis Smoothing                               |
-///          |    - Smooth selector changes and route oscillation    |
-///          |    - Delay soft pauses and most resumes               |
-///          +-------------------------------------------------------+
-///                                     |
-///                                     v
-///              Selection Updates + Receiver BWE Demand
-/// ```
+/// Eligible downsteps commit immediately. Soft overload may exceed the receiver
+/// budget during its dwell. Admitted BWE demand remains independent of that hold.
 fn append_receiver_policy_updates<'a>(
     tx: &mut SourcePolicyTransaction,
     receiver_routes: &'a [ReceiverVideoRouteInput<'a>],
     max_video_downloads_per_receiver: usize,
     tuning: VideoAdaptationTuning,
+    current_soft_pause_deadline: Option<Instant>,
+    now: Instant,
 ) -> Bitrate {
     let Some(first_route) = receiver_routes.first() else {
         return Bitrate::zero();
@@ -338,10 +235,13 @@ fn append_receiver_policy_updates<'a>(
     if let Some(video_budget) = video_budget {
         apply_overload_policy(&mut planned_routes, video_budget);
     }
-    for route in &mut planned_routes {
-        let selection = resolve_hysteresis(route, tuning);
-        route.apply_resolved_selection(selection);
-    }
+    append_receiver_dwell(
+        tx,
+        &mut planned_routes,
+        current_soft_pause_deadline,
+        tuning,
+        now,
+    );
     let planned_budget =
         receiver_video_budget_diagnostics(&planned_routes, receiver_bandwidth, video_budget);
     if planned_routes.iter().any(route_controls_changed) {
@@ -370,7 +270,13 @@ fn append_receiver_policy_updates<'a>(
             projection::consumer_packet_selection_update(&planned_route, planned_budget)
         else {
             if route_controls_changed(&planned_route) {
-                tx.expect_route_update();
+                tx.expect_route_update(
+                    planned_route
+                        .input
+                        .route
+                        .consumer_session_key()
+                        .connection_id(),
+                );
             }
             continue;
         };
@@ -389,6 +295,61 @@ fn route_controls_changed(route: &PlannedReceiverRoute<'_>) -> bool {
         || current.policy_pause_reason() != route.selection.policy_pause_reason
 }
 
+/// Resolves post-fit continuity and carries new plus retained receiver wakeups.
+fn append_receiver_dwell(
+    tx: &mut SourcePolicyTransaction,
+    planned_routes: &mut [PlannedReceiverRoute<'_>],
+    current_soft_pause_deadline: Option<Instant>,
+    tuning: VideoAdaptationTuning,
+    now: Instant,
+) {
+    let soft_pause_deadline = planned_routes
+        .iter()
+        .any(|route| {
+            route
+                .selection
+                .policy_pause_reason
+                .is_some_and(is_soft_pause)
+        })
+        .then(|| current_soft_pause_deadline.unwrap_or_else(|| now + tuning.soft_pause_dwell));
+    let mut next_deadline = soft_pause_deadline.filter(|deadline| *deadline > now);
+    let mut retained_deadline =
+        next_deadline.filter(|deadline| Some(*deadline) == current_soft_pause_deadline);
+    for route in planned_routes.iter_mut() {
+        let selection = resolve_dwell(route, tuning, soft_pause_deadline, now);
+        if let Some(upgrade) = selection
+            .pending_upgrade
+            .filter(|upgrade| upgrade.deadline > now)
+        {
+            next_deadline = Some(
+                next_deadline.map_or(upgrade.deadline, |deadline| deadline.min(upgrade.deadline)),
+            );
+            if route.input.pending_upgrade == Some(&upgrade) {
+                retained_deadline = Some(
+                    retained_deadline
+                        .map_or(upgrade.deadline, |deadline| deadline.min(upgrade.deadline)),
+                );
+            }
+        }
+        route.apply_resolved_selection(selection);
+    }
+    if current_soft_pause_deadline.is_some()
+        || soft_pause_deadline.is_some()
+        || next_deadline.is_some()
+    {
+        let Some(first_route) = planned_routes.first().map(|route| route.input) else {
+            return;
+        };
+        tx.push_receiver_timing(ReceiverPolicyTiming {
+            receiver: first_route.key.receiver.clone(),
+            connection_id: first_route.route.consumer_session_key().connection_id(),
+            soft_pause_deadline,
+            next_deadline,
+            retained_deadline,
+        });
+    }
+}
+
 fn video_route_allocation(
     input: &ReceiverVideoRouteInput<'_>,
     resolved: Option<&PlannedReceiverRoute<'_>>,
@@ -403,6 +364,8 @@ fn video_route_allocation(
         key: input.key.clone(),
         source_id: input.source.source_id(),
         route: input.route.clone(),
+        interrupts_upgrade: resolved
+            .is_some_and(|route| route.selection.interrupts_upgrade(input.pending_upgrade)),
         captured: VideoRouteAllocationState {
             selector: captured.selector(),
             policy_pause_reason: captured.policy_pause_reason(),
@@ -424,9 +387,8 @@ fn route_plan(
     let source_cap = route.source.policy().video_bitrate_cap();
     if source_cap.is_some_and(|cap| source_exceeds_bitrate_cap(route, cap)) {
         return Some(ReceiverRouteSelection::pause(
-            route.current_selection,
+            route.current_selection.selector(),
             PolicyPauseReason::SourceBitrateLimit,
-            AdaptationCounts::reset(),
         ));
     }
     let selection = match policy {
@@ -443,22 +405,20 @@ fn route_plan(
     .or_else(|| match policy {
         SourceAdaptationPolicy::None if source_cap.is_none() => None,
         _ if source_cap.is_some() => Some(ReceiverRouteSelection::pause(
-            route.current_selection,
+            route.current_selection.selector(),
             PolicyPauseReason::SourceBitrateLimit,
-            AdaptationCounts::reset(),
         )),
-        _ => Some(adaptation_hold(
-            route.current_selection,
-            AdaptationCounts::from_current(route.current_selection),
+        _ => Some(ReceiverRouteSelection::send(
+            route.current_selection.selector(),
+            false,
         )),
     })?;
     if selection.policy_pause_reason.is_none()
         && selector_bitrate(route, selection.selector).is_none()
     {
         return Some(ReceiverRouteSelection::pause(
-            route.current_selection,
+            route.current_selection.selector(),
             PolicyPauseReason::MissingUsableLayer,
-            AdaptationCounts::reset(),
         ));
     }
     Some(selection)
@@ -508,7 +468,7 @@ pub(super) fn selector_bitrate(
 
 fn highest_allowed_plan(route: &ReceiverVideoRouteInput<'_>) -> Option<ReceiverRouteSelection> {
     let target_selector = highest_allowed_selector(route)?;
-    Some(adaptation_send(
+    Some(ReceiverRouteSelection::send(
         target_selector,
         target_selector != route.current_selection.selector(),
     ))
@@ -607,7 +567,6 @@ fn scalable_plan(
         return None;
     }
     let current = route.current_selection;
-    let current_index = selector_index(route.source, current.selector());
     let target_index = desired_encoding_index(route, source_cap, tuning)?;
     let target_selector = SourceSelector::Encoding(
         route
@@ -615,47 +574,10 @@ fn scalable_plan(
             .selectable_encoding_by_rank(target_index)?
             .encoding_id(),
     );
-    let request_keyframe = target_selector != current.selector();
-    if target_index == current_index || route.receiver_bandwidth.is_none() {
-        return Some(adaptation_send(target_selector, request_keyframe));
-    }
-    if target_index < current_index {
-        // A policy-paused route has no delivered quality transition to smooth.
-        // Downswitch hysteresis would reset the observations needed to resume it.
-        if !current.policy_allows_delivery()
-            || source_cap.is_some_and(|cap| {
-                selector_bitrate(route, current.selector()).is_some_and(|bitrate| bitrate > cap)
-            })
-        {
-            return Some(adaptation_send(target_selector, request_keyframe));
-        }
-        let pressure_limit = tuning.downswitch_pressure_observations;
-        let counts = AdaptationCounts::next_pressure(current, pressure_limit);
-        if counts.pressure >= pressure_limit {
-            return Some(adaptation_send(target_selector, request_keyframe));
-        }
-        return Some(adaptation_hold(current, counts));
-    }
-    let stable_limit = tuning.upswitch_stable_observations;
-    let counts = AdaptationCounts::next_upgrade(current, stable_limit);
-    if counts.upgrade >= stable_limit {
-        return Some(adaptation_send(target_selector, true));
-    }
-    Some(adaptation_hold(current, counts))
-}
-
-const fn adaptation_send(
-    selector: SourceSelector,
-    request_keyframe: bool,
-) -> ReceiverRouteSelection {
-    ReceiverRouteSelection::send(selector, AdaptationCounts::reset(), request_keyframe)
-}
-
-const fn adaptation_hold(
-    current: ConsumerSourceSelection,
-    counts: AdaptationCounts,
-) -> ReceiverRouteSelection {
-    ReceiverRouteSelection::send(current.selector(), counts, false)
+    Some(ReceiverRouteSelection::send(
+        target_selector,
+        target_selector != current.selector(),
+    ))
 }
 
 fn desired_encoding_index(
@@ -915,47 +837,70 @@ fn pause_reason_for_route(route: &PlannedReceiverRoute<'_>) -> PolicyPauseReason
     }
 }
 
-fn resolve_hysteresis(
+const fn is_soft_pause(reason: PolicyPauseReason) -> bool {
+    matches!(
+        reason,
+        PolicyPauseReason::BudgetPressure
+            | PolicyPauseReason::HiddenTile
+            | PolicyPauseReason::OverflowTile
+    )
+}
+
+fn resolve_dwell(
     route: &PlannedReceiverRoute<'_>,
     tuning: VideoAdaptationTuning,
+    soft_pause_deadline: Option<Instant>,
+    now: Instant,
 ) -> ReceiverRouteSelection {
     let current = route.input.current_selection;
-    let current_pause_reason = current.policy_pause_reason();
-    let selection = route.selection;
-    match (selection.policy_pause_reason, current_pause_reason) {
-        // Resume a route newly admitted under the download limit immediately
-        // because recovery hysteresis would leave an available slot unused.
-        (None, Some(PolicyPauseReason::VideoDownloadLimit)) => {
-            ReceiverRouteSelection::send(selection.selector, AdaptationCounts::reset(), true)
+    let mut selection = route.selection;
+    if let Some(reason) = selection.policy_pause_reason {
+        if !is_soft_pause(reason)
+            || current.policy_pause_reason().is_some()
+            || soft_pause_deadline.is_some_and(|deadline| deadline <= now)
+        {
+            return selection;
         }
-        (None, Some(reason)) => {
-            let stable_limit = tuning.upswitch_stable_observations;
-            let counts = AdaptationCounts::next_upgrade(current, stable_limit);
-            if counts.upgrade >= stable_limit {
-                ReceiverRouteSelection::send(selection.selector, AdaptationCounts::reset(), true)
-            } else {
-                ReceiverRouteSelection::hold(current, Some(reason), counts)
-            }
+        // Preserve a fitted downstep during grace. Rebuilding from `current`
+        // used to retain the expensive RID until the whole route paused.
+        if selection.selector != current.selector()
+            && selector_index(route.input.source, selection.selector)
+                > selector_index(route.input.source, current.selector())
+        {
+            selection.selector = current.selector();
         }
-        (Some(reason), pause_reason) if pause_reason != Some(reason) => {
-            // Per-receiver download count and source bitrate caps are hard
-            // constraints. Holding current state would exceed the admission
-            // limit or source ceiling.
-            if matches!(
-                reason,
-                PolicyPauseReason::VideoDownloadLimit | PolicyPauseReason::SourceBitrateLimit
-            ) {
-                return ReceiverRouteSelection::pause(current, reason, AdaptationCounts::reset());
-            }
-            let pressure_limit = tuning.downswitch_pressure_observations;
-            let counts = AdaptationCounts::next_pressure(current, pressure_limit);
-            if counts.pressure >= pressure_limit {
-                ReceiverRouteSelection::pause(current, reason, AdaptationCounts::reset())
-            } else {
-                ReceiverRouteSelection::hold(current, None, counts)
-            }
-        }
-        _ => selection,
+        selection.policy_pause_reason = None;
+        return selection;
+    }
+    let immediate = current.policy_pause_reason() == Some(PolicyPauseReason::VideoDownloadLimit)
+        || (current.policy_pause_reason().is_none()
+            && (selection.selector == current.selector()
+                || current.selector() == SourceSelector::Open
+                || selector_index(route.input.source, selection.selector)
+                    <= selector_index(route.input.source, current.selector())));
+    if immediate {
+        return selection;
+    }
+    // Resolve one exact target after aggregate fitting. A pre-fit upgrade that
+    // fitting reverses must not keep restarting its own eligibility deadline.
+    let pending = route
+        .input
+        .pending_upgrade
+        .filter(|pending| pending.selector == selection.selector)
+        .copied()
+        .unwrap_or_else(|| PendingUpgrade {
+            selector: selection.selector,
+            deadline: now + tuning.upgrade_dwell,
+        });
+    if pending.deadline <= now {
+        selection.request_keyframe = true;
+        return selection;
+    }
+    ReceiverRouteSelection {
+        selector: current.selector(),
+        policy_pause_reason: current.policy_pause_reason(),
+        pending_upgrade: Some(pending),
+        request_keyframe: false,
     }
 }
 

--- a/crates/core/src/engine/room/state/membership/mod.rs
+++ b/crates/core/src/engine/room/state/membership/mod.rs
@@ -179,6 +179,7 @@ impl RoomState {
             user.reset_presentation();
             user.parsed_client_rtp_capabilities = None;
             user.connection_id = connection_id;
+            user.video_soft_pause_deadline = None;
             return Some(old_sender);
         }
         self.users.insert(
@@ -190,6 +191,7 @@ impl RoomState {
                 server_featured: None,
                 parsed_client_rtp_capabilities: None,
                 connection_id,
+                video_soft_pause_deadline: None,
                 sender,
             },
         );

--- a/crates/core/src/engine/room/state/shared.rs
+++ b/crates/core/src/engine/room/state/shared.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
+    time::Instant,
 };
 
 use o_sfu_router::rtp::{MediaCapabilities, MediaCapabilities as RouterRtpCapabilities};
@@ -45,6 +46,8 @@ pub struct ActiveUser {
     pub(super) server_featured: Option<bool>,
     pub parsed_client_rtp_capabilities: Option<RouterRtpCapabilities>,
     pub connection_id: ConnectionId,
+    /// Continuous receiver pressure survives victim changes within this connection.
+    pub(in crate::engine::room) video_soft_pause_deadline: Option<Instant>,
     pub sender: OutboundSender,
 }
 

--- a/crates/core/src/engine/source_model/selection.rs
+++ b/crates/core/src/engine/source_model/selection.rs
@@ -49,8 +49,6 @@ pub struct ConsumerSourceSelection {
     selector: SourceSelector,
     policy_pause_reason: Option<PolicyPauseReason>,
     budget: ReceiverVideoBudgetDiagnostics,
-    pressure_observations: u8,
-    upgrade_observations: u8,
 }
 
 impl ConsumerSourceSelection {
@@ -61,8 +59,6 @@ impl ConsumerSourceSelection {
             selector: SourceSelector::Open,
             policy_pause_reason: None,
             budget: ReceiverVideoBudgetDiagnostics::new(None, None, 0, Bitrate::zero()),
-            pressure_observations: 0,
-            upgrade_observations: 0,
         }
     }
 
@@ -101,16 +97,6 @@ impl ConsumerSourceSelection {
         self.budget
     }
 
-    #[must_use]
-    pub const fn pressure_observations(self) -> u8 {
-        self.pressure_observations
-    }
-
-    #[must_use]
-    pub const fn upgrade_observations(self) -> u8 {
-        self.upgrade_observations
-    }
-
     pub const fn set_active(&mut self, active: bool) {
         self.active = active;
     }
@@ -125,14 +111,5 @@ impl ConsumerSourceSelection {
 
     pub const fn set_budget(&mut self, budget: ReceiverVideoBudgetDiagnostics) {
         self.budget = budget;
-    }
-
-    pub const fn set_adaptation_observations(
-        &mut self,
-        pressure_observations: u8,
-        upgrade_observations: u8,
-    ) {
-        self.pressure_observations = pressure_observations;
-        self.upgrade_observations = upgrade_observations;
     }
 }

--- a/crates/core/src/options/TESTS/media.rs
+++ b/crates/core/src/options/TESTS/media.rs
@@ -4,16 +4,25 @@
     reason = "test assertions use unwrap and expect for clear failure messages"
 )]
 
+use std::time::Duration;
+
 use super::{Bitrate, VideoAdaptationTuning, VideoAdaptationTuningError};
 
 #[test]
 fn video_adaptation_tuning_accepts_valid_knobs() {
-    let tuning = VideoAdaptationTuning::try_new(4, 3, 1, 2, 10, Bitrate::from_kbps(32))
-        .expect("valid tuning should build");
+    let tuning = VideoAdaptationTuning::try_new(
+        4,
+        3,
+        Duration::from_millis(250),
+        Duration::from_millis(1250),
+        10,
+        Bitrate::from_kbps(32),
+    )
+    .expect("valid tuning should build");
     assert_eq!(tuning.multiparty_scalable_video_threshold, 4);
     assert_eq!(tuning.thumbnail_budget_divisor, 3);
-    assert_eq!(tuning.downswitch_pressure_observations, 1);
-    assert_eq!(tuning.upswitch_stable_observations, 2);
+    assert_eq!(tuning.soft_pause_dwell, Duration::from_millis(250));
+    assert_eq!(tuning.upgrade_dwell, Duration::from_millis(1250));
     assert_eq!(tuning.receiver_budget_headroom_percent, 10);
     assert_eq!(tuning.audio_reserve_per_speaker, Bitrate::from_kbps(32));
 }
@@ -22,27 +31,104 @@ fn video_adaptation_tuning_accepts_valid_knobs() {
 fn video_adaptation_tuning_rejects_invalid_knobs() {
     let cases = [
         (
-            VideoAdaptationTuning::try_new(0, 2, 2, 3, 0, Bitrate::zero()),
+            VideoAdaptationTuning::try_new(
+                0,
+                2,
+                Duration::from_millis(750),
+                Duration::from_millis(750),
+                0,
+                Bitrate::zero(),
+            ),
             VideoAdaptationTuningError::MultipartyScalableVideoThresholdZero,
         ),
         (
-            VideoAdaptationTuning::try_new(3, 0, 2, 3, 0, Bitrate::zero()),
+            VideoAdaptationTuning::try_new(
+                3,
+                0,
+                Duration::from_millis(750),
+                Duration::from_millis(750),
+                0,
+                Bitrate::zero(),
+            ),
             VideoAdaptationTuningError::ThumbnailBudgetDivisorZero,
         ),
         (
-            VideoAdaptationTuning::try_new(3, 2, 0, 3, 0, Bitrate::zero()),
-            VideoAdaptationTuningError::DownswitchPressureObservationsZero,
+            VideoAdaptationTuning::try_new(
+                3,
+                2,
+                Duration::ZERO,
+                Duration::from_millis(750),
+                0,
+                Bitrate::zero(),
+            ),
+            VideoAdaptationTuningError::SoftPauseDwellZero,
         ),
         (
-            VideoAdaptationTuning::try_new(3, 2, 2, 0, 0, Bitrate::zero()),
-            VideoAdaptationTuningError::UpswitchStableObservationsZero,
+            VideoAdaptationTuning::try_new(
+                3,
+                2,
+                Duration::from_millis(750),
+                Duration::ZERO,
+                0,
+                Bitrate::zero(),
+            ),
+            VideoAdaptationTuningError::UpgradeDwellZero,
         ),
         (
-            VideoAdaptationTuning::try_new(3, 2, 2, 3, 101, Bitrate::zero()),
+            VideoAdaptationTuning::try_new(
+                3,
+                2,
+                Duration::from_millis(750),
+                Duration::from_millis(750),
+                101,
+                Bitrate::zero(),
+            ),
             VideoAdaptationTuningError::ReceiverBudgetHeadroomPercentTooHigh,
         ),
     ];
     for (result, expected) in cases {
         assert_eq!(result.err(), Some(expected));
     }
+}
+
+#[test]
+fn video_adaptation_tuning_rejects_unrepresentable_deadlines() {
+    for invalid in [
+        Duration::MAX,
+        VideoAdaptationTuning::MAX_DWELL + Duration::from_nanos(1),
+    ] {
+        assert_eq!(
+            VideoAdaptationTuning::try_new(
+                3,
+                2,
+                invalid,
+                Duration::from_millis(750),
+                0,
+                Bitrate::zero()
+            ),
+            Err(VideoAdaptationTuningError::SoftPauseDwellTooLong)
+        );
+        assert_eq!(
+            VideoAdaptationTuning::try_new(
+                3,
+                2,
+                Duration::from_millis(750),
+                invalid,
+                0,
+                Bitrate::zero()
+            ),
+            Err(VideoAdaptationTuningError::UpgradeDwellTooLong)
+        );
+    }
+    assert!(
+        VideoAdaptationTuning::try_new(
+            3,
+            2,
+            VideoAdaptationTuning::MAX_DWELL,
+            VideoAdaptationTuning::MAX_DWELL,
+            0,
+            Bitrate::zero()
+        )
+        .is_ok()
+    );
 }

--- a/crates/core/src/options/media.rs
+++ b/crates/core/src/options/media.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, time::Duration};
 
 use crate::Bitrate;
 
@@ -176,22 +176,23 @@ impl Default for RoomMediaLimits {
     }
 }
 
-/// Room-wide video budget and adaptation hysteresis.
+/// Room-wide video budget and adaptation dwell.
 ///
 /// When room membership reaches `multiparty_scalable_video_threshold`,
 /// scalable-video per-route targets use available receiver bandwidth and the
 /// resolved layout role. Pinned, featured, readable-detail and active-speaker
 /// targets use the full receiver budget. When several visible scalable routes
 /// share a receiver, other scalable targets divide that budget by their count and
-/// `thumbnail_budget_divisor`. Observation counts require consecutive policy
-/// turns. Headroom is removed before `audio_reserve_per_speaker` is subtracted
+/// `thumbnail_budget_divisor`. Soft pauses require continuous receiver pressure
+/// for `soft_pause_dwell`. Upgrades require one eligible target for `upgrade_dwell`.
+/// Headroom is removed before `audio_reserve_per_speaker` is subtracted
 /// for each admitted audio route the receiver consumes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoAdaptationTuning {
     pub(crate) multiparty_scalable_video_threshold: usize,
     pub(crate) thumbnail_budget_divisor: u64,
-    pub(crate) downswitch_pressure_observations: u8,
-    pub(crate) upswitch_stable_observations: u8,
+    pub(crate) soft_pause_dwell: Duration,
+    pub(crate) upgrade_dwell: Duration,
     pub(crate) receiver_budget_headroom_percent: u8,
     pub(crate) audio_reserve_per_speaker: Bitrate,
 }
@@ -202,10 +203,14 @@ pub enum VideoAdaptationTuningError {
     MultipartyScalableVideoThresholdZero,
     #[error("thumbnail budget divisor must be greater than zero")]
     ThumbnailBudgetDivisorZero,
-    #[error("downswitch pressure observations must be greater than zero")]
-    DownswitchPressureObservationsZero,
-    #[error("upswitch stable observations must be greater than zero")]
-    UpswitchStableObservationsZero,
+    #[error("soft pause dwell must be greater than zero")]
+    SoftPauseDwellZero,
+    #[error("upgrade dwell must be greater than zero")]
+    UpgradeDwellZero,
+    #[error("soft pause dwell exceeds the portable deadline range")]
+    SoftPauseDwellTooLong,
+    #[error("upgrade dwell exceeds the portable deadline range")]
+    UpgradeDwellTooLong,
     #[error("receiver budget headroom percent must not exceed 100")]
     ReceiverBudgetHeadroomPercentTooHigh,
 }
@@ -213,8 +218,12 @@ pub enum VideoAdaptationTuningError {
 impl VideoAdaptationTuning {
     pub const DEFAULT_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD: usize = 3;
     pub const DEFAULT_THUMBNAIL_BUDGET_DIVISOR: u64 = 2;
-    pub const DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS: u8 = 2;
-    pub const DEFAULT_UPSWITCH_STABLE_OBSERVATIONS: u8 = 3;
+    pub const DEFAULT_SOFT_PAUSE_DWELL: Duration = Duration::from_millis(750);
+    pub const DEFAULT_UPGRADE_DWELL: Duration = Duration::from_millis(750);
+    /// Bounds deadline addition to the roughly 100-year portable `Instant` range.
+    ///
+    /// See [`Instant` OS-specific behavior](std::time::Instant#os-specific-behaviors).
+    pub const MAX_DWELL: Duration = Duration::from_hours(100 * 365 * 24);
     pub const DEFAULT_RECEIVER_BUDGET_HEADROOM_PERCENT: u8 = 0;
     pub const DEFAULT_AUDIO_RESERVE_PER_SPEAKER: Bitrate = Bitrate::zero();
 
@@ -223,13 +232,13 @@ impl VideoAdaptationTuning {
     /// # Errors
     ///
     /// Returns [`VideoAdaptationTuningError`] when the scalable-video threshold,
-    /// the thumbnail budget divisor or either observation knob is zero, or when
-    /// the headroom percent exceeds 100.
+    /// the thumbnail budget divisor or either dwell is zero, either dwell exceeds
+    /// [`Self::MAX_DWELL`] or the headroom percent exceeds 100.
     pub const fn try_new(
         multiparty_scalable_video_threshold: usize,
         thumbnail_budget_divisor: u64,
-        downswitch_pressure_observations: u8,
-        upswitch_stable_observations: u8,
+        soft_pause_dwell: Duration,
+        upgrade_dwell: Duration,
         receiver_budget_headroom_percent: u8,
         audio_reserve_per_speaker: Bitrate,
     ) -> Result<Self, VideoAdaptationTuningError> {
@@ -239,11 +248,17 @@ impl VideoAdaptationTuning {
         if thumbnail_budget_divisor == 0 {
             return Err(VideoAdaptationTuningError::ThumbnailBudgetDivisorZero);
         }
-        if downswitch_pressure_observations == 0 {
-            return Err(VideoAdaptationTuningError::DownswitchPressureObservationsZero);
+        if soft_pause_dwell.is_zero() {
+            return Err(VideoAdaptationTuningError::SoftPauseDwellZero);
         }
-        if upswitch_stable_observations == 0 {
-            return Err(VideoAdaptationTuningError::UpswitchStableObservationsZero);
+        if upgrade_dwell.is_zero() {
+            return Err(VideoAdaptationTuningError::UpgradeDwellZero);
+        }
+        if soft_pause_dwell.as_nanos() > Self::MAX_DWELL.as_nanos() {
+            return Err(VideoAdaptationTuningError::SoftPauseDwellTooLong);
+        }
+        if upgrade_dwell.as_nanos() > Self::MAX_DWELL.as_nanos() {
+            return Err(VideoAdaptationTuningError::UpgradeDwellTooLong);
         }
         if receiver_budget_headroom_percent > 100 {
             return Err(VideoAdaptationTuningError::ReceiverBudgetHeadroomPercentTooHigh);
@@ -251,8 +266,8 @@ impl VideoAdaptationTuning {
         Ok(Self {
             multiparty_scalable_video_threshold,
             thumbnail_budget_divisor,
-            downswitch_pressure_observations,
-            upswitch_stable_observations,
+            soft_pause_dwell,
+            upgrade_dwell,
             receiver_budget_headroom_percent,
             audio_reserve_per_speaker,
         })
@@ -264,8 +279,8 @@ impl Default for VideoAdaptationTuning {
         Self {
             multiparty_scalable_video_threshold: Self::DEFAULT_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD,
             thumbnail_budget_divisor: Self::DEFAULT_THUMBNAIL_BUDGET_DIVISOR,
-            downswitch_pressure_observations: Self::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS,
-            upswitch_stable_observations: Self::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS,
+            soft_pause_dwell: Self::DEFAULT_SOFT_PAUSE_DWELL,
+            upgrade_dwell: Self::DEFAULT_UPGRADE_DWELL,
             receiver_budget_headroom_percent: Self::DEFAULT_RECEIVER_BUDGET_HEADROOM_PERCENT,
             audio_reserve_per_speaker: Self::DEFAULT_AUDIO_RESERVE_PER_SPEAKER,
         }

--- a/crates/telemetry/src/diagnostics/mod.rs
+++ b/crates/telemetry/src/diagnostics/mod.rs
@@ -2,12 +2,13 @@ pub mod types;
 
 pub use types::{
     DiagnosticsActiveSpeaker, DiagnosticsActiveSpeakerReason, DiagnosticsActiveSpeakerState,
-    DiagnosticsIncomingBitrate, DiagnosticsMediaKind, DiagnosticsPolicyPauseReason,
-    DiagnosticsPublication, DiagnosticsQualitySummary, DiagnosticsRoomDetail,
-    DiagnosticsRoomSummary, DiagnosticsRouteState, DiagnosticsSource, DiagnosticsSourceEncoding,
-    DiagnosticsSourceSelection, DiagnosticsSourceSelectionReason, DiagnosticsSourceSelector,
-    DiagnosticsSubscription, DiagnosticsSummaryResponse, DiagnosticsTransportCounts,
-    DiagnosticsTransportHealth, DiagnosticsUserDetail, DiagnosticsUserSummary,
-    DiagnosticsUserTransport, DiagnosticsUserView, DiagnosticsVideoLayoutRole,
-    DiagnosticsVideoRoutePriority, DiagnosticsWorkerPressure, DiagnosticsWorkerSummary,
+    DiagnosticsIncomingBitrate, DiagnosticsMediaKind, DiagnosticsPendingUpgrade,
+    DiagnosticsPolicyPauseReason, DiagnosticsPublication, DiagnosticsQualitySummary,
+    DiagnosticsRoomDetail, DiagnosticsRoomSummary, DiagnosticsRouteState, DiagnosticsSource,
+    DiagnosticsSourceEncoding, DiagnosticsSourceSelection, DiagnosticsSourceSelectionReason,
+    DiagnosticsSourceSelector, DiagnosticsSubscription, DiagnosticsSummaryResponse,
+    DiagnosticsTransportCounts, DiagnosticsTransportHealth, DiagnosticsUserDetail,
+    DiagnosticsUserSummary, DiagnosticsUserTransport, DiagnosticsUserView,
+    DiagnosticsVideoLayoutRole, DiagnosticsVideoRoutePriority, DiagnosticsWorkerPressure,
+    DiagnosticsWorkerSummary,
 };

--- a/crates/telemetry/src/diagnostics/types.rs
+++ b/crates/telemetry/src/diagnostics/types.rs
@@ -170,6 +170,8 @@ pub struct DiagnosticsUserTransport {
     pub health: Option<DiagnosticsTransportHealth>,
     pub media_worker_id: usize,
     pub quality_summary: DiagnosticsQualitySummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub video_soft_pause_remaining_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -238,6 +240,15 @@ pub struct DiagnosticsSource {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DiagnosticsPendingUpgrade {
+    pub selector: DiagnosticsSourceSelector,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding_id: Option<u64>,
+    pub remaining_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DiagnosticsSourceSelection {
     pub active: bool,
     pub active_video_route_count: usize,
@@ -246,7 +257,8 @@ pub struct DiagnosticsSourceSelection {
     pub policy_allows_delivery: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_pause_reason: Option<DiagnosticsPolicyPauseReason>,
-    pub pressure_observations: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_upgrade: Option<DiagnosticsPendingUpgrade>,
     pub selection_reason: DiagnosticsSourceSelectionReason,
     pub selector: DiagnosticsSourceSelector,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -258,7 +270,6 @@ pub struct DiagnosticsSourceSelection {
     pub selected_encoding_id: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected_rid: Option<String>,
-    pub upgrade_observations: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/telemetry/src/graph/room.rs
+++ b/crates/telemetry/src/graph/room.rs
@@ -229,8 +229,7 @@ fn download_edge(
         "detail__selector": format!("{:?}", sub.selection.selector),
         "detail__selection_reason": format!("{:?}", sub.selection.selection_reason),
         "detail__selection_active": sub.selection.active,
-        "detail__pressure_observations": sub.selection.pressure_observations,
-        "detail__upgrade_observations": sub.selection.upgrade_observations,
+        "detail__pending_upgrade": sub.selection.pending_upgrade,
         "detail__source_transport_media_id": sub.source_transport_media_id,
         "detail__consumer_transport_media_id": sub.consumer_transport_media_id,
     });

--- a/src/config/TESTS/transport.rs
+++ b/src/config/TESTS/transport.rs
@@ -1,4 +1,7 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
 
 use anyhow::Result;
 
@@ -146,15 +149,22 @@ fn load_transport_config_accepts_video_adaptation_tuning() -> Result<()> {
     let config = load_transport_config_with_defaults(&[
         ("ROOM_MULTIPARTY_SCALABLE_VIDEO_THRESHOLD", "5"),
         ("ROOM_THUMBNAIL_BUDGET_DIVISOR", "3"),
-        ("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS", "4"),
-        ("ROOM_UPSWITCH_STABLE_OBSERVATIONS", "6"),
+        ("ROOM_SOFT_PAUSE_DWELL_MS", "250"),
+        ("ROOM_UPGRADE_DWELL_MS", "1250"),
         ("ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT", "15"),
         ("ROOM_AUDIO_RESERVE_PER_SPEAKER_BPS", "40000"),
     ])?;
 
     assert_eq!(
         config.video_adaptation_tuning,
-        VideoAdaptationTuning::try_new(5, 3, 4, 6, 15, Bitrate::from_bps(40_000))?
+        VideoAdaptationTuning::try_new(
+            5,
+            3,
+            Duration::from_millis(250),
+            Duration::from_millis(1250),
+            15,
+            Bitrate::from_bps(40_000)
+        )?
     );
     Ok(())
 }
@@ -174,9 +184,27 @@ fn load_transport_config_defaults_video_adaptation_tuning() -> Result<()> {
 fn load_transport_config_rejects_invalid_video_adaptation_tuning() {
     assert_invalid_transport_cases(&[
         InvalidTransportCase {
-            name: "zero downswitch pressure observations",
-            overrides: &[("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS", "0")],
-            message: "ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS must be greater than zero",
+            name: "zero soft pause dwell",
+            overrides: &[("ROOM_SOFT_PAUSE_DWELL_MS", "0")],
+            message: "ROOM_SOFT_PAUSE_DWELL_MS must be greater than zero",
+        },
+        InvalidTransportCase {
+            name: "zero upgrade dwell",
+            overrides: &[("ROOM_UPGRADE_DWELL_MS", "0")],
+            message: "ROOM_UPGRADE_DWELL_MS must be greater than zero",
+        },
+        InvalidTransportCase {
+            name: "legacy pause count",
+            overrides: &[("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS", "2")],
+            message: "ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS is no longer supported, use ROOM_SOFT_PAUSE_DWELL_MS",
+        },
+        InvalidTransportCase {
+            name: "legacy upgrade count with replacement",
+            overrides: &[
+                ("ROOM_UPSWITCH_STABLE_OBSERVATIONS", "3"),
+                ("ROOM_UPGRADE_DWELL_MS", "1250"),
+            ],
+            message: "ROOM_UPSWITCH_STABLE_OBSERVATIONS is no longer supported, use ROOM_UPGRADE_DWELL_MS",
         },
         InvalidTransportCase {
             name: "headroom percent above 100",
@@ -388,6 +416,22 @@ fn load_transport_config_preserves_numeric_parse_errors() {
             name: "invalid video download limit",
             overrides: &[("ROOM_MAX_VIDEO_DOWNLOADS_PER_RECEIVER", "abc")],
             message: "ROOM_MAX_VIDEO_DOWNLOADS_PER_RECEIVER must be a valid usize",
+        },
+    ]);
+}
+
+#[test]
+fn load_transport_config_rejects_unrepresentable_policy_deadlines() {
+    assert_invalid_transport_cases(&[
+        InvalidTransportCase {
+            name: "unrepresentable soft pause dwell",
+            overrides: &[("ROOM_SOFT_PAUSE_DWELL_MS", "18446744073709551615")],
+            message: "ROOM_SOFT_PAUSE_DWELL_MS must not exceed 3153600000000",
+        },
+        InvalidTransportCase {
+            name: "unrepresentable upgrade dwell",
+            overrides: &[("ROOM_UPGRADE_DWELL_MS", "18446744073709551615")],
+            message: "ROOM_UPGRADE_DWELL_MS must not exceed 3153600000000",
         },
     ]);
 }

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -2,6 +2,7 @@ use std::{
     net::IpAddr,
     num::{NonZeroU64, NonZeroUsize},
     thread,
+    time::Duration,
 };
 
 use anyhow::{Result, anyhow, ensure};
@@ -138,14 +139,34 @@ fn video_adaptation_tuning_from_env(env: &Env<'_>) -> Result<VideoAdaptationTuni
         .var("ROOM_THUMBNAIL_BUDGET_DIVISOR")
         .check(positive)
         .default(VideoAdaptationTuning::DEFAULT_THUMBNAIL_BUDGET_DIVISOR)?;
-    let downswitch_pressure_observations = env
-        .var("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS")
+    for (legacy, replacement) in [
+        (
+            "ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS",
+            "ROOM_SOFT_PAUSE_DWELL_MS",
+        ),
+        ("ROOM_UPSWITCH_STABLE_OBSERVATIONS", "ROOM_UPGRADE_DWELL_MS"),
+    ] {
+        ensure!(
+            env.var::<String>(legacy).optional()?.is_none(),
+            "{legacy} is no longer supported, use {replacement}"
+        );
+    }
+    let soft_pause_dwell = env
+        .var("ROOM_SOFT_PAUSE_DWELL_MS")
         .check(positive)
-        .default(VideoAdaptationTuning::DEFAULT_DOWNSWITCH_PRESSURE_OBSERVATIONS)?;
-    let upswitch_stable_observations = env
-        .var("ROOM_UPSWITCH_STABLE_OBSERVATIONS")
+        .optional()?
+        .map_or(
+            VideoAdaptationTuning::DEFAULT_SOFT_PAUSE_DWELL,
+            Duration::from_millis,
+        );
+    let upgrade_dwell = env
+        .var("ROOM_UPGRADE_DWELL_MS")
         .check(positive)
-        .default(VideoAdaptationTuning::DEFAULT_UPSWITCH_STABLE_OBSERVATIONS)?;
+        .optional()?
+        .map_or(
+            VideoAdaptationTuning::DEFAULT_UPGRADE_DWELL,
+            Duration::from_millis,
+        );
     let receiver_budget_headroom_percent = env
         .var("ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT")
         .default(VideoAdaptationTuning::DEFAULT_RECEIVER_BUDGET_HEADROOM_PERCENT)?;
@@ -155,8 +176,8 @@ fn video_adaptation_tuning_from_env(env: &Env<'_>) -> Result<VideoAdaptationTuni
     VideoAdaptationTuning::try_new(
         multiparty_scalable_video_threshold,
         thumbnail_budget_divisor,
-        downswitch_pressure_observations,
-        upswitch_stable_observations,
+        soft_pause_dwell,
+        upgrade_dwell,
         receiver_budget_headroom_percent,
         Bitrate::from_bps(audio_reserve_per_speaker_bps),
     )
@@ -175,11 +196,23 @@ fn video_adaptation_tuning_error(error: VideoAdaptationTuningError) -> anyhow::E
         VideoAdaptationTuningError::ThumbnailBudgetDivisorZero => {
             anyhow!("ROOM_THUMBNAIL_BUDGET_DIVISOR must be greater than zero")
         }
-        VideoAdaptationTuningError::DownswitchPressureObservationsZero => {
-            anyhow!("ROOM_DOWNSWITCH_PRESSURE_OBSERVATIONS must be greater than zero")
+        VideoAdaptationTuningError::SoftPauseDwellZero => {
+            anyhow!("ROOM_SOFT_PAUSE_DWELL_MS must be greater than zero")
         }
-        VideoAdaptationTuningError::UpswitchStableObservationsZero => {
-            anyhow!("ROOM_UPSWITCH_STABLE_OBSERVATIONS must be greater than zero")
+        VideoAdaptationTuningError::UpgradeDwellZero => {
+            anyhow!("ROOM_UPGRADE_DWELL_MS must be greater than zero")
+        }
+        VideoAdaptationTuningError::SoftPauseDwellTooLong => {
+            anyhow!(
+                "ROOM_SOFT_PAUSE_DWELL_MS must not exceed {}",
+                VideoAdaptationTuning::MAX_DWELL.as_millis()
+            )
+        }
+        VideoAdaptationTuningError::UpgradeDwellTooLong => {
+            anyhow!(
+                "ROOM_UPGRADE_DWELL_MS must not exceed {}",
+                VideoAdaptationTuning::MAX_DWELL.as_millis()
+            )
         }
         VideoAdaptationTuningError::ReceiverBudgetHeadroomPercentTooHigh => {
             anyhow!("ROOM_RECEIVER_BUDGET_HEADROOM_PERCENT must not exceed 100")

--- a/tests/benchmarks/source_policy/mod.rs
+++ b/tests/benchmarks/source_policy/mod.rs
@@ -37,15 +37,15 @@
 //! every `BudgetPressure` decision
 //! injecting the snapshot is what makes those paths run
 //!
-//! the trace walks down from comfortable headroom to hard overload and back, so
-//! consecutive turns disagree and the hysteresis counters carried in committed
-//! consumer selections actually advance
+//! Each bandwidth plateau lasts through the 750 ms dwell. Injected time makes
+//! pressure and upgrade eligibility deterministic.
 
 use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv4Addr},
     num::{NonZeroU64, NonZeroUsize},
     sync::Arc,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Result, anyhow};
@@ -96,21 +96,21 @@ const MAX_ACTIVE_AUDIO_SPEAKERS: usize = 4;
 /// video downloads the room admits per receiver
 const MAX_VIDEO_DOWNLOADS: usize = 3;
 
-/// one policy turn per receiver bandwidth report of a twelve second call
+/// one policy turn per receiver bandwidth report of a six second call
 const POLICY_TURNS: usize = 24;
 
 /// receiver bandwidth walked from headroom into hard overload and back
 ///
-/// a receiver holding one featured layer plus four thumbnails wants roughly
-/// 2 Mbps, so the lower half of this trace forces the budget solver to drop
-/// layers and the upper half lets it recover them
-const BANDWIDTH_TRACE_BPS: [u64; 8] = [
-    2_500_000, 2_000_000, 1_400_000, 900_000, 600_000, 900_000, 1_400_000, 2_000_000,
+/// The hard limit admits three routes with a combined 450 kbps floor. The
+/// 400 kbps plateau forces a pause after the dwell and later plateaus recover.
+const BANDWIDTH_TRACE_BPS: [u64; 12] = [
+    2_500_000, 2_500_000, 2_500_000, 2_500_000, 400_000, 400_000, 400_000, 400_000, 900_000,
+    900_000, 900_000, 900_000,
 ];
 /// bandwidth pair used by the out-of-window differential observation
 const RELAXED_BANDWIDTH_BPS: u64 = 2_500_000;
-const PRESSURED_BANDWIDTH_BPS: u64 = 600_000;
-/// turns driven at each bandwidth before observing, so hysteresis converges
+const PRESSURED_BANDWIDTH_BPS: u64 = 400_000;
+/// turns driven at each bandwidth before observing, so the 750 ms dwell expires
 const OBSERVATION_TURNS: usize = 4;
 /// top layer of the three-layer simulcast ladder the publishers offer
 const TOP_SIMULCAST_RID: &str = "hi";
@@ -156,7 +156,7 @@ impl Default for SourcePolicyFixture {
 impl SourcePolicyFixture {
     /// builds the room, its publications and its subscriptions
     ///
-    /// one warm-up turn at full headroom settles the initial selections so the
+    /// Four turns spanning 750 ms at full headroom settle initial selections so the
     /// measured turns are all bandwidth-driven changes
     #[expect(
         clippy::panic,
@@ -194,7 +194,7 @@ impl SourcePolicyFixture {
         let stats = self.scenario.stats;
         assert_eq!(
             stats.turns_with_work, stats.turns,
-            "the bandwidth trace changes every turn, so every turn must commit a plan, got {} of {}",
+            "each bandwidth or dwell turn must commit its receiver plan, got {} of {}",
             stats.turns_with_work, stats.turns
         );
     }
@@ -251,6 +251,7 @@ struct SourcePolicyScenario {
     outbound_metrics: Arc<RuntimeMetrics>,
     receivers: BTreeMap<RawUserId, UserOutboundReceiver>,
     room: Arc<Room>,
+    now: Instant,
     session_keys: Vec<TransportSessionKey>,
     stats: SourcePolicyStats,
     user_sessions: BTreeMap<RawUserId, MediaSession>,
@@ -275,14 +276,17 @@ impl SourcePolicyScenario {
             outbound_metrics: Arc::new(RuntimeMetrics::default()),
             receivers: BTreeMap::new(),
             room,
+            now: Instant::now(),
             session_keys: Vec::with_capacity(PARTICIPANTS),
             stats: SourcePolicyStats::default(),
             user_sessions: BTreeMap::new(),
         };
         scenario.build_room(&core).await?;
-        // one settling turn at full headroom keeps the measured turns focused on
-        // bandwidth-driven changes rather than first-time subscription plans
-        scenario.run_turn(BANDWIDTH_TRACE_BPS[0]).await?;
+        scenario.now = Instant::now();
+        // Settle initial exact-target upgrades before measuring pressure turns.
+        for _ in 0..OBSERVATION_TURNS {
+            scenario.run_turn(BANDWIDTH_TRACE_BPS[0]).await?;
+        }
         scenario.stats = SourcePolicyStats::default();
         Ok(scenario)
     }
@@ -308,9 +312,14 @@ impl SourcePolicyScenario {
                 .map(|session_key| (session_key, Bitrate::from_bps(bandwidth_bps)))
                 .collect(),
         };
-        let produced_work =
-            run_source_policy_turn_for_benchmark(&self.room, &self.media_transport, &bandwidth)
-                .await;
+        let produced_work = run_source_policy_turn_for_benchmark(
+            &self.room,
+            &self.media_transport,
+            &bandwidth,
+            self.now,
+        )
+        .await;
+        self.now += Duration::from_millis(250);
         self.stats.turns = self.stats.turns.saturating_add(1);
         if produced_work {
             self.stats.turns_with_work = self.stats.turns_with_work.saturating_add(1);


### PR DESCRIPTION
Startup BWE convergence can briefly pause receiver video. Use receiver pressure and exact-target upgrade deadlines. Keep timing with its connection or committed route.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check all -->
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [coding_guidelines.md](coding_guidelines.md)
- [x] I will not use AI to fabricate answers to comments in this PR

#### AI
<!-- if no checkbox is checked, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate text (comments, documentation, commit message,...)
- [x] AI was used to generate trivial and/or sporadic changes (autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If something else than checkbox "No AI involvement" is checked, write a summary explaining the extent involvement of AI.
-->
