### PR TITLE
[IMP] core: complete port range split test coverage

### DIFF
--- a/crates/core/src/options/TESTS/media.rs
+++ b/crates/core/src/options/TESTS/media.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use super::{Bitrate, VideoAdaptationTuning, VideoAdaptationTuningError};
+use super::{Bitrate, RtcPortRange, VideoAdaptationTuning, VideoAdaptationTuningError};
 
 #[test]
 fn video_adaptation_tuning_accepts_valid_knobs() {
@@ -130,5 +130,36 @@ fn video_adaptation_tuning_rejects_unrepresentable_deadlines() {
             Bitrate::zero()
         )
         .is_ok()
+    );
+}
+
+#[test]
+fn rtc_port_range_splits_ports_across_workers() {
+    // zero workers → None
+    assert_eq!(RtcPortRange::new(40_000, 40_000).split_for_workers(0), None,);
+    // more workers than ports → None
+    assert_eq!(RtcPortRange::new(40_000, 40_000).split_for_workers(2), None,);
+    // single worker → full range
+    assert_eq!(
+        RtcPortRange::new(40_000, 40_003).split_for_workers(1),
+        Some(vec![RtcPortRange::new(40_000, 40_003)]),
+    );
+    // workers == ports → one port each
+    assert_eq!(
+        RtcPortRange::new(40_000, 40_002).split_for_workers(3),
+        Some(vec![
+            RtcPortRange::new(40_000, 40_000),
+            RtcPortRange::new(40_001, 40_001),
+            RtcPortRange::new(40_002, 40_002),
+        ]),
+    );
+    // uneven split → earlier workers get the extras
+    assert_eq!(
+        RtcPortRange::new(40_000, 40_004).split_for_workers(3),
+        Some(vec![
+            RtcPortRange::new(40_000, 40_001),
+            RtcPortRange::new(40_002, 40_003),
+            RtcPortRange::new(40_004, 40_004),
+        ]),
     );
 }

--- a/src/config/TESTS/transport.rs
+++ b/src/config/TESTS/transport.rs
@@ -243,19 +243,6 @@ fn load_transport_config_keeps_explicit_single_router_strict() -> Result<()> {
 }
 
 #[test]
-fn rtc_port_range_splits_ports_across_workers() {
-    let ranges = RtcPortRange::new(40_000, 40_004).split_for_workers(3);
-    assert_eq!(
-        ranges,
-        Some(vec![
-            RtcPortRange::new(40_000, 40_001),
-            RtcPortRange::new(40_002, 40_003),
-            RtcPortRange::new(40_004, 40_004),
-        ])
-    );
-}
-
-#[test]
 fn load_transport_config_rejects_invalid_transport_values() {
     assert_invalid_transport_cases(&[
         InvalidTransportCase {


### PR DESCRIPTION
Extend `RtcPortRange::split_for_workers` test coverage with the four
 missing cases and relocate the test.

  Closes #682

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check all -->
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [coding_guidelines.md](coding_guidelines.md)
- [x] I will not use AI to fabricate answers to comments in this PR

#### AI
<!-- if no checkbox is checked, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate text (comments, documentation, commit message,...)
- [ ] AI was used to generate trivial and/or sporadic changes (autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If something else than checkbox "No AI involvement" is checked, write a summary explaining the extent involvement of AI.
-->
