### PR TITLE
[IMP] core: add semantic logging for control operations

### DIFF
--- a/crates/core/src/engine/room/TESTS/manager_tests.rs
+++ b/crates/core/src/engine/room/TESTS/manager_tests.rs
@@ -182,6 +182,53 @@ async fn room_and_user_lifecycle_events_preserve_contract_fields() {
             &[],
         );
     }
+    assert_exact(
+        telemetry_event::ROOM_DESTROYED,
+        &[("room_id", Value::from(room.uuid()))],
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn users_bulk_disconnected_event_preserves_contract_fields() {
+    let _guard = capture().await;
+    let manager = RoomManager::for_test();
+    let media_transport = real_adapter();
+    let room = manager
+        .serve_room(
+            "issuer-bulk-disconnect",
+            TEST_ROOM_KEY,
+            &RoomConfig::default(),
+            Some("203.0.113.1"),
+        )
+        .await
+        .expect("test room should be served");
+    manager_join_user(&manager, &room, 1, &media_transport).await;
+    // success case: user is in a live room; this also empties and destroys the room
+    manager
+        .disconnect_users(room.uuid(), &[UserId::Integer(1)], &media_transport)
+        .await;
+    assert_exact(
+        telemetry_event::USERS_BULK_DISCONNECTED,
+        &[
+            ("room_id", Value::from(room.uuid())),
+            ("requested_user_count", Value::from(1u64)),
+            ("disconnected_session_count", Value::from(1u64)),
+            ("outcome", Value::from("success")),
+        ],
+    );
+    // room_missing case: the same room was destroyed by the previous call
+    manager
+        .disconnect_users(room.uuid(), &[UserId::Integer(1)], &media_transport)
+        .await;
+    assert_exact(
+        telemetry_event::USERS_BULK_DISCONNECTED,
+        &[
+            ("room_id", Value::from(room.uuid())),
+            ("requested_user_count", Value::from(1u64)),
+            ("disconnected_session_count", Value::from(0u64)),
+            ("outcome", Value::from("room_missing")),
+        ],
+    );
 }
 
 #[tokio::test]

--- a/crates/core/src/engine/room/directory.rs
+++ b/crates/core/src/engine/room/directory.rs
@@ -274,11 +274,13 @@ impl RoomDirectory {
             .is_some_and(|entry| Arc::ptr_eq(&entry.room, room))
     }
 
-    pub(crate) fn remove_if_current(&mut self, uuid: &str, room: &Arc<Room>) {
+    pub(crate) fn remove_if_current(&mut self, uuid: &str, room: &Arc<Room>) -> bool {
         if self.contains_current(uuid, room) {
             self.by_uuid.remove(uuid);
             self.uuid_by_issuer.remove(room.issuer());
             self.uuid_by_instance.remove(&room.instance_id());
+            return true;
         }
+        false
     }
 }

--- a/crates/core/src/engine/room/manager/mod.rs
+++ b/crates/core/src/engine/room/manager/mod.rs
@@ -353,15 +353,23 @@ impl RoomManager {
         user_ids: &[UserId],
         media_transport: &MediaTransport,
     ) {
-        let _ = self
+        let result = self
             .run_current_room_mutation(
                 room_id,
-                |room| async move {
-                    room.disconnect_users(user_ids, media_transport).await;
-                },
+                |room| async move { room.disconnect_users(user_ids, media_transport).await },
                 true,
             )
             .await;
+        let (disconnected_session_count, outcome) =
+            result.map_or((0, "room_missing"), |count| (count, "success"));
+        info!(
+            event = telemetry_event::USERS_BULK_DISCONNECTED,
+            disconnected_session_count,
+            outcome,
+            requested_user_count = user_ids.len(),
+            room_id,
+            "bulk disconnect handled"
+        );
     }
 
     /// Claims and removes expired reservations with no active room mutations.
@@ -416,11 +424,17 @@ impl RoomManager {
         // Read emptiness after this mutation. A later accepted mutation can
         // supply the final removal proof. Dropping the final lease supplies no
         // proof and cancels the pending claim.
-        if lease.finish(remove_if_empty, room.is_empty().await) {
-            self.directory
+        if lease.finish(remove_if_empty, room.is_empty().await)
+            && self
+                .directory
                 .write()
                 .await
-                .remove_if_current(room_id, &room);
+                .remove_if_current(room_id, &room)
+        {
+            info!(
+                event = telemetry_event::ROOM_DESTROYED,
+                room_id, "room destroyed"
+            );
         }
     }
 

--- a/crates/core/src/engine/room/membership.rs
+++ b/crates/core/src/engine/room/membership.rs
@@ -210,12 +210,14 @@ impl Room {
         &self,
         user_ids: &[UserId],
         media_transport: &MediaTransport,
-    ) {
+    ) -> usize {
         self.disconnect_users_with_teardown(user_ids, RoomEffectContext::runtime(media_transport))
-            .await;
+            .await
     }
 
     /// Removes current sessions in one state commit and ignores missing users.
+    ///
+    /// Returns the number of sessions actually torn down.
     ///
     /// # Panics
     ///
@@ -224,7 +226,7 @@ impl Room {
         &self,
         user_ids: &[UserId],
         context: RoomEffectContext<'_>,
-    ) {
+    ) -> usize {
         let commit = {
             let mut state = self.state.write().await;
             state.apply_disconnect_users(user_ids)
@@ -237,7 +239,7 @@ impl Room {
         RoomEffects::from_disconnect(commit)
             .execute(self, context)
             .await;
-        for session in sessions {
+        for session in &sessions {
             info!(
                 event = telemetry_event::USER_DISCONNECTED,
                 room_id = self.uuid(),
@@ -247,6 +249,7 @@ impl Room {
                 "user disconnected"
             );
         }
+        sessions.len()
     }
 
     #[cfg(any(test, feature = "testing-transport"))]

--- a/crates/telemetry/src/schema.rs
+++ b/crates/telemetry/src/schema.rs
@@ -13,9 +13,11 @@ pub mod event {
     pub const ROOM_CREATED: &str = "room.created";
     pub const ROOM_RESERVATION_EXPIRED: &str = "room.reservation.expired";
     pub const ROOM_RESERVATION_CONFLICT: &str = "room.reservation_conflict";
+    pub const ROOM_DESTROYED: &str = "room.destroyed";
     pub const USER_JOINED: &str = "user.joined";
     pub const USER_CLOSED: &str = "user.closed";
     pub const USER_DISCONNECTED: &str = "user.disconnected";
+    pub const USERS_BULK_DISCONNECTED: &str = "users.bulk_disconnected";
     pub const WS_CONNECTION_CLOSED: &str = "ws.closed";
     pub const WS_HANDSHAKE_REJECTED: &str = "ws.handshake_rejected";
     pub const WS_JOIN_FAILED: &str = "ws.join_failed";


### PR DESCRIPTION
Emit `users.bulk_disconnected` on every POST /v1/disconnect per targeted room (outcome ∈ {success, room_missing}) so bulk-disconnect requests get per-request attribution. Emit `room.destroyed` when a room is removed after becoming empty so end-of-life room removal is no longer silent (previously only the reservation-expiry death path was logged).

Closes #691

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check all -->
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [coding_guidelines.md](coding_guidelines.md)
- [x] I will not use AI to fabricate answers to comments in this PR

#### AI
<!-- if no checkbox is checked, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate text (comments, documentation, commit message,...)
- [x] AI was used to generate trivial and/or sporadic changes (autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If something else than checkbox "No AI involvement" is checked, write a summary explaining the extent involvement of AI.
-->
