### PR TITLE
[ADD] core: prove RTP projection invariants

### DIFF
--- a/.github/workflows/formal-verification-pr.yml
+++ b/.github/workflows/formal-verification-pr.yml
@@ -99,6 +99,11 @@ jobs:
             harness: vp8_identity_projection_matches_modular_model
             covers: 10
             timeout_minutes: 30
+          - shard: core-rtp-projection
+            package: o-sfu-core
+            harness: rtp_projection_matches_affine_model
+            covers: 24
+            timeout_minutes: 30
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -93,6 +93,11 @@ jobs:
             harness: vp8_identity_projection_matches_modular_model
             covers: 10
             timeout_minutes: 30
+          - shard: core-rtp-projection
+            package: o-sfu-core
+            harness: rtp_projection_matches_affine_model
+            covers: 24
+            timeout_minutes: 30
 
     steps:
       - name: Checkout repository

--- a/crates/core/src/engine/media_transport/rtc/consumer_egress/PROOFS/streams.rs
+++ b/crates/core/src/engine/media_transport/rtc/consumer_egress/PROOFS/streams.rs
@@ -1,0 +1,321 @@
+use super::{ProjectedRtp, RtpProjection, RtpProjectionOutcome, RtpTimeline};
+
+const SEQUENCE_LIMIT: u128 = (1_u128 << 64) - 1;
+const TIMESTAMP_MODULUS: u64 = 1_u64 << 32;
+
+#[derive(Clone, Copy)]
+struct Packet {
+    ssrc: u32,
+    sequence: u64,
+    timestamp: u32,
+    reanchor: bool,
+    repair: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Mapping {
+    ssrc: u32,
+    source: u128,
+    destination: u128,
+    highest_source: u128,
+    source_timestamp: u64,
+    destination_timestamp: u64,
+    highest_timestamp: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Model {
+    next: u128,
+    mapping: Option<Mapping>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Projected {
+    sequence: u128,
+    timestamp: u64,
+    advances: bool,
+    previous_ssrc: Option<u32>,
+}
+
+/// Proof for `RtpProjection::project`.
+/// Checks full-width sequence/timestamp inputs and the optimized packet path,
+/// including overflow boundaries that regression tests only sample. Rejection
+/// and observation preserve all projection state.
+///
+/// `Model::valid` is inductive and includes exhausted states. Assumes repairs
+/// do not reanchor. Excludes generation admission, codec commits and RTC I/O.
+#[kani::proof]
+fn rtp_projection_matches_affine_model() {
+    let mut projection = arbitrary_projection();
+    let before = snapshot(projection);
+    kani::assume(before.valid());
+    let packet = Packet {
+        ssrc: kani::any(),
+        sequence: kani::any(),
+        timestamp: kani::any(),
+        reanchor: kani::any(),
+        repair: kani::any(),
+    };
+    kani::assume(!packet.repair || !packet.reanchor);
+    let mut expected_state = before;
+    let expected = expected_state.project(packet);
+    let actual = projection
+        .project(
+            packet.ssrc.into(),
+            packet.sequence.into(),
+            packet.timestamp,
+            packet.reanchor,
+            packet.repair,
+        )
+        .map(projected_snapshot);
+    let after = snapshot(projection);
+    assert_eq!(actual, expected);
+    assert_eq!(after, expected_state);
+    assert!(after.valid());
+    if actual.is_none_or(|output| !output.advances) {
+        assert_eq!(after, before);
+    }
+    cover_transitions(before, after, packet, actual);
+}
+
+fn arbitrary_projection() -> RtpProjection {
+    let timeline = if kani::any() {
+        RtpTimeline::Active {
+            ssrc: kani::any::<u32>().into(),
+            src_seq_anchor: kani::any::<u64>().into(),
+            dst_seq_anchor: kani::any::<u64>().into(),
+            highest_src_seq: kani::any::<u64>().into(),
+            src_timestamp_anchor: kani::any(),
+            dst_timestamp_anchor: kani::any(),
+            highest_timestamp: kani::any(),
+        }
+    } else {
+        RtpTimeline::Empty
+    };
+    RtpProjection {
+        next_seq_no: kani::any::<u64>().into(),
+        timeline,
+    }
+}
+
+fn snapshot(projection: RtpProjection) -> Model {
+    let mapping = match projection.timeline {
+        RtpTimeline::Empty => None,
+        RtpTimeline::Active {
+            ssrc,
+            src_seq_anchor,
+            dst_seq_anchor,
+            highest_src_seq,
+            src_timestamp_anchor,
+            dst_timestamp_anchor,
+            highest_timestamp,
+        } => Some(Mapping {
+            ssrc: *ssrc,
+            source: u128::from(*src_seq_anchor),
+            destination: u128::from(*dst_seq_anchor),
+            highest_source: u128::from(*highest_src_seq),
+            source_timestamp: u64::from(src_timestamp_anchor),
+            destination_timestamp: u64::from(dst_timestamp_anchor),
+            highest_timestamp: u64::from(highest_timestamp),
+        }),
+    };
+    Model {
+        next: u128::from(*projection.next_seq_no),
+        mapping,
+    }
+}
+
+fn projected_snapshot(projected: ProjectedRtp) -> Projected {
+    let (advances, previous_ssrc) = match projected.outcome {
+        RtpProjectionOutcome::Advanced => (true, None),
+        RtpProjectionOutcome::Observed => (false, None),
+        RtpProjectionOutcome::Switched { previous_ssrc } => (true, Some(*previous_ssrc)),
+    };
+    Projected {
+        sequence: u128::from(*projected.seq_no),
+        timestamp: u64::from(projected.rtp_timestamp),
+        advances,
+        previous_ssrc,
+    }
+}
+
+impl Model {
+    fn valid(self) -> bool {
+        self.next <= SEQUENCE_LIMIT
+            && self.mapping.is_none_or(|line| {
+                line.source <= line.highest_source
+                    && line.destination + (line.highest_source - line.source) + 1 == self.next
+            })
+    }
+
+    fn project(&mut self, packet: Packet) -> Option<Projected> {
+        let source = u128::from(packet.sequence);
+        let source_timestamp = u64::from(packet.timestamp);
+        if packet.repair
+            && !self.mapping.is_some_and(|line| {
+                line.ssrc == packet.ssrc && line.source <= source && source < line.highest_source
+            })
+        {
+            return None;
+        }
+        let continued = self
+            .mapping
+            .filter(|line| line.ssrc == packet.ssrc && !packet.reanchor);
+        let (sequence, timestamp, advances) = if let Some(line) = continued {
+            if source < line.source {
+                return None;
+            }
+            (
+                line.destination + source - line.source,
+                (line.destination_timestamp + TIMESTAMP_MODULUS + source_timestamp
+                    - line.source_timestamp)
+                    % TIMESTAMP_MODULUS,
+                source > line.highest_source,
+            )
+        } else {
+            (
+                self.next,
+                self.mapping.map_or(source_timestamp, |line| {
+                    (line.highest_timestamp + 1) % TIMESTAMP_MODULUS
+                }),
+                true,
+            )
+        };
+        if sequence + u128::from(advances) > SEQUENCE_LIMIT {
+            return None;
+        }
+        let previous_ssrc = self
+            .mapping
+            .filter(|line| line.ssrc != packet.ssrc)
+            .map(|line| line.ssrc);
+        if advances {
+            self.next = sequence + 1;
+            self.mapping = Some(Mapping {
+                highest_source: source,
+                highest_timestamp: timestamp,
+                ..continued.unwrap_or(Mapping {
+                    ssrc: packet.ssrc,
+                    source,
+                    destination: sequence,
+                    highest_source: source,
+                    source_timestamp,
+                    destination_timestamp: timestamp,
+                    highest_timestamp: timestamp,
+                })
+            });
+        }
+        Some(Projected {
+            sequence,
+            timestamp,
+            advances,
+            previous_ssrc,
+        })
+    }
+}
+
+fn cover_transitions(before: Model, after: Model, packet: Packet, output: Option<Projected>) {
+    let accepted = output.is_some();
+    let Some(line) = before.mapping else {
+        kani::cover!(accepted, "first primary");
+        kani::cover!(packet.repair && !accepted, "repair before first primary");
+        kani::cover!(
+            before.next == SEQUENCE_LIMIT && !packet.repair,
+            "exhausted seed"
+        );
+        return;
+    };
+    let source = u128::from(packet.sequence);
+    let continued = packet.ssrc == line.ssrc && !packet.reanchor;
+    let primary = !packet.repair;
+    let exhausted = before.next == SEQUENCE_LIMIT;
+    kani::cover!(
+        continued && primary && source == line.highest_source + 1 && accepted,
+        "consecutive primary"
+    );
+    kani::cover!(
+        continued && primary && source > line.highest_source + 1 && accepted,
+        "gapped primary"
+    );
+    kani::cover!(
+        continued
+            && primary
+            && source == line.highest_source
+            && output.is_some_and(|projected| projected.timestamp != line.highest_timestamp)
+            && accepted,
+        "duplicate with changed timestamp"
+    );
+    kani::cover!(
+        continued && primary && source < line.highest_source && accepted,
+        "reordered primary"
+    );
+    kani::cover!(packet.repair && accepted, "admitted repair");
+    kani::cover!(
+        packet.repair && packet.ssrc != line.ssrc && !accepted,
+        "repair from another source"
+    );
+    kani::cover!(
+        continued && primary && source < line.source && !accepted,
+        "before source anchor"
+    );
+    kani::cover!(
+        continued
+            && primary
+            && source >= line.source
+            && line.destination + source > SEQUENCE_LIMIT + line.source
+            && !accepted,
+        "receiver sequence overflow"
+    );
+    kani::cover!(
+        continued
+            && primary
+            && source > line.highest_source
+            && line.destination + source == SEQUENCE_LIMIT + line.source
+            && !accepted,
+        "receiver successor overflow"
+    );
+    kani::cover!(
+        !exhausted && after.next == SEQUENCE_LIMIT && accepted,
+        "last representable primary"
+    );
+    kani::cover!(
+        exhausted && primary && continued && accepted,
+        "primary observation after exhaustion"
+    );
+    kani::cover!(
+        exhausted && packet.repair && accepted,
+        "repair after exhaustion"
+    );
+    kani::cover!(
+        exhausted && primary && continued && source == line.highest_source + 1 && !accepted,
+        "exhausted consecutive primary"
+    );
+    kani::cover!(
+        exhausted && primary && continued && source > line.highest_source + 1 && !accepted,
+        "exhausted gapped primary"
+    );
+    kani::cover!(
+        exhausted && packet.reanchor && packet.ssrc == line.ssrc && !accepted,
+        "exhausted reanchor"
+    );
+    kani::cover!(
+        exhausted && primary && packet.ssrc != line.ssrc && !accepted,
+        "exhausted source switch"
+    );
+    kani::cover!(packet.ssrc != line.ssrc && accepted, "source switch");
+    kani::cover!(
+        packet.reanchor && packet.ssrc == line.ssrc && accepted,
+        "same source reanchor"
+    );
+    kani::cover!(
+        continued && u64::from(packet.timestamp) < line.source_timestamp && accepted,
+        "source timestamp rollover"
+    );
+    kani::cover!(
+        !continued && line.highest_timestamp + 1 == TIMESTAMP_MODULUS && accepted,
+        "receiver timestamp rollover on reanchor"
+    );
+    kani::cover!(
+        continued && primary && line.highest_source == SEQUENCE_LIMIT && source == 0 && !accepted,
+        "extended source sequence rollover"
+    );
+}

--- a/crates/core/src/engine/media_transport/rtc/consumer_egress/TESTS/streams.rs
+++ b/crates/core/src/engine/media_transport/rtc/consumer_egress/TESTS/streams.rs
@@ -671,6 +671,100 @@ fn rejected_source_deltas_preserve_the_next_valid_projection() {
 }
 
 #[test]
+fn exhausted_sequence_preserves_observations() {
+    let source_ssrc = Ssrc::from(111);
+    let inspector = vp8_inspector();
+    let mut stream = ConsumerStream {
+        rtp: RtpProjection::new(0_u64.into()),
+        ..ConsumerStream::default()
+    };
+    for (sequence, timestamp, picture_id) in [(0_u64, 10_000, 10), (u64::MAX - 1, 20_000, 12)] {
+        let Some(projected) = stream.project(
+            0,
+            source_ssrc,
+            sequence.into(),
+            timestamp,
+            vp8_packet(&inspector, u16::from(picture_id), picture_id).identity(),
+            false,
+        ) else {
+            panic!("a representable receiver successor should be accepted");
+        };
+        assert_eq!(projected.seq_no, sequence.into());
+    }
+    assert_eq!(stream.rtp.next_seq_no, u64::MAX.into());
+    for (generation, ssrc, sequence) in [
+        (0, source_ssrc, u64::MAX),
+        (0, Ssrc::from(222), 1),
+        (1, source_ssrc, 1),
+    ] {
+        let mut control = stream;
+        assert!(
+            stream
+                .project(
+                    generation,
+                    ssrc,
+                    sequence.into(),
+                    50_000,
+                    vp8_packet(&inspector, 100, 100).identity(),
+                    false,
+                )
+                .is_none()
+        );
+        assert_eq!(stream.delivery_generation, control.delivery_generation);
+        assert_eq!(stream.rtp.next_seq_no, control.rtp.next_seq_no);
+        assert!(
+            stream
+                .project(
+                    0,
+                    source_ssrc,
+                    (u64::MAX - 1).into(),
+                    20_000,
+                    vp8_packet(&inspector, 12, 12).identity(),
+                    true,
+                )
+                .is_none()
+        );
+        for (sequence, was_repair) in [(0_u64, false), (u64::MAX - 2, true), (u64::MAX - 1, false)]
+        {
+            let identity = vp8_packet(&inspector, 11, 11).identity();
+            let actual = stream.project(
+                0,
+                source_ssrc,
+                sequence.into(),
+                11_000,
+                identity,
+                was_repair,
+            );
+            let expected = control.project(
+                0,
+                source_ssrc,
+                sequence.into(),
+                11_000,
+                identity,
+                was_repair,
+            );
+            assert!(expected.is_some());
+            assert_eq!(actual, expected);
+        }
+        let mut actual_codec = stream.codec;
+        let mut expected_codec = control.codec;
+        let identity = vp8_packet(&inspector, 1, 1).identity();
+        assert_eq!(
+            actual_codec.project(identity, true),
+            expected_codec.project(identity, true)
+        );
+    }
+    let mut empty = RtpProjection::new(u64::MAX.into());
+    assert!(
+        empty
+            .project(source_ssrc, 0_u64.into(), 0, false, false)
+            .is_none()
+    );
+    assert_eq!(empty.next_seq_no, u64::MAX.into());
+    assert!(matches!(empty.timeline, RtpTimeline::Empty));
+}
+
+#[test]
 fn repair_admission_preserves_the_active_projection_window() {
     let source_ssrc = Ssrc::from(111);
     let inspector = vp8_inspector();

--- a/crates/core/src/engine/media_transport/rtc/consumer_egress/streams.rs
+++ b/crates/core/src/engine/media_transport/rtc/consumer_egress/streams.rs
@@ -284,7 +284,8 @@ impl ConsumerStreamStore {
     /// delivery-generation projection window. This does not prove that packet was lost.
     ///
     /// Returns `None` for a stale handle, an older delivery generation, a repair outside
-    /// that window or a source sequence outside the representable projection range.
+    /// that window, a source sequence outside the representable projection range or
+    /// an advancing packet without a representable receiver successor.
     pub(super) fn project_identity(
         &mut self,
         stream_handle: ConsumerStreamHandle,
@@ -459,8 +460,10 @@ impl RtpProjection {
 
     /// Projects one packet without changing the RTP mapping on rejection.
     ///
-    /// Returns `None` for repairs outside the active SSRC sequence window or
-    /// source deltas outside the representable receiver sequence range.
+    /// Returns `None` for repairs outside the active SSRC sequence window,
+    /// source deltas outside the representable receiver sequence range or
+    /// advancement whose receiver successor would exceed `u64::MAX`.
+    /// Reordered packets and accepted repairs remain projectable after exhaustion.
     /// The caller validates the delivery generation before requesting reanchoring.
     // Outlining this transition adds a call frame to every primary packet.
     #[inline]
@@ -478,7 +481,8 @@ impl RtpProjection {
         match &mut self.timeline {
             RtpTimeline::Empty => {
                 cold_path();
-                let seq_no = self.next_seq_no.inc();
+                let seq_no = self.next_seq_no;
+                self.next_seq_no = (*seq_no).checked_add(1)?.into();
                 self.timeline = RtpTimeline::Active {
                     ssrc: source_ssrc,
                     src_seq_anchor: source_seq_no,
@@ -509,7 +513,9 @@ impl RtpProjection {
                         cold_path();
                         return self.project_source_delta(source_seq_no, source_timestamp);
                     }
-                    let seq_no = self.next_seq_no.inc();
+                    // A source gap can exhaust the successor before the next consecutive packet.
+                    let seq_no = self.next_seq_no;
+                    self.next_seq_no = (*seq_no).checked_add(1)?.into();
                     *highest_src_seq = source_seq_no;
                     let rtp_timestamp = dst_timestamp_anchor
                         .wrapping_add(source_timestamp.wrapping_sub(*src_timestamp_anchor));
@@ -521,7 +527,8 @@ impl RtpProjection {
                     });
                 }
                 let previous_ssrc = *ssrc;
-                let seq_no = self.next_seq_no.inc();
+                let seq_no = self.next_seq_no;
+                self.next_seq_no = (*seq_no).checked_add(1)?.into();
                 let rtp_timestamp = highest_timestamp.wrapping_add(1);
                 self.timeline = RtpTimeline::Active {
                     ssrc: source_ssrc,
@@ -680,6 +687,10 @@ pub fn rotate_rtx_cache(rtc: &mut Rtc, primary_ssrc: Ssrc) {
         stream.set_rtx_cache(RTX_CACHE_MAX_PACKETS, RTX_CACHE_LIFETIME, RTX_RATIO_CAP);
     }
 }
+
+#[cfg(kani)]
+#[path = "PROOFS/streams.rs"]
+mod proofs;
 
 #[cfg(test)]
 #[path = "TESTS/streams.rs"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,7 +65,18 @@ cargo kani --package o-sfu-proofs --lib \
 
 cargo kani --package o-sfu-core --lib \
   --harness vp8_identity_projection_matches_modular_model
+
+cargo kani --package o-sfu-core --lib \
+  --harness rtp_projection_matches_affine_model
 ```
+
+The RTP harness checks the production projection against widened sequence and
+modular timestamp arithmetic. It proves output agreement, state preservation on
+rejection or observation and preservation of the active sequence invariant.
+Exhausted states remain in scope: advancing packets are rejected while eligible
+observations and repairs retain their mapping. Repairs cannot request reanchoring.
+The theorem excludes generation admission, codec commits, SRTP validation and RTC
+writes. Both Kani workflows require all 24 transition cover properties to pass.
 
 CI builds its Rust 1.95-compatible Kani toolchain from an exact upstream
 revision until that compiler support is available in a Kani release.


### PR DESCRIPTION
Verify RTP mapping and state preservation against widened arithmetic. Reject exhausted advancement while retaining repairs.

<!-- Write your PR message here -->


#### Guidelines
<!-- You must check all -->
- [x] I read [CONTRIBUTING.md](https://github.com/odoo/o-sfu/blob/master/.github/CONTRIBUTING.md) and [coding_guidelines.md](https://github.com/odoo/o-sfu/blob/master/.github/coding_guidelines.md)
- [x] I will not use AI to fabricate answers to comments in this PR

#### AI
<!-- if no checkbox is checked, the PR will be closed without a review -->

- [ ] No AI involvement at all.
- [ ] AI was used to design/research the specifications
- [x] AI was used to generate text (comments, documentation, commit message,...)
- [x] AI was used to generate trivial and/or sporadic changes (autocompletion,...)
- [ ] AI was used to write substantial segments of the code

<!-- 
If something else than checkbox "No AI involvement" is checked, write a summary explaining the extent involvement of AI.
-->
