### PR TITLE
[IMP] core: add intermediate camera quality

### DIFF
--- a/crates/client/playwright/live_server.spec.js
+++ b/crates/client/playwright/live_server.spec.js
@@ -121,6 +121,12 @@ test("default VP8 camera pauses and resumes without renegotiation", async ({
             },
             {
                 active: true,
+                maxBitrate: 800000,
+                rid: "mid",
+                scaleResolutionDownBy: 2
+            },
+            {
+                active: true,
                 maxBitrate: 4000000,
                 rid: "hi",
                 scaleResolutionDownBy: 1
@@ -133,7 +139,7 @@ test("default VP8 camera pauses and resumes without renegotiation", async ({
     expect(video.vp8PayloadTypes.size).toBeGreaterThan(0);
     expect(video.hasSendRidLo).toBeTruthy();
     expect(video.hasSendRidHi).toBeTruthy();
-    expect(video.hasSendSimulcastLoHi).toBeTruthy();
+    expect(video.hasSendSimulcastLoMidHi).toBeTruthy();
 });
 
 test("browser compatibility upload and download flows survive live-server replacement", async ({
@@ -304,6 +310,12 @@ test("audio and screen streams publish, pause and clean up independently", async
                 maxBitrate: 150000,
                 rid: "lo",
                 scaleResolutionDownBy: 4
+            },
+            {
+                active: true,
+                maxBitrate: 800000,
+                rid: "mid",
+                scaleResolutionDownBy: 2
             },
             {
                 active: true,
@@ -542,6 +554,12 @@ test("H264-only live publish applies RID simulcast and renders when supported", 
                 },
                 {
                     active: true,
+                    maxBitrate: 800000,
+                    rid: "mid",
+                    scaleResolutionDownBy: undefined
+                },
+                {
+                    active: true,
                     maxBitrate: 4000000,
                     rid: "hi",
                     scaleResolutionDownBy: undefined
@@ -555,7 +573,7 @@ test("H264-only live publish applies RID simulcast and renders when supported", 
         expect(video.vp8PayloadTypes.size).toBe(0);
         expect(video.hasSendRidLo).toBeTruthy();
         expect(video.hasSendRidHi).toBeTruthy();
-        expect(video.hasSendSimulcastLoHi).toBeTruthy();
+        expect(video.hasSendSimulcastLoMidHi).toBeTruthy();
     } finally {
         await server.stop();
     }
@@ -804,7 +822,7 @@ function parseVideoCodecAnswer(sdp) {
     const fmtpByPayloadType = new Map();
     const hasSendRidHi = lines.some((line) => /^a=rid:hi send(?: |$)/.test(line));
     const hasSendRidLo = lines.some((line) => /^a=rid:lo send(?: |$)/.test(line));
-    const hasSendSimulcastLoHi = lines.some((line) => /^a=simulcast:send lo[;,]hi$/.test(line));
+    const hasSendSimulcastLoMidHi = lines.some((line) => /^a=simulcast:send lo;mid;hi$/.test(line));
     const rtxAssociations = new Map();
     const rtxPayloadTypes = new Set();
     const videoCodecPayloadTypes = new Set();
@@ -903,7 +921,7 @@ function parseVideoCodecAnswer(sdp) {
         hasRepairedRidExtension,
         hasSendRidHi,
         hasSendRidLo,
-        hasSendSimulcastLoHi,
+        hasSendSimulcastLoMidHi,
         h264PayloadTypes,
         h264Variants,
         rtxAssociations,
@@ -928,12 +946,102 @@ function parseFmtpParameters(formatParams) {
     );
 }
 
+test("middle camera RID delivers half-resolution decoded video", async ({
+    browserName,
+    context
+}) => {
+    test.setTimeout(60_000);
+    const maxVideoBitrate = 4_000_000;
+    const middleBitrate = 800_000;
+    const server = await spawnLiveServer({
+        bindPort: browserName === "firefox" ? 18088 : 18087,
+        rtcMinPort: browserName === "firefox" ? 58392 : 58360,
+        rtcMaxPort: browserName === "firefox" ? 58423 : 58391,
+        maxBitrateOut: middleBitrate,
+        maxVideoBitrate
+    });
+    let diagnostics;
+    let frame;
+    try {
+        const channelUuid = await createChannel({
+            authKey: server.authKey,
+            httpBaseUrl: server.httpBaseUrl
+        });
+        const publisher = await createPeerPage(context);
+        const receiver = await createPeerPage(context);
+        const participant = await createPeerPage(context);
+        for (const [page, sessionId] of [
+            [publisher, 41],
+            [receiver, 42],
+            [participant, 43]
+        ]) {
+            await connectPeer(page, {
+                channelUuid,
+                jwt: createConnectToken(channelUuid, sessionId),
+                url: server.wsUrl
+            });
+            await expect.poll(async () => (await peerSnapshot(page)).state).toBe("connected");
+        }
+        await publishSyntheticCamera(publisher, "middle-camera", {
+            width: 1280,
+            height: 720,
+            frameRate: 30,
+            movingPattern: true
+        });
+        await setStreamDownload(receiver, 41, "camera", true, "pinned");
+        await expect
+            .poll(
+                async () => {
+                    diagnostics = await streamDiagnostics({
+                        consumerSessionId: 42,
+                        httpBaseUrl: server.httpBaseUrl,
+                        producerSessionId: 41,
+                        roomId: channelUuid,
+                        streamType: "camera"
+                    });
+                    const selection = diagnostics.subscription?.selection;
+                    const middle = diagnostics.source?.encodings.find(
+                        (encoding) => encoding.rid === "mid"
+                    );
+                    return (
+                        diagnostics.subscription?.state === "active" &&
+                        selection?.selectedRid === "mid" &&
+                        selection.latestReceiverBandwidthEstimateBps >= middleBitrate &&
+                        selection.latestReceiverBandwidthEstimateBps < maxVideoBitrate &&
+                        Number.isFinite(middle?.lastPacketAgeMs) &&
+                        middle.lastPacketAgeMs < 1_000
+                    );
+                },
+                { intervals: [20, 50, 100], timeout: 25_000 }
+            )
+            .toBeTruthy();
+        // A selected RID can still await its strict gate. Decoded dimensions
+        // prove that forwarding has left the incumbent or bootstrap encoding.
+        await expect
+            .poll(
+                async () => {
+                    frame = await waitForDecodedRemoteVideoFrame(receiver, 41, "camera");
+                    return { width: frame.width, height: frame.height };
+                },
+                { intervals: [20, 50, 100], timeout: 15_000 }
+            )
+            .toEqual({ width: 640, height: 360 });
+    } finally {
+        await test.info().attach("middle-camera-diagnostics", {
+            body: JSON.stringify({ diagnostics, frame }),
+            contentType: "application/json"
+        });
+        await server.stop();
+    }
+});
+
 test("startup pressure holds the thumbnail through the soft pause dwell", async ({
     browserName,
     context
 }) => {
     test.setTimeout(60_000);
-    // PR3 must recalibrate this band when the generated upload ladder changes.
+    // At this cap lo and mid both cost 150 kbps. Three camera floors
+    // exceed the 400 kbps probe ceiling throughout the soft pause dwell.
     const maxVideoBitrate = 200_000;
     const server = await spawnLiveServer({
         bindPort: browserName === "firefox" ? 18086 : 18085,
@@ -1034,9 +1142,7 @@ test("startup pressure holds the thumbnail through the soft pause dwell", async 
         expect(grace.subscription.selection.selectedVideoBudgetBps).toBeGreaterThanOrEqual(
             maxVideoBitrate
         );
-        expect(grace.subscription.selection.selectedVideoBudgetBps).toBeLessThan(
-            maxVideoBitrate + 2 * 150_000
-        );
+        expect(grace.subscription.selection.selectedVideoBudgetBps).toBeLessThan(3 * 150_000);
         await test.info().attach("soft-pause-grace", {
             body: JSON.stringify(grace),
             contentType: "application/json"

--- a/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
+++ b/crates/core/src/engine/media_transport/rtc/TESTS/negotiation_tests.rs
@@ -178,7 +178,7 @@ async fn rtc_initial_session_offer_advertises_vp8_simulcast_receive_surface() {
     assert!(
         offer_sdp.contains(&sdp_simulcast_line(
             sdp::simulcast::DIRECTION_RECV,
-            &["lo", "hi"]
+            &["lo", "mid", "hi"]
         )),
         "video offers should advertise VP8 RID simulcast receive metadata"
     );
@@ -206,19 +206,7 @@ async fn rtc_initial_session_offer_advertises_vp8_simulcast_receive_surface() {
             String::from(rfc_rtp::codec_name::H264)
         ]
     );
-    assert_eq!(video_slot.simulcast_encodings.len(), 2);
-    assert_eq!(video_slot.simulcast_encodings[0].rid, "lo");
-    assert_eq!(
-        video_slot.simulcast_encodings[0].max_bitrate,
-        Some(Bitrate::from_kbps(150))
-    );
-    assert_eq!(video_slot.simulcast_encodings[0].resolution_scale, Some(4));
-    assert_eq!(video_slot.simulcast_encodings[1].rid, "hi");
-    assert_eq!(
-        video_slot.simulcast_encodings[1].max_bitrate,
-        Some(Bitrate::from_mbps(4))
-    );
-    assert_eq!(video_slot.simulcast_encodings[1].resolution_scale, Some(1));
+    assert_default_vp8_upload_slot(&upload_slots);
 }
 
 #[tokio::test]
@@ -242,7 +230,7 @@ async fn rtc_initial_session_offer_advertises_h264_simulcast_when_h264_leads() {
     assert!(
         offer_sdp.contains(&sdp_simulcast_line(
             sdp::simulcast::DIRECTION_RECV,
-            &["lo", "hi"]
+            &["lo", "mid", "hi"]
         )),
         "H264-first video offers should claim the promoted RID simulcast matrix"
     );
@@ -260,19 +248,22 @@ async fn rtc_initial_session_offer_advertises_h264_simulcast_when_h264_leads() {
             String::from(rfc_rtp::codec_name::VP8)
         ]
     );
-    assert_eq!(video_slot.simulcast_encodings.len(), 2);
-    assert_eq!(video_slot.simulcast_encodings[0].rid, "lo");
     assert_eq!(
-        video_slot.simulcast_encodings[0].max_bitrate,
-        Some(Bitrate::from_kbps(150))
+        video_slot
+            .simulcast_encodings
+            .iter()
+            .map(|encoding| (
+                encoding.rid.as_str(),
+                encoding.max_bitrate,
+                encoding.resolution_scale,
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            ("lo", Some(Bitrate::from_kbps(150)), None),
+            ("mid", Some(Bitrate::from_kbps(800)), None),
+            ("hi", Some(Bitrate::from_mbps(4)), None),
+        ]
     );
-    assert_eq!(video_slot.simulcast_encodings[0].resolution_scale, None);
-    assert_eq!(video_slot.simulcast_encodings[1].rid, "hi");
-    assert_eq!(
-        video_slot.simulcast_encodings[1].max_bitrate,
-        Some(Bitrate::from_mbps(4))
-    );
-    assert_eq!(video_slot.simulcast_encodings[1].resolution_scale, None);
 }
 
 #[expect(
@@ -368,7 +359,7 @@ async fn rtc_initial_session_offer_reports_configured_codec_preferences() {
     }
     assert!(!offer_sdp.contains(&sdp_simulcast_line(
         sdp::simulcast::DIRECTION_RECV,
-        &["lo", "hi"]
+        &["lo", "mid", "hi"]
     )));
 }
 
@@ -961,66 +952,95 @@ async fn rtc_session_renegotiation_offer_stages_protocol_producer_additions() {
 
 #[tokio::test]
 async fn rtc_protocol_publish_projects_rid_bindings_when_publish_intent_is_empty() {
-    let adapter = RtcWorker::default();
-    let session_key = transport_key(1, 46, UserId::Integer(46));
-
-    let mut remote = complete_initial_offer_answer(&adapter, &session_key, 55_007).await;
-
-    let transport_media_id = adapter
-        .add_recv_media(
-            &session_key,
-            Str0mMediaKind::Video,
-            &RouterRtpParameters::new(vec![], vec![], vec![]),
-        )
-        .await
-        .expect("protocol publish intent should stage a recv-only media line");
-    let (renegotiation_sdp, upload_slots) = adapter
-        .create_session_renegotiation_offer(&session_key)
-        .await
-        .expect("protocol publish should stage a follow-up offer")
-        .into_parts();
-    assert_default_vp8_upload_slot(&upload_slots);
-    assert!(
-        renegotiation_sdp.contains(&sdp_simulcast_line(
-            sdp::simulcast::DIRECTION_RECV,
-            &["lo", "hi"]
-        )),
-        "empty protocol publish intents should emit the server-defined RID ladder"
-    );
-    let negotiated_mid = adapter
-        .debug_resolve_mid(transport_media_id)
-        .await
-        .expect("transport media should expose its negotiated mid");
-    let answer_sdp = remote
-        .sdp_api()
-        .accept_offer(
-            SdpOffer::from_sdp_string(&renegotiation_sdp)
-                .expect("default simulcast offer should parse"),
-        )
-        .expect("remote default simulcast answer should build")
-        .to_sdp_string();
-    let answer_sdp = answer_with_simulcast_send_rids(
-        &answer_sdp,
-        &negotiated_mid,
-        &[("lo", Some(150_000)), ("hi", Some(4_000_000))],
-    );
-
-    adapter
-        .apply_session_answer(&session_key, &answer_sdp)
-        .await
-        .expect("default simulcast answer should apply");
-
-    let negotiated_parameters = adapter
-        .negotiated_producer_parameters(&session_key, transport_media_id)
-        .await
-        .expect("protocol publish should project negotiated RTP parameters");
-    assert_eq!(
-        negotiated_parameters
-            .bindings()
-            .map(|binding| binding.rid())
-            .collect::<Vec<_>>(),
-        vec![Some("lo"), Some("hi")]
-    );
+    let offered = [
+        ("lo", Some(150_000), Some(4)),
+        ("mid", Some(800_000), Some(2)),
+        ("hi", Some(4_000_000), Some(1)),
+    ];
+    for accepted_rids in [
+        &["lo", "mid", "hi"][..],
+        &["lo", "hi"],
+        &["mid", "hi"],
+        &["mid"],
+    ] {
+        let adapter = RtcWorker::default();
+        let session_key = transport_key(1, 46, UserId::Integer(46));
+        let mut remote = complete_initial_offer_answer(&adapter, &session_key, 55_007).await;
+        let transport_media_id = adapter
+            .add_recv_media(
+                &session_key,
+                Str0mMediaKind::Video,
+                &RouterRtpParameters::new(vec![], vec![], vec![]),
+            )
+            .await
+            .expect("protocol publish intent should stage a recv-only media line");
+        let (renegotiation_sdp, upload_slots) = adapter
+            .create_session_renegotiation_offer(&session_key)
+            .await
+            .expect("protocol publish should stage a follow-up offer")
+            .into_parts();
+        assert_default_vp8_upload_slot(&upload_slots);
+        assert!(
+            renegotiation_sdp.contains(&sdp_simulcast_line(
+                sdp::simulcast::DIRECTION_RECV,
+                &["lo", "mid", "hi"]
+            )),
+            "empty protocol publish intents should emit the server-defined RID ladder"
+        );
+        let negotiated_mid = adapter
+            .debug_resolve_mid(transport_media_id)
+            .await
+            .expect("transport media should expose its negotiated mid");
+        let answer_sdp = remote
+            .sdp_api()
+            .accept_offer(
+                SdpOffer::from_sdp_string(&renegotiation_sdp)
+                    .expect("default simulcast offer should parse"),
+            )
+            .expect("remote default simulcast answer should build")
+            .to_sdp_string();
+        let accepted = offered
+            .iter()
+            .filter(|(rid, _, _)| accepted_rids.contains(rid))
+            .copied()
+            .collect::<Vec<_>>();
+        let answer_sdp = answer_with_simulcast_send_rids(
+            &answer_sdp,
+            &negotiated_mid,
+            &accepted
+                .iter()
+                .map(|(rid, bitrate, _scale)| (*rid, *bitrate))
+                .collect::<Vec<_>>(),
+        );
+        let applied = adapter
+            .apply_session_answer(&session_key, &answer_sdp)
+            .await
+            .expect("default simulcast answer should apply");
+        assert_eq!(
+            applied
+                .negotiated_producer_upload_encodings(transport_media_id)
+                .iter()
+                .map(|encoding| (
+                    encoding.rid.as_str(),
+                    encoding.max_bitrate.map(Bitrate::as_bps),
+                    encoding.resolution_scale,
+                ))
+                .collect::<Vec<_>>(),
+            accepted,
+            "answer pruning must preserve the offered RID bitrate and resolution"
+        );
+        let negotiated_parameters = adapter
+            .negotiated_producer_parameters(&session_key, transport_media_id)
+            .await
+            .expect("protocol publish should project negotiated RTP parameters");
+        assert_eq!(
+            negotiated_parameters
+                .bindings()
+                .map(|binding| binding.rid())
+                .collect::<Vec<_>>(),
+            accepted_rids.iter().copied().map(Some).collect::<Vec<_>>()
+        );
+    }
 }
 
 #[tokio::test]
@@ -1666,7 +1686,6 @@ fn assert_default_vp8_upload_slot(upload_slots: &[SessionUploadSlot]) {
             .any(|codec| codec.as_str() == rfc_rtp::codec_name::VP8),
         "empty protocol publish intent should use the server-defined VP8 upload profile"
     );
-    assert_eq!(video_upload_slot.simulcast_encodings.len(), 2);
     assert_eq!(
         video_upload_slot
             .simulcast_encodings
@@ -1679,6 +1698,7 @@ fn assert_default_vp8_upload_slot(upload_slots: &[SessionUploadSlot]) {
             .collect::<Vec<_>>(),
         vec![
             ("lo", Some(Bitrate::from_kbps(150)), Some(4)),
+            ("mid", Some(Bitrate::from_kbps(800)), Some(2)),
             ("hi", Some(Bitrate::from_mbps(4)), Some(1))
         ]
     );

--- a/crates/core/src/engine/media_transport/rtc/codec/TESTS/h264.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/TESTS/h264.rs
@@ -24,7 +24,7 @@ fn profile_accepts_only_the_promoted_chromium_format() {
 }
 
 #[test]
-fn default_policy_advertises_two_rids_without_resolution_hints() {
+fn default_policy_advertises_three_rids_without_resolution_hints() {
     let profile = SimulcastProfile::new(VideoBitrateLimits::default());
     let simulcast = profile.recv_simulcast(None);
 
@@ -38,6 +38,12 @@ fn default_policy_advertises_two_rids_without_resolution_hints() {
                 max_framerate: None,
             },
             SessionUploadEncoding {
+                rid: rid::DEFAULT_MIDDLE_RID.to_owned(),
+                max_bitrate: Some(Bitrate::from_kbps(800)),
+                resolution_scale: None,
+                max_framerate: None,
+            },
+            SessionUploadEncoding {
                 rid: rid::DEFAULT_HIGH_RID.to_owned(),
                 max_bitrate: Some(VideoBitrateLimits::default().max_video_bitrate()),
                 resolution_scale: None,
@@ -45,7 +51,7 @@ fn default_policy_advertises_two_rids_without_resolution_hints() {
             },
         ]
     );
-    assert!(matches!(simulcast, Some(simulcast) if simulcast.recv.len() == 2));
+    assert!(matches!(simulcast, Some(simulcast) if simulcast.recv.len() == 3));
 }
 
 #[test]
@@ -61,6 +67,9 @@ fn publication_policy_preserves_rid_bitrates_without_resolution_hints() {
                 .with_rid(rid::DEFAULT_LOW_RID)
                 .with_max_bitrate(120_000),
             StreamBinding::new()
+                .with_rid(rid::DEFAULT_MIDDLE_RID)
+                .with_max_bitrate(400_000),
+            StreamBinding::new()
                 .with_rid(rid::DEFAULT_HIGH_RID)
                 .with_max_bitrate(800_000),
         ],
@@ -73,6 +82,12 @@ fn publication_policy_preserves_rid_bitrates_without_resolution_hints() {
             SessionUploadEncoding {
                 rid: rid::DEFAULT_LOW_RID.to_owned(),
                 max_bitrate: Some(Bitrate::from_kbps(120)),
+                resolution_scale: None,
+                max_framerate: None,
+            },
+            SessionUploadEncoding {
+                rid: rid::DEFAULT_MIDDLE_RID.to_owned(),
+                max_bitrate: Some(Bitrate::from_kbps(400)),
                 resolution_scale: None,
                 max_framerate: None,
             },

--- a/crates/core/src/engine/media_transport/rtc/codec/TESTS/mod.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/TESTS/mod.rs
@@ -76,6 +76,41 @@ fn publication_profile_follows_first_primary_codec() {
     );
 }
 
+#[test]
+fn publication_profile_preserves_explicit_three_rid_ladder() {
+    let parameters = MediaStream::new(
+        vp8_parameters().formats().cloned().collect(),
+        Vec::new(),
+        vec![
+            StreamBinding::new()
+                .with_rid("small")
+                .with_max_bitrate(120_000),
+            StreamBinding::new()
+                .with_rid("medium")
+                .with_max_bitrate(400_000),
+            StreamBinding::new()
+                .with_rid("large")
+                .with_max_bitrate(800_000),
+        ],
+    );
+    let encodings = publish_upload_encodings(MediaKind::Video, &parameters);
+    assert_eq!(
+        encodings
+            .iter()
+            .map(|encoding| (
+                encoding.rid.as_str(),
+                encoding.max_bitrate,
+                encoding.resolution_scale,
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            ("small", Some(crate::Bitrate::from_kbps(120)), Some(4)),
+            ("medium", Some(crate::Bitrate::from_kbps(400)), Some(2)),
+            ("large", Some(crate::Bitrate::from_kbps(800)), Some(1)),
+        ],
+    );
+}
+
 fn vp8_parameters() -> MediaStream {
     video_parameters([MediaFormat::new(
         RouterMediaKind::Video,

--- a/crates/core/src/engine/media_transport/rtc/codec/TESTS/rid.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/TESTS/rid.rs
@@ -9,6 +9,25 @@ use crate::Bitrate;
 
 const HIGH_MAX_BITRATE: Bitrate = Bitrate::from_kbps(900);
 
+#[test]
+fn default_upload_ladder_respects_video_cap() {
+    for (cap, expected) in [
+        (0, [0, 0, 0]),
+        (100_000, [100_000, 100_000, 100_000]),
+        (150_000, [150_000, 150_000, 150_000]),
+        (500_000, [150_000, 150_000, 500_000]),
+        (1_000_000, [150_000, 200_000, 1_000_000]),
+        (4_000_000, [150_000, 800_000, 4_000_000]),
+    ] {
+        let layers = default_layers(VideoBitrateLimits::new(Bitrate::from_bps(cap)));
+        assert_eq!(layers.map(|layer| layer.rid), ["lo", "mid", "hi"]);
+        assert_eq!(
+            layers.map(|layer| layer.max_bitrate),
+            expected.map(|rate| Some(Bitrate::from_bps(rate))),
+        );
+    }
+}
+
 fn send_rids(
     answer_sdp: &str,
     offered_encodings: &[SessionUploadEncoding],
@@ -304,7 +323,42 @@ fn answer_rejects_invalid_rfc8852_ids() {
 }
 
 #[test]
-fn answer_rejects_extra_simulcast_streams() {
+fn three_rid_answer_accepts_offered_streams_and_subsets() {
+    let mut offered_encodings = default_upload_encodings();
+    offered_encodings.insert(
+        1,
+        SessionUploadEncoding {
+            rid: "mid".to_owned(),
+            max_bitrate: Some(Bitrate::from_kbps(450)),
+            resolution_scale: Some(2),
+            max_framerate: None,
+        },
+    );
+    for accepted in [
+        &[("lo", 150_000), ("mid", 450_000), ("hi", 900_000)][..],
+        &[("lo", 150_000), ("hi", 900_000)],
+        &[("mid", 450_000), ("hi", 900_000)],
+        &[("mid", 450_000)],
+    ] {
+        let rids = accepted.iter().map(|(rid, _)| *rid).collect::<Vec<_>>();
+        let answer = answer(
+            "video_0",
+            &[("lo", None), ("mid", None), ("hi", None)],
+            Some(&rids.join(";")),
+        );
+        let expected = accepted
+            .iter()
+            .map(|(rid, bitrate)| NegotiatedRid {
+                rid: Rid::from(*rid),
+                max_bitrate: Some(Bitrate::from_bps(*bitrate)),
+            })
+            .collect();
+        assert_eq!(send_rids(&answer, &offered_encodings), Ok(expected));
+    }
+}
+
+#[test]
+fn answer_rejects_unoffered_simulcast_stream() {
     let send = format!(
         "lo{separator}mid{separator}hi",
         separator = sdp::simulcast::STREAM_SEPARATOR,
@@ -322,6 +376,14 @@ fn answer_rejects_extra_simulcast_streams() {
     assert_eq!(
         send_rids(&answer, &default_upload_encodings()),
         Err(SimulcastAnswerError)
+    );
+}
+
+#[test]
+fn answer_rejects_more_than_three_simulcast_streams() {
+    assert_eq!(
+        send_simulcast_stream_count("send lo;mid;hi;extra"),
+        Err(SimulcastAnswerError),
     );
 }
 

--- a/crates/core/src/engine/media_transport/rtc/codec/rid.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/rid.rs
@@ -16,9 +16,11 @@ use crate::{
 };
 
 pub(super) const DEFAULT_LOW_RID: &str = "lo";
+pub(super) const DEFAULT_MIDDLE_RID: &str = "mid";
 pub(super) const DEFAULT_HIGH_RID: &str = "hi";
 pub(super) const DEFAULT_LOW_MAX_BITRATE: Bitrate = Bitrate::from_kbps(150);
-const MAX_SEND_STREAMS: usize = 2;
+const MIDDLE_BITRATE_DIVISOR: u64 = 5;
+const MAX_SEND_STREAMS: usize = 3;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::engine::media_transport::rtc) struct NegotiatedRid {
@@ -78,12 +80,21 @@ pub(super) struct LayerSpec<'a> {
     pub(super) max_bitrate: Option<Bitrate>,
 }
 
-pub(super) fn default_layers(video_bitrate_limits: VideoBitrateLimits) -> [LayerSpec<'static>; 2] {
+pub(super) fn default_layers(video_bitrate_limits: VideoBitrateLimits) -> [LayerSpec<'static>; 3] {
     let high_max_bitrate = video_bitrate_limits.max_video_bitrate();
+    let low_max_bitrate = DEFAULT_LOW_MAX_BITRATE.min(high_max_bitrate);
     [
         LayerSpec {
             rid: DEFAULT_LOW_RID,
-            max_bitrate: Some(DEFAULT_LOW_MAX_BITRATE.min(high_max_bitrate)),
+            max_bitrate: Some(low_max_bitrate),
+        },
+        LayerSpec {
+            rid: DEFAULT_MIDDLE_RID,
+            max_bitrate: Some(
+                high_max_bitrate
+                    .divided_by(MIDDLE_BITRATE_DIVISOR)
+                    .max(low_max_bitrate),
+            ),
         },
         LayerSpec {
             rid: DEFAULT_HIGH_RID,

--- a/crates/core/src/engine/media_transport/rtc/codec/vp8.rs
+++ b/crates/core/src/engine/media_transport/rtc/codec/vp8.rs
@@ -11,6 +11,7 @@ use super::rid::{self, LayerSpec};
 use crate::{VideoBitrateLimits, engine::media_transport::SessionUploadEncoding};
 
 const LOW_LAYER_RESOLUTION_SCALE: u16 = 4;
+const MIDDLE_LAYER_RESOLUTION_SCALE: u16 = 2;
 const HIGH_LAYER_RESOLUTION_SCALE: u16 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,16 +36,20 @@ impl SimulcastProfile {
         parameters: Option<&MediaStream>,
     ) -> Vec<SessionUploadEncoding> {
         self.layers(parameters).map_or_else(Vec::new, |layers| {
+            let layer_count = layers.len();
             layers
                 .into_iter()
                 .enumerate()
                 .map(|(index, layer)| SessionUploadEncoding {
                     rid: layer.rid.to_owned(),
                     max_bitrate: layer.max_bitrate,
+                    // Two-RID publishers retain their existing 4:1 spatial ladder.
                     resolution_scale: Some(if index == 0 {
                         LOW_LAYER_RESOLUTION_SCALE
-                    } else {
+                    } else if index + 1 == layer_count {
                         HIGH_LAYER_RESOLUTION_SCALE
+                    } else {
+                        MIDDLE_LAYER_RESOLUTION_SCALE
                     }),
                     max_framerate: None,
                 })

--- a/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
+++ b/crates/core/src/engine/room/TESTS/producer_tests/source_policy.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use o_sfu_router::rtp::MediaStream;
 use o_sfu_telemetry::schema::event as telemetry_event;
 use serde_json::json;
 use tokio::time::{Instant as TokioInstant, advance, pause, resume, timeout};
@@ -1408,6 +1409,203 @@ async fn overload_steps_thumbnail_down_one_layer_and_keeps_it_deliverable() {
     )
     .await;
     drop(capture);
+}
+
+#[tokio::test]
+async fn aggregate_pressure_uses_intermediate_quality_before_pausing_thumbnails() {
+    for layout in [
+        Some(VideoLayoutIntent::Pinned),
+        Some(VideoLayoutIntent::Featured),
+        None,
+    ] {
+        let scenario = SourcePolicyScenario::three_ready_users().await;
+        let publisher = UserId::Integer(1);
+        let receiver = UserId::Integer(2);
+        publish_three_layer_camera(&scenario.room, &publisher, &scenario.adapter).await;
+        publish_simulcast_camera(&scenario.room, &UserId::Integer(3), &scenario.adapter).await;
+        if let Some(layout) = layout {
+            scenario.set_scalable_video_layout(2, 1, layout).await;
+        } else {
+            publish_track(
+                &scenario.room,
+                &publisher,
+                TestSourceKind::AudioDetector,
+                MediaKind::Audio,
+                test_audio_rtp_parameters(),
+                &scenario.adapter,
+            )
+            .await;
+            scenario
+                .mark_active_speaker(scenario.audio_media_id(1).await)
+                .await;
+        }
+        scenario.refresh_policy_until_upgrades_settle().await;
+        let speakers = scenario.adapter.active_speaker_source_snapshot().await;
+        let now = scenario.policy_now.get().max(Instant::now());
+        // Each important route can afford hi alone. Only the aggregate pass can
+        // trade it for mid and keep the thumbnail within this receiver budget.
+        policy_at(
+            &scenario,
+            &speakers,
+            &bandwidth_for(&scenario, 2, 900).await,
+            now,
+        )
+        .await;
+        assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "mid").await;
+        assert_scalable_video_rid_for_publishers(&scenario, &receiver, [3], "lo").await;
+        assert_eq!(
+            receiver_selected_video_bitrate(&scenario.room, &scenario.adapter, &receiver).await,
+            Bitrate::from_kbps(600)
+        );
+        assert_eq!(soft_pause_deadline(&scenario, 2).await, None);
+        assert_receiver_bwe_target(
+            &scenario.room,
+            &scenario.adapter,
+            &receiver,
+            Bitrate::from_kbps(1_800),
+        )
+        .await;
+
+        let pressure = bandwidth_for(&scenario, 2, 550).await;
+        policy_at(&scenario, &speakers, &pressure, now).await;
+        assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "mid").await;
+        assert_eq!(
+            soft_pause_deadline(&scenario, 2).await,
+            Some(now + Duration::from_millis(750))
+        );
+        policy_at(
+            &scenario,
+            &speakers,
+            &pressure,
+            now + Duration::from_millis(750),
+        )
+        .await;
+        assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "mid").await;
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &receiver,
+            &UserId::Integer(3),
+            TestSourceKind::ScalableVideo,
+            Some(DiagnosticsPolicyPauseReason::BudgetPressure),
+        )
+        .await;
+
+        // Floor protection belongs only to aggregate fitting. A receiver that
+        // cannot afford mid still selects lo through its per-route budget.
+        policy_at(
+            &scenario,
+            &speakers,
+            &bandwidth_for(&scenario, 2, 300).await,
+            now + Duration::from_millis(751),
+        )
+        .await;
+        assert_scalable_video_rid_for_publishers(&scenario, &receiver, [1], "lo").await;
+    }
+}
+
+#[tokio::test]
+async fn aggregate_pressure_preserves_pinned_quality_without_an_intermediate_bitrate() {
+    let two_layers = test_simulcast_video_rtp_parameters();
+    let mut bindings = two_layers.bindings().cloned().collect::<Vec<_>>();
+    bindings.insert(1, bindings[0].clone().with_rid("mid").with_ssrc(31_003));
+    let repeated_floor = MediaStream::new(
+        two_layers.formats().cloned().collect(),
+        two_layers.header_extensions().cloned().collect(),
+        bindings,
+    );
+    for parameters in [two_layers, repeated_floor] {
+        let scenario = SourcePolicyScenario::three_ready_users().await;
+        publish_track(
+            &scenario.room,
+            &UserId::Integer(1),
+            TestSourceKind::ScalableVideo,
+            MediaKind::Video,
+            parameters,
+            &scenario.adapter,
+        )
+        .await;
+        publish_simulcast_camera(&scenario.room, &UserId::Integer(3), &scenario.adapter).await;
+        scenario
+            .set_scalable_video_layout(2, 1, VideoLayoutIntent::Pinned)
+            .await;
+        scenario.refresh_policy_until_upgrades_settle().await;
+        let bandwidth = bandwidth_for(&scenario, 2, 900).await;
+        let now = scenario.policy_now.get().max(Instant::now());
+        for elapsed in [0, 750] {
+            policy_at(
+                &scenario,
+                &[],
+                &bandwidth,
+                now + Duration::from_millis(elapsed),
+            )
+            .await;
+            assert_scalable_video_rid_for_publishers(&scenario, &UserId::Integer(2), [1], "hi")
+                .await;
+        }
+        assert_subscription_policy_pause_reason(
+            &scenario.room,
+            &scenario.adapter,
+            &UserId::Integer(2),
+            &UserId::Integer(3),
+            TestSourceKind::ScalableVideo,
+            Some(DiagnosticsPolicyPauseReason::BudgetPressure),
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn pinned_video_without_a_ladder_keeps_the_soft_pause_dwell() {
+    let scenario = SourcePolicyScenario::with_ready_users(&[1, 2]).await;
+    let publisher = UserId::Integer(1);
+    let receiver = UserId::Integer(2);
+    publish_track(
+        &scenario.room,
+        &publisher,
+        TestSourceKind::ScalableVideo,
+        MediaKind::Video,
+        test_video_rtp_parameters(),
+        &scenario.adapter,
+    )
+    .await;
+    scenario
+        .set_scalable_video_layout(2, 1, VideoLayoutIntent::Pinned)
+        .await;
+    let source_media =
+        source_media_id(&scenario.room, &publisher, TestSourceKind::ScalableVideo).await;
+    let source_bitrate = TransportBitrateSnapshot {
+        total: Bitrate::from_kbps(500),
+        per_media: vec![(source_media, Bitrate::from_kbps(500))],
+    };
+    let now = scenario.policy_now.get().max(Instant::now());
+    for (budget, elapsed) in [(1_000, 0), (1_000, 750), (0, 751), (0, 1_501)] {
+        let bandwidth = bandwidth_for(&scenario, 2, budget).await;
+        let tx = {
+            let state = scenario.room.state.read().await;
+            SourcePolicyTransaction::plan(
+                &state,
+                &[],
+                &bandwidth,
+                &source_bitrate,
+                now + Duration::from_millis(elapsed),
+            )
+        };
+        if let Some(tx) = tx {
+            tx.execute(&scenario.room, &scenario.adapter).await;
+        }
+        if elapsed >= 750 {
+            assert_subscription_policy_pause_reason(
+                &scenario.room,
+                &scenario.adapter,
+                &receiver,
+                &publisher,
+                TestSourceKind::ScalableVideo,
+                (elapsed == 1_501).then_some(DiagnosticsPolicyPauseReason::BudgetPressure),
+            )
+            .await;
+        }
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -3203,12 +3401,23 @@ async fn a_rejected_sibling_pause_cannot_extend_upgrade_eligibility() {
     .unwrap();
     let scenario = SourcePolicyScenario::with_ready_users_and_tuning(&[1, 2, 3], tuning).await;
     for publisher in [1, 3] {
-        publish_three_layer_camera(
-            &scenario.room,
-            &UserId::Integer(publisher),
-            &scenario.adapter,
-        )
-        .await;
+        // One legacy ladder keeps aggregate pressure while its pinned route
+        // upgrades. Two intermediate rungs would fit and cancel the pause.
+        if publisher == 1 {
+            publish_simulcast_camera(
+                &scenario.room,
+                &UserId::Integer(publisher),
+                &scenario.adapter,
+            )
+            .await;
+        } else {
+            publish_three_layer_camera(
+                &scenario.room,
+                &UserId::Integer(publisher),
+                &scenario.adapter,
+            )
+            .await;
+        }
         scenario
             .set_scalable_video_layout(2, publisher, VideoLayoutIntent::Pinned)
             .await;

--- a/crates/core/src/engine/room/media_graph/TESTS/mod.rs
+++ b/crates/core/src/engine/room/media_graph/TESTS/mod.rs
@@ -14,7 +14,7 @@ use o_sfu_router::{
     rtp::{MediaStream, Mid, Rid, Ssrc},
     test_support::rtp_samples::{
         sample_client_rtp_capabilities, sample_simulcast_video_rtp_parameters,
-        sample_video_rtp_parameters,
+        sample_three_layer_simulcast_video_rtp_parameters, sample_video_rtp_parameters,
     },
 };
 
@@ -676,4 +676,84 @@ fn commit_publish_reservation_registers_all_source_encodings() {
             .map(|encoding| encoding.encoding_id())
             .collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn publication_preserves_negotiated_upload_roles() {
+    let mut upload_encodings = test_upload_encodings();
+    upload_encodings.insert(
+        1,
+        SessionUploadEncoding {
+            rid: "mid".to_owned(),
+            max_bitrate: Some(Bitrate::from_kbps(450)),
+            resolution_scale: Some(2),
+            max_framerate: None,
+        },
+    );
+    for expected in [
+        &[
+            ("lo", 4, UploadLayerPolicyRole::DegradedThumbnail),
+            ("mid", 2, UploadLayerPolicyRole::Thumbnail),
+            ("hi", 1, UploadLayerPolicyRole::Featured),
+        ][..],
+        &[("mid", 2, UploadLayerPolicyRole::Thumbnail)],
+    ] {
+        let mut state = test_state();
+        let user_id = UserId::Integer(1);
+        join_test_user(&mut state, &user_id);
+        let connection_id = set_test_user_ready(&mut state, &user_id);
+        let offered = sample_three_layer_simulcast_video_rtp_parameters(Some("camera-0"));
+        let accepted_rid = |rid: &str| expected.iter().any(|(accepted, _, _)| *accepted == rid);
+        let parameters = MediaStream::new(
+            offered.formats().cloned().collect(),
+            offered.header_extensions().cloned().collect(),
+            offered
+                .bindings()
+                .filter(|binding| binding.rid().is_some_and(accepted_rid))
+                .cloned()
+                .collect(),
+        );
+        let parameters =
+            derive_consumable_rtp_parameters(&parameters, &state.router_rtp_capabilities())
+                .expect("accepted RID publication should negotiate");
+        let publish = state
+            .validate_publish(
+                &user_id,
+                connection_id,
+                &source_publish_intent_for_source(TestSourceKind::ScalableVideo),
+            )
+            .expect("ready publisher should validate");
+        let accepted_upload_encodings = upload_encodings
+            .iter()
+            .filter(|encoding| accepted_rid(&encoding.rid))
+            .cloned()
+            .collect::<Vec<_>>();
+        let media = TransportMediaId::new(101);
+        assert!(
+            state
+                .commit_publish_reservation(publish, parameters, &accepted_upload_encodings, media)
+                .is_some()
+        );
+        let source_id = state
+            .inspect_source_id_for_transport_media_id(media)
+            .unwrap();
+        let source = state.topology.source_descriptor(source_id).unwrap();
+        let metadata = source
+            .selectable_encodings()
+            .map(|encoding| {
+                (
+                    encoding.rid().map(Rid::as_str),
+                    encoding.resolution_scale(),
+                    encoding.policy_role(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            metadata,
+            expected
+                .iter()
+                .map(|(rid, scale, role)| (Some(*rid), Some(*scale), Some(*role)))
+                .collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/core/src/engine/room/media_graph/producer.rs
+++ b/crates/core/src/engine/room/media_graph/producer.rs
@@ -350,8 +350,9 @@ pub(super) fn allocate_source_descriptor(
                     .or_else(|| upload_profile.and_then(MatchedUploadEncoding::max_bitrate)),
                 resolution_scale: upload_profile.and_then(MatchedUploadEncoding::resolution_scale),
                 max_framerate: upload_profile.and_then(MatchedUploadEncoding::max_framerate),
-                policy_role: upload_profile
-                    .map(|profile| upload_layer_policy_role_for_rank(profile.rank)),
+                policy_role: upload_profile.map(|profile| {
+                    upload_layer_policy_role_for_rank(profile.rank, upload_encodings.len())
+                }),
                 negotiated_format: negotiated_format_for_binding(
                     consumable_rtp_parameters,
                     binding.payload_type(),
@@ -402,11 +403,16 @@ impl MatchedUploadEncoding<'_> {
     }
 }
 
-const fn upload_layer_policy_role_for_rank(rank: usize) -> UploadLayerPolicyRole {
-    if rank == 0 {
-        UploadLayerPolicyRole::Thumbnail
-    } else {
+const fn upload_layer_policy_role_for_rank(
+    rank: usize,
+    layer_count: usize,
+) -> UploadLayerPolicyRole {
+    if layer_count > 1 && rank + 1 == layer_count {
         UploadLayerPolicyRole::Featured
+    } else if rank == 0 && layer_count > 2 {
+        UploadLayerPolicyRole::DegradedThumbnail
+    } else {
+        UploadLayerPolicyRole::Thumbnail
     }
 }
 

--- a/crates/core/src/engine/room/source_policy/video/solver.rs
+++ b/crates/core/src/engine/room/source_policy/video/solver.rs
@@ -28,7 +28,7 @@ use crate::{
         source_model::{
             PolicyPauseReason, PublishedSourceDescriptor, PublishedSourceId,
             ReceiverVideoBudgetDiagnostics, SourceAdaptationPolicy, SourceEncodingDescriptor,
-            SourceRoomPolicySelector, SourceRoutePriority, SourceSelector, UploadLayerPolicyRole,
+            SourceRoomPolicySelector, SourceRoutePriority, SourceSelector,
         },
     },
 };
@@ -497,28 +497,6 @@ fn highest_allowed_selector(route: &ReceiverVideoRouteInput<'_>) -> Option<Sourc
     ))
 }
 
-fn cheapest_useful_selector(
-    route: &ReceiverVideoRouteInput<'_>,
-) -> Option<(SourceSelector, Bitrate)> {
-    let source_cap = route.source.policy().video_bitrate_cap();
-    route
-        .source
-        .selectable_encodings()
-        .filter(|encoding| {
-            !matches!(
-                encoding.policy_role(),
-                Some(UploadLayerPolicyRole::Featured)
-            )
-        })
-        .chain(route.source.selectable_encodings())
-        .find_map(|encoding| {
-            let bitrate = encoding.max_bitrate()?;
-            source_cap
-                .is_none_or(|source_cap| bitrate <= source_cap)
-                .then_some((SourceSelector::Encoding(encoding.encoding_id()), bitrate))
-        })
-}
-
 /// Separates configured downlink headroom from audio consumption so receivers
 /// reserve audio only for admitted routes they can hear.
 fn effective_video_budget(
@@ -532,30 +510,29 @@ fn effective_video_budget(
     after_overhead.saturating_sub(audio_reserve)
 }
 
-/// next allowed, non-featured layer one step below `current`, with its bitrate
+/// Returns the next cheaper allowed encoding and its bitrate.
 ///
-/// returns `None` when the route is already at its lowest usable layer, letting
-/// the overload pass stop degrading a route before it bottoms out
-fn step_down_selector(
-    route: &ReceiverVideoRouteInput<'_>,
-    current: SourceSelector,
-) -> Option<(SourceSelector, Bitrate)> {
-    let source = route.source;
+/// Routes using featured quality retain an intermediate rung during aggregate fitting.
+/// Their per-route target may still select the floor when the receiver cannot
+/// afford that intermediate quality. Equal bitrate ceilings do not create an
+/// intermediate operating point.
+fn step_down_selector(route: &PlannedReceiverRoute<'_>) -> Option<(SourceSelector, Bitrate)> {
+    let source = route.input.source;
     let source_cap = source.policy().video_bitrate_cap();
-    let current_index = selector_index(source, current);
-    (0..current_index).rev().find_map(|index| {
+    let current_index = selector_index(source, route.selection.selector);
+    let mut cheaper_encodings = (0..current_index).rev().filter_map(|index| {
         let encoding = source.selectable_encoding_by_rank(index)?;
-        if matches!(
-            encoding.policy_role(),
-            Some(UploadLayerPolicyRole::Featured)
-        ) {
-            return None;
-        }
         let bitrate = encoding.max_bitrate()?;
-        source_cap
-            .is_none_or(|cap| bitrate <= cap)
+        (bitrate < route.selected_bitrate && source_cap.is_none_or(|cap| bitrate <= cap))
             .then_some((SourceSelector::Encoding(encoding.encoding_id()), bitrate))
-    })
+    });
+    let (selector, bitrate) = cheaper_encodings.next()?;
+    if route.input.layout_role.uses_featured_quality()
+        && !cheaper_encodings.any(|(_selector, lower_bitrate)| lower_bitrate < bitrate)
+    {
+        return None;
+    }
+    Some((selector, bitrate))
 }
 
 fn scalable_plan(
@@ -719,12 +696,11 @@ fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], video_budget: 
     if total_bitrate <= video_budget {
         return;
     }
-    // Drop downgradable routes that have no usable layer to fall back to.
+    // Missing-layer pauses stay limited to secondary routes. Widening encoding
+    // downsteps must not bypass the soft-pause dwell for important fixed video.
     let mut missing_ladders = routes
         .iter_mut()
-        .filter(|route| {
-            route_can_downgrade(route) && cheapest_useful_selector(route.input).is_none()
-        })
+        .filter(|route| route_needs_missing_layer_pause(route))
         .map(|route| (video_download_rank(route), route))
         .collect::<Vec<_>>();
     missing_ladders.sort_by_key(|(rank, _route)| Reverse(*rank));
@@ -743,8 +719,7 @@ fn apply_overload_policy(routes: &mut [PlannedReceiverRoute<'_>], video_budget: 
             .iter_mut()
             .filter(|route| route_can_downgrade(route))
             .filter_map(|route| {
-                step_down_selector(route.input, route.selection.selector)
-                    .map(|(selector, bitrate)| (route, selector, bitrate))
+                step_down_selector(route).map(|(selector, bitrate)| (route, selector, bitrate))
             })
             .max_by_key(|(route, _selector, _bitrate)| {
                 (video_download_rank(route), route.selected_bitrate)
@@ -816,13 +791,20 @@ fn admitted_video_bwe_demand(routes: &[PlannedReceiverRoute<'_>]) -> Bitrate {
 }
 
 fn route_can_downgrade(route: &PlannedReceiverRoute<'_>) -> bool {
-    let input = route.input;
     route.selection.policy_pause_reason.is_none()
-        && input.source.policy().adaptation() == SourceAdaptationPolicy::ScalableVideo
-        && matches!(
-            input.layout_role.priority(),
-            SourceRoutePriority::VisibleThumbnail | SourceRoutePriority::HiddenOrOverflow
-        )
+        && route.input.source.policy().adaptation() == SourceAdaptationPolicy::ScalableVideo
+}
+
+fn route_needs_missing_layer_pause(route: &PlannedReceiverRoute<'_>) -> bool {
+    let input = route.input;
+    let source_cap = input.source.policy().video_bitrate_cap();
+    route_can_downgrade(route)
+        && !input.layout_role.uses_featured_quality()
+        && !input.source.selectable_encodings().any(|encoding| {
+            encoding
+                .max_bitrate()
+                .is_some_and(|bitrate| source_cap.is_none_or(|cap| bitrate <= cap))
+        })
 }
 
 fn pause_reason_for_route(route: &PlannedReceiverRoute<'_>) -> PolicyPauseReason {

--- a/crates/core/src/engine/source_model/policy.rs
+++ b/crates/core/src/engine/source_model/policy.rs
@@ -257,8 +257,8 @@ impl SourceRoomPolicySelector {
 
 /// overload priority derived from a route's room-policy selector
 ///
-/// lower-priority buckets exhaust their cheaper encodings and pause before
-/// overload handling changes a higher-priority bucket
+/// Each downgrade or pause pass visits lower priorities first. All eligible
+/// encoding downsteps precede whole-route pauses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SourceRoutePriority {
     /// explicit receiver intent

--- a/crates/core/src/options/media.rs
+++ b/crates/core/src/options/media.rs
@@ -321,7 +321,8 @@ impl SessionBitrateLimits {
 /// Bitrate limit used by generated VP8 and H.264 simulcast upload profiles.
 ///
 /// The high RID uses `max_video_bitrate`. The low RID uses the lower of
-/// `max_video_bitrate` and 150 kbps.
+/// `max_video_bitrate` and 150 kbps. The middle RID uses one fifth of
+/// `max_video_bitrate`, raised to the low RID's limit when necessary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoBitrateLimits {
     max_video_bitrate: Bitrate,


### PR DESCRIPTION
Offer three RIDs so important cameras can reduce demand before thumbnail pauses.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check all -->
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [coding_guidelines.md](coding_guidelines.md)
- [x] I will not use AI to fabricate answers to comments in this PR

#### AI
<!-- if no checkbox is checked, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate text (comments, documentation, commit message,...)
- [x] AI was used to generate trivial and/or sporadic changes (autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If something else than checkbox "No AI involvement" is checked, write a summary explaining the extent involvement of AI.
-->
