### PR TITLE
[FIX] doc: lib rustdoc arch graph

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,18 +26,18 @@
 //! resulting transport state to UDP datagrams.
 //!
 //! ```text
-//! HTTP control API ----------------------> RoomManager
-//!                                               |
-//! WebSocket session -> SfuCore -> MediaSession  |
-//!                              \                /
-//!                               +----> Room <----+
-//!                                      |
-//!                                      +<----> Router
-//!                                      |
-//!                                      v
-//!                                MediaTransport
-//!                                 |    |    |
-//!                                 v    v    v
+//! HTTP control API ------------------------------> RoomManager
+//!                                                       |
+//! WebSocket session -> SfuCore -> MediaSession          |
+//!                                    \                  /
+//!                                     +----> Room <----+
+//!                                             |
+//!                                             +<----> Router
+//!                                             |
+//!                                             v
+//!                                       MediaTransport
+//!                                        |    |    |
+//!                                        v    v    v
 //!                          RTC workers / packet loops (~1 worker per thread)
 //!                         |            |             |
 //!                      UDP:40001   UDP:40002     UDP:40003


### PR DESCRIPTION
the architecture graph had some lines that didn't align neatly

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check all -->
- [x] I read [CONTRIBUTING.md](https://github.com/odoo/o-sfu/blob/master/.github/CONTRIBUTING.md) and [coding_guidelines.md](https://github.com/odoo/o-sfu/blob/master/.github/coding_guidelines.md)
- [x] I will not use AI to fabricate answers to comments in this PR

#### AI
<!-- if no checkbox is checked, the PR will be closed without a review -->

- [x] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [ ] AI was used to generate text (comments, documentation, commit message,...)
- [ ] AI was used to generate trivial and/or sporadic changes (autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If something else than checkbox "No AI involvement" is checked, write a summary explaining the extent involvement of AI.
-->
